### PR TITLE
Fix Firestore undefined value error on update/create

### DIFF
--- a/app/apps/todo-app/lib/storage.ts
+++ b/app/apps/todo-app/lib/storage.ts
@@ -95,12 +95,17 @@ export class FirebaseRepository implements TaskRepository {
 
   async update(id: string, updates: Partial<Task>): Promise<Task> {
     const docRef = doc(this.db, COLLECTION_NAME, id);
-    const updateData = {
-      ...updates,
-      updatedAt: new Date().toISOString(),
-    };
 
-    await updateDoc(docRef, updateData);
+    // Filter out undefined values - Firestore doesn't accept them
+    const cleanUpdates: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(updates)) {
+      if (value !== undefined) {
+        cleanUpdates[key] = value;
+      }
+    }
+    cleanUpdates.updatedAt = new Date().toISOString();
+
+    await updateDoc(docRef, cleanUpdates);
 
     const updated = await getDoc(docRef);
     return updated.data() as Task;


### PR DESCRIPTION
- Filter out undefined values before sending to Firestore
- Applied to game-analytics create() and update() methods
- Applied to todo-app update() method
- Firestore rejects undefined values, causing 'invalid data' errors