### PR TITLE
Add day counter and daily notes feature to todo app

### DIFF
--- a/app/apps/todo-app/components/DayNotesEditor.tsx
+++ b/app/apps/todo-app/components/DayNotesEditor.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { BookOpen, Save, X } from 'lucide-react';
+import clsx from 'clsx';
+
+interface DayNotesEditorProps {
+  date: string;
+  dayNumber: number | null;
+  initialContent: string;
+  onSave: (content: string) => Promise<void>;
+  onClose: () => void;
+}
+
+export function DayNotesEditor({ date, dayNumber, initialContent, onSave, onClose }: DayNotesEditorProps) {
+  const [content, setContent] = useState(initialContent);
+  const [saving, setSaving] = useState(false);
+  const [hasChanges, setHasChanges] = useState(false);
+
+  useEffect(() => {
+    setContent(initialContent);
+    setHasChanges(false);
+  }, [initialContent, date]);
+
+  const handleContentChange = (value: string) => {
+    setContent(value);
+    setHasChanges(value !== initialContent);
+  };
+
+  const handleSave = async () => {
+    if (!hasChanges) return;
+
+    try {
+      setSaving(true);
+      await onSave(content);
+      setHasChanges(false);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (hasChanges) {
+      if (confirm('You have unsaved changes. Are you sure you want to close?')) {
+        onClose();
+      }
+    } else {
+      onClose();
+    }
+  };
+
+  const formatDate = () => {
+    const dateObj = new Date(date + 'T12:00:00');
+    const formatted = dateObj.toLocaleDateString('en-US', {
+      weekday: 'long',
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric'
+    });
+    return formatted;
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="flex items-center justify-between px-6 py-4 border-b border-white/5">
+        <div className="flex items-center gap-3">
+          <div className="w-10 h-10 bg-purple-600/20 rounded-lg flex items-center justify-center">
+            <BookOpen size={20} className="text-purple-400" />
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold text-white">
+              {dayNumber !== null && (
+                <span className="text-purple-400">Day {dayNumber}</span>
+              )}
+              {dayNumber !== null && ' • '}
+              {formatDate()}
+            </h3>
+            <p className="text-xs text-white/40">Daily notes & reflections</p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handleSave}
+            disabled={!hasChanges || saving}
+            className={clsx(
+              'px-4 py-2 rounded-lg font-medium text-sm transition-all flex items-center gap-2',
+              hasChanges && !saving
+                ? 'bg-purple-600 hover:bg-purple-700 text-white'
+                : 'bg-white/[0.03] text-white/30 cursor-not-allowed'
+            )}
+          >
+            {saving ? (
+              <>
+                <div className="w-4 h-4 border-2 border-white/20 border-t-white rounded-full animate-spin" />
+                Saving...
+              </>
+            ) : (
+              <>
+                <Save size={16} />
+                Save
+              </>
+            )}
+          </button>
+          <button
+            onClick={handleClose}
+            className="p-2 text-white/40 hover:text-white/70 hover:bg-white/5 rounded-lg transition-all"
+            aria-label="Close"
+          >
+            <X size={20} />
+          </button>
+        </div>
+      </div>
+
+      {/* Editor */}
+      <div className="flex-1 p-6">
+        <textarea
+          value={content}
+          onChange={(e) => handleContentChange(e.target.value)}
+          placeholder="Write your thoughts, reflections, or notes for this day...
+
+You can write anything you want here:
+• How was your day?
+• What did you accomplish?
+• What are you grateful for?
+• What could be improved?
+• Any insights or learnings?
+
+This is your personal space to reflect and track your journey."
+          className="w-full h-full bg-white/[0.03] border border-white/10 rounded-lg px-4 py-3 text-white placeholder:text-white/20 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent resize-none transition-all"
+        />
+      </div>
+
+      {/* Footer */}
+      <div className="px-6 py-3 border-t border-white/5">
+        <div className="flex items-center justify-between text-xs text-white/40">
+          <div>
+            {hasChanges ? (
+              <span className="text-amber-400">Unsaved changes</span>
+            ) : (
+              <span>All changes saved</span>
+            )}
+          </div>
+          <div>
+            {content.length} characters
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/apps/todo-app/components/StartDateSetup.tsx
+++ b/app/apps/todo-app/components/StartDateSetup.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useState } from 'react';
+import { Calendar } from 'lucide-react';
+
+interface StartDateSetupProps {
+  onSetStartDate: (date: string) => Promise<void>;
+}
+
+export function StartDateSetup({ onSetStartDate }: StartDateSetupProps) {
+  const [selectedDate, setSelectedDate] = useState(() => {
+    return new Date().toISOString().split('T')[0];
+  });
+  const [saving, setSaving] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      setSaving(true);
+      await onSetStartDate(selectedDate);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="min-h-[calc(100vh-60px)] flex items-center justify-center px-6">
+      <div className="max-w-md w-full">
+        <div className="bg-white/[0.03] border border-white/10 rounded-2xl p-8">
+          <div className="flex items-center justify-center mb-6">
+            <div className="w-16 h-16 bg-purple-600/20 rounded-2xl flex items-center justify-center">
+              <Calendar size={32} className="text-purple-400" />
+            </div>
+          </div>
+
+          <h2 className="text-2xl font-bold text-white text-center mb-2">
+            Welcome to Tasks
+          </h2>
+          <p className="text-white/60 text-center mb-8">
+            Let&apos;s set your starting date. This will be <span className="text-white font-medium">Day 1</span>.
+          </p>
+
+          <form onSubmit={handleSubmit}>
+            <div className="mb-6">
+              <label className="block text-sm font-medium text-white/80 mb-3">
+                Choose your Day 1
+              </label>
+              <input
+                type="date"
+                value={selectedDate}
+                onChange={(e) => setSelectedDate(e.target.value)}
+                className="w-full px-4 py-3 bg-white/[0.05] border border-white/10 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all"
+                required
+              />
+              <p className="text-xs text-white/40 mt-2">
+                You can pick today or any past date
+              </p>
+            </div>
+
+            <button
+              type="submit"
+              disabled={saving}
+              className="w-full py-3 bg-purple-600 hover:bg-purple-700 disabled:bg-purple-600/50 text-white font-medium rounded-lg transition-all flex items-center justify-center gap-2"
+            >
+              {saving ? (
+                <>
+                  <div className="w-4 h-4 border-2 border-white/20 border-t-white rounded-full animate-spin" />
+                  Setting up...
+                </>
+              ) : (
+                <>
+                  <Calendar size={18} />
+                  Start Tracking
+                </>
+              )}
+            </button>
+          </form>
+
+          <div className="mt-6 p-4 bg-white/[0.03] border border-white/10 rounded-lg">
+            <p className="text-xs text-white/60">
+              <span className="font-medium text-white/80">Note:</span> Each day will show as &quot;Day 1&quot;, &quot;Day 2&quot;, etc. alongside the actual date. You can change this later in settings.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/apps/todo-app/hooks/useDayNotes.ts
+++ b/app/apps/todo-app/hooks/useDayNotes.ts
@@ -1,0 +1,70 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { notesRepository } from '../lib/notes-storage';
+import { DayNote } from '../lib/types';
+
+export function useDayNotes(date: string, userId: string | null) {
+  const [note, setNote] = useState<DayNote | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const refresh = async () => {
+    try {
+      setLoading(true);
+      notesRepository.setUserId(userId || 'local-user');
+      const data = await notesRepository.getByDate(date);
+      setNote(data);
+      setError(null);
+    } catch (e) {
+      setError(e as Error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [date, userId]);
+
+  const saveNote = async (content: string): Promise<DayNote> => {
+    try {
+      notesRepository.setUserId(userId || 'local-user');
+
+      let savedNote: DayNote;
+      if (note) {
+        savedNote = await notesRepository.update(note.id, { content });
+      } else {
+        savedNote = await notesRepository.create({ date, content });
+      }
+
+      await refresh();
+      return savedNote;
+    } catch (e) {
+      setError(e as Error);
+      throw e;
+    }
+  };
+
+  const deleteNote = async (): Promise<void> => {
+    if (!note) return;
+    try {
+      notesRepository.setUserId(userId || 'local-user');
+      await notesRepository.delete(note.id);
+      await refresh();
+    } catch (e) {
+      setError(e as Error);
+      throw e;
+    }
+  };
+
+  return {
+    note,
+    loading,
+    error,
+    saveNote,
+    deleteNote,
+    refresh,
+  };
+}

--- a/app/apps/todo-app/hooks/useSettings.ts
+++ b/app/apps/todo-app/hooks/useSettings.ts
@@ -1,0 +1,63 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { settingsRepository } from '../lib/settings-storage';
+import { AppSettings } from '../lib/types';
+
+export function useSettings(userId: string | null) {
+  const [settings, setSettings] = useState<AppSettings | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const refresh = async () => {
+    try {
+      setLoading(true);
+      settingsRepository.setUserId(userId || 'local-user');
+      const data = await settingsRepository.get();
+      setSettings(data);
+      setError(null);
+    } catch (e) {
+      setError(e as Error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userId]);
+
+  const setStartDate = async (startDate: string): Promise<AppSettings> => {
+    try {
+      settingsRepository.setUserId(userId || 'local-user');
+      const updated = await settingsRepository.set(startDate);
+      await refresh();
+      return updated;
+    } catch (e) {
+      setError(e as Error);
+      throw e;
+    }
+  };
+
+  const updateSettings = async (updates: Partial<Omit<AppSettings, 'id' | 'userId' | 'createdAt' | 'updatedAt'>>): Promise<AppSettings> => {
+    try {
+      settingsRepository.setUserId(userId || 'local-user');
+      const updated = await settingsRepository.update(updates);
+      await refresh();
+      return updated;
+    } catch (e) {
+      setError(e as Error);
+      throw e;
+    }
+  };
+
+  return {
+    settings,
+    loading,
+    error,
+    setStartDate,
+    updateSettings,
+    refresh,
+  };
+}

--- a/app/apps/todo-app/lib/calculations.ts
+++ b/app/apps/todo-app/lib/calculations.ts
@@ -203,3 +203,19 @@ export function parseTaskText(input: string): { text: string; priority: Priority
 
   return { text, priority, category };
 }
+
+/**
+ * Calculate day number based on start date
+ * @param currentDate - Current date (YYYY-MM-DD)
+ * @param startDate - Start date (YYYY-MM-DD) - represents Day 1
+ * @returns Day number (1, 2, 3, etc.)
+ */
+export function calculateDayNumber(currentDate: string, startDate: string): number {
+  const current = new Date(currentDate + 'T12:00:00');
+  const start = new Date(startDate + 'T12:00:00');
+
+  const diffTime = current.getTime() - start.getTime();
+  const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
+
+  return diffDays + 1; // Day 1 is the start date
+}

--- a/app/apps/todo-app/lib/notes-storage.ts
+++ b/app/apps/todo-app/lib/notes-storage.ts
@@ -1,0 +1,220 @@
+import { v4 as uuidv4 } from 'uuid';
+import { DayNote, DayNoteRepository } from './types';
+import { getFirebaseDb, isFirebaseConfigured } from '@/lib/firebase';
+import {
+  collection,
+  doc,
+  getDocs,
+  getDoc,
+  setDoc,
+  updateDoc,
+  deleteDoc,
+  query,
+  where,
+  orderBy,
+  limit,
+} from 'firebase/firestore';
+
+const STORAGE_KEY = 'todo-app-notes';
+const COLLECTION_NAME = 'dayNotes';
+
+// Firebase Repository
+export class FirebaseNotesRepository implements DayNoteRepository {
+  private userId: string = '';
+
+  private get db() {
+    return getFirebaseDb();
+  }
+
+  private get notesCollection() {
+    return collection(this.db, COLLECTION_NAME);
+  }
+
+  setUserId(userId: string): void {
+    this.userId = userId;
+  }
+
+  async getAll(): Promise<DayNote[]> {
+    if (!this.userId) return [];
+    const q = query(
+      this.notesCollection,
+      where('userId', '==', this.userId),
+      orderBy('date', 'desc')
+    );
+    const snapshot = await getDocs(q);
+    return snapshot.docs.map(doc => doc.data() as DayNote);
+  }
+
+  async getByDate(date: string): Promise<DayNote | null> {
+    if (!this.userId) return null;
+    const q = query(
+      this.notesCollection,
+      where('userId', '==', this.userId),
+      where('date', '==', date),
+      limit(1)
+    );
+    const snapshot = await getDocs(q);
+    if (snapshot.empty) return null;
+    return snapshot.docs[0].data() as DayNote;
+  }
+
+  async create(noteData: Omit<DayNote, 'id' | 'userId' | 'createdAt' | 'updatedAt'>): Promise<DayNote> {
+    if (!this.userId) throw new Error('Not authenticated');
+
+    // Check if note already exists for this date
+    const existing = await this.getByDate(noteData.date);
+    if (existing) {
+      return this.update(existing.id, { content: noteData.content });
+    }
+
+    const now = new Date().toISOString();
+    const note: DayNote = {
+      ...noteData,
+      id: uuidv4(),
+      userId: this.userId,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await setDoc(doc(this.db, COLLECTION_NAME, note.id), note);
+    return note;
+  }
+
+  async update(id: string, updates: Partial<DayNote>): Promise<DayNote> {
+    const docRef = doc(this.db, COLLECTION_NAME, id);
+
+    const cleanUpdates: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(updates)) {
+      if (value !== undefined) {
+        cleanUpdates[key] = value;
+      }
+    }
+    cleanUpdates.updatedAt = new Date().toISOString();
+
+    await updateDoc(docRef, cleanUpdates);
+
+    const updated = await getDoc(docRef);
+    return updated.data() as DayNote;
+  }
+
+  async delete(id: string): Promise<void> {
+    await deleteDoc(doc(this.db, COLLECTION_NAME, id));
+  }
+}
+
+// LocalStorage Repository
+export class LocalStorageNotesRepository implements DayNoteRepository {
+  private userId: string = 'local-user';
+
+  setUserId(userId: string): void {
+    this.userId = userId || 'local-user';
+  }
+
+  private getStorageKey(): string {
+    return `${STORAGE_KEY}-${this.userId}`;
+  }
+
+  async getAll(): Promise<DayNote[]> {
+    if (typeof window === 'undefined') return [];
+    const data = localStorage.getItem(this.getStorageKey());
+    const notes = data ? JSON.parse(data) : [];
+    return notes.sort((a: DayNote, b: DayNote) => b.date.localeCompare(a.date));
+  }
+
+  async getByDate(date: string): Promise<DayNote | null> {
+    const allNotes = await this.getAll();
+    return allNotes.find(note => note.date === date) || null;
+  }
+
+  async create(noteData: Omit<DayNote, 'id' | 'userId' | 'createdAt' | 'updatedAt'>): Promise<DayNote> {
+    const allNotes = await this.getAll();
+
+    // Check if note already exists for this date
+    const existingIndex = allNotes.findIndex(note => note.date === noteData.date);
+    if (existingIndex !== -1) {
+      return this.update(allNotes[existingIndex].id, { content: noteData.content });
+    }
+
+    const now = new Date().toISOString();
+    const note: DayNote = {
+      ...noteData,
+      id: uuidv4(),
+      userId: this.userId,
+      createdAt: now,
+      updatedAt: now,
+    };
+    allNotes.push(note);
+    this.save(allNotes);
+    return note;
+  }
+
+  async update(id: string, updates: Partial<DayNote>): Promise<DayNote> {
+    const allNotes = await this.getAll();
+    const index = allNotes.findIndex(note => note.id === id);
+    if (index === -1) {
+      throw new Error(`Note with id ${id} not found`);
+    }
+
+    const updatedNote = {
+      ...allNotes[index],
+      ...updates,
+      updatedAt: new Date().toISOString(),
+    };
+    allNotes[index] = updatedNote;
+    this.save(allNotes);
+    return updatedNote;
+  }
+
+  async delete(id: string): Promise<void> {
+    const allNotes = await this.getAll();
+    const filtered = allNotes.filter(note => note.id !== id);
+    this.save(filtered);
+  }
+
+  private save(notes: DayNote[]): void {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(this.getStorageKey(), JSON.stringify(notes));
+    }
+  }
+}
+
+// Hybrid Repository
+class HybridNotesRepository implements DayNoteRepository {
+  private firebaseRepo = new FirebaseNotesRepository();
+  private localRepo = new LocalStorageNotesRepository();
+  private useFirebase = false;
+
+  setUserId(userId: string): void {
+    const isRealUser = !!userId && userId !== 'local-user';
+    this.useFirebase = isRealUser && isFirebaseConfigured();
+    this.firebaseRepo.setUserId(userId);
+    this.localRepo.setUserId(userId || 'local-user');
+  }
+
+  private get repo(): DayNoteRepository {
+    return this.useFirebase ? this.firebaseRepo : this.localRepo;
+  }
+
+  getAll(): Promise<DayNote[]> {
+    return this.repo.getAll();
+  }
+
+  getByDate(date: string): Promise<DayNote | null> {
+    return this.repo.getByDate(date);
+  }
+
+  create(noteData: Omit<DayNote, 'id' | 'userId' | 'createdAt' | 'updatedAt'>): Promise<DayNote> {
+    return this.repo.create(noteData);
+  }
+
+  update(id: string, updates: Partial<DayNote>): Promise<DayNote> {
+    return this.repo.update(id, updates);
+  }
+
+  delete(id: string): Promise<void> {
+    return this.repo.delete(id);
+  }
+}
+
+// Export singleton
+export const notesRepository: DayNoteRepository = new HybridNotesRepository();

--- a/app/apps/todo-app/lib/settings-storage.ts
+++ b/app/apps/todo-app/lib/settings-storage.ts
@@ -1,0 +1,183 @@
+import { v4 as uuidv4 } from 'uuid';
+import { AppSettings, AppSettingsRepository } from './types';
+import { getFirebaseDb, isFirebaseConfigured } from '@/lib/firebase';
+import {
+  collection,
+  doc,
+  getDocs,
+  getDoc,
+  setDoc,
+  updateDoc,
+  query,
+  where,
+  limit,
+} from 'firebase/firestore';
+
+const STORAGE_KEY = 'todo-app-settings';
+const COLLECTION_NAME = 'todoAppSettings';
+
+// Firebase Repository
+export class FirebaseSettingsRepository implements AppSettingsRepository {
+  private userId: string = '';
+
+  private get db() {
+    return getFirebaseDb();
+  }
+
+  private get settingsCollection() {
+    return collection(this.db, COLLECTION_NAME);
+  }
+
+  setUserId(userId: string): void {
+    this.userId = userId;
+  }
+
+  async get(): Promise<AppSettings | null> {
+    if (!this.userId) return null;
+    const q = query(
+      this.settingsCollection,
+      where('userId', '==', this.userId),
+      limit(1)
+    );
+    const snapshot = await getDocs(q);
+    if (snapshot.empty) return null;
+    return snapshot.docs[0].data() as AppSettings;
+  }
+
+  async set(startDate: string): Promise<AppSettings> {
+    if (!this.userId) throw new Error('Not authenticated');
+
+    // Check if settings already exist
+    const existing = await this.get();
+    if (existing) {
+      return this.update({ startDate });
+    }
+
+    const now = new Date().toISOString();
+    const settings: AppSettings = {
+      id: uuidv4(),
+      userId: this.userId,
+      startDate,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await setDoc(doc(this.db, COLLECTION_NAME, settings.id), settings);
+    return settings;
+  }
+
+  async update(updates: Partial<Omit<AppSettings, 'id' | 'userId' | 'createdAt' | 'updatedAt'>>): Promise<AppSettings> {
+    const existing = await this.get();
+    if (!existing) {
+      throw new Error('Settings not found');
+    }
+
+    const docRef = doc(this.db, COLLECTION_NAME, existing.id);
+
+    const cleanUpdates: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(updates)) {
+      if (value !== undefined) {
+        cleanUpdates[key] = value;
+      }
+    }
+    cleanUpdates.updatedAt = new Date().toISOString();
+
+    await updateDoc(docRef, cleanUpdates);
+
+    const updated = await getDoc(docRef);
+    return updated.data() as AppSettings;
+  }
+}
+
+// LocalStorage Repository
+export class LocalStorageSettingsRepository implements AppSettingsRepository {
+  private userId: string = 'local-user';
+
+  setUserId(userId: string): void {
+    this.userId = userId || 'local-user';
+  }
+
+  private getStorageKey(): string {
+    return `${STORAGE_KEY}-${this.userId}`;
+  }
+
+  async get(): Promise<AppSettings | null> {
+    if (typeof window === 'undefined') return null;
+    const data = localStorage.getItem(this.getStorageKey());
+    return data ? JSON.parse(data) : null;
+  }
+
+  async set(startDate: string): Promise<AppSettings> {
+    const existing = await this.get();
+    if (existing) {
+      return this.update({ startDate });
+    }
+
+    const now = new Date().toISOString();
+    const settings: AppSettings = {
+      id: uuidv4(),
+      userId: this.userId,
+      startDate,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this.save(settings);
+    return settings;
+  }
+
+  async update(updates: Partial<Omit<AppSettings, 'id' | 'userId' | 'createdAt' | 'updatedAt'>>): Promise<AppSettings> {
+    const existing = await this.get();
+    if (!existing) {
+      throw new Error('Settings not found');
+    }
+
+    const updated: AppSettings = {
+      ...existing,
+      ...updates,
+      updatedAt: new Date().toISOString(),
+    };
+
+    this.save(updated);
+    return updated;
+  }
+
+  private save(settings: AppSettings): void {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(this.getStorageKey(), JSON.stringify(settings));
+    }
+  }
+}
+
+// Hybrid Repository
+class HybridSettingsRepository implements AppSettingsRepository {
+  private firebaseRepo = new FirebaseSettingsRepository();
+  private localRepo = new LocalStorageSettingsRepository();
+  private useFirebase = false;
+
+  setUserId(userId: string): void {
+    const isRealUser = !!userId && userId !== 'local-user';
+    this.useFirebase = isRealUser && isFirebaseConfigured();
+    this.firebaseRepo.setUserId(userId);
+    this.localRepo.setUserId(userId || 'local-user');
+  }
+
+  private get repo(): AppSettingsRepository {
+    return this.useFirebase ? this.firebaseRepo : this.localRepo;
+  }
+
+  get(): Promise<AppSettings | null> {
+    return this.repo.get();
+  }
+
+  set(startDate: string): Promise<AppSettings> {
+    return this.repo.set(startDate);
+  }
+
+  update(updates: Partial<Omit<AppSettings, 'id' | 'userId' | 'createdAt' | 'updatedAt'>>): Promise<AppSettings> {
+    return this.repo.update(updates);
+  }
+}
+
+// Export singleton
+export const settingsRepository: AppSettingsRepository = new HybridSettingsRepository();

--- a/app/apps/todo-app/lib/types.ts
+++ b/app/apps/todo-app/lib/types.ts
@@ -51,3 +51,36 @@ export interface DailyCompletion {
   completed: number;
   points: number;
 }
+
+export interface AppSettings {
+  id: string;
+  userId: string;
+  startDate: string; // ISO date string (YYYY-MM-DD) - Day 1
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AppSettingsRepository {
+  setUserId(userId: string): void;
+  get(): Promise<AppSettings | null>;
+  set(startDate: string): Promise<AppSettings>;
+  update(updates: Partial<Omit<AppSettings, 'id' | 'userId' | 'createdAt' | 'updatedAt'>>): Promise<AppSettings>;
+}
+
+export interface DayNote {
+  id: string;
+  userId: string;
+  date: string; // ISO date string (YYYY-MM-DD)
+  content: string; // Markdown content
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface DayNoteRepository {
+  setUserId(userId: string): void;
+  getAll(): Promise<DayNote[]>;
+  getByDate(date: string): Promise<DayNote | null>;
+  create(note: Omit<DayNote, 'id' | 'userId' | 'createdAt' | 'updatedAt'>): Promise<DayNote>;
+  update(id: string, updates: Partial<DayNote>): Promise<DayNote>;
+  delete(id: string): Promise<void>;
+}


### PR DESCRIPTION
- Add day counter: Each day now shows "Day 1", "Day 2", etc. based on a start date
- Add start date setup: Users are prompted to choose their Day 1 on first use
- Add daily notes/diary: New "Notes" tab for writing daily reflections
- Update date navigation to display day number alongside actual date
- Add settings storage for tracking start date
- Add notes storage for daily diary entries
- Create StartDateSetup component for initial configuration
- Create DayNotesEditor component for writing daily notes
- Support both Firebase and localStorage for settings and notes