### PR TITLE
Fix game hour calculations to add baseline + logged hours

### DIFF
--- a/app/apps/game-analytics/components/PlayLogModal.tsx
+++ b/app/apps/game-analytics/components/PlayLogModal.tsx
@@ -54,6 +54,7 @@ export function PlayLogModal({ game, onSave, onClose }: PlayLogModalProps) {
   };
 
   const totalLoggedHours = logs.reduce((sum, log) => sum + log.hours, 0);
+  const totalHours = game.hours + totalLoggedHours; // Baseline + logged hours
 
   // Parse date string (YYYY-MM-DD) as local date to avoid timezone shift
   const parseLocalDate = (dateStr: string) => {
@@ -81,8 +82,8 @@ export function PlayLogModal({ game, onSave, onClose }: PlayLogModalProps) {
         {/* Stats Bar */}
         <div className="px-4 py-3 bg-white/[0.02] border-b border-white/5 flex items-center gap-6">
           <div>
-            <div className="text-xs text-white/40">Sessions</div>
-            <div className="text-lg font-semibold text-white">{logs.length}</div>
+            <div className="text-xs text-white/40">Baseline Hours</div>
+            <div className="text-lg font-semibold text-white/40">{game.hours}h</div>
           </div>
           <div>
             <div className="text-xs text-white/40">Logged Hours</div>
@@ -90,7 +91,7 @@ export function PlayLogModal({ game, onSave, onClose }: PlayLogModalProps) {
           </div>
           <div>
             <div className="text-xs text-white/40">Total Hours</div>
-            <div className="text-lg font-semibold text-white/60">{game.hours}h</div>
+            <div className="text-lg font-semibold text-white">{totalHours.toFixed(1)}h</div>
           </div>
         </div>
 

--- a/app/apps/game-analytics/hooks/useAnalytics.ts
+++ b/app/apps/game-analytics/hooks/useAnalytics.ts
@@ -2,16 +2,18 @@
 
 import { useMemo } from 'react';
 import { Game, GameMetrics, AnalyticsSummary } from '../lib/types';
-import { calculateMetrics, calculateSummary } from '../lib/calculations';
+import { calculateMetrics, calculateSummary, getTotalHours } from '../lib/calculations';
 
 export interface GameWithMetrics extends Game {
   metrics: GameMetrics;
+  totalHours: number; // Baseline + logged hours
 }
 
 export function useAnalytics(games: Game[]) {
   const gamesWithMetrics = useMemo<GameWithMetrics[]>(() => {
     return games.map(g => ({
       ...g,
+      totalHours: getTotalHours(g),
       metrics: calculateMetrics(g),
     }));
   }, [games]);

--- a/app/apps/game-analytics/page.tsx
+++ b/app/apps/game-analytics/page.tsx
@@ -74,10 +74,9 @@ export default function GameAnalyticsPage() {
 
   const handleSavePlayLogs = async (playLogs: PlayLog[]) => {
     if (!playLogGame) return;
-    const totalHours = playLogs.reduce((sum, log) => sum + log.hours, 0);
+    // Only update playLogs - hours field remains as baseline
     await updateGame(playLogGame.id, {
       playLogs,
-      hours: Math.max(playLogGame.hours, totalHours), // Keep manual hours if higher
     });
     setPlayLogGame(null);
     showToast('Play sessions saved', 'success');
@@ -488,10 +487,9 @@ export default function GameAnalyticsPage() {
                 if (game) {
                   const existingLogs = game.playLogs || [];
                   const updatedLogs = [...existingLogs, playLog];
-                  const totalHours = updatedLogs.reduce((sum, log) => sum + log.hours, 0);
+                  // Only update playLogs - hours field remains as baseline
                   await updateGame(gameId, {
                     playLogs: updatedLogs,
-                    hours: Math.max(game.hours, totalHours),
                   });
                   showToast('Play session added', 'success');
                 }


### PR DESCRIPTION
- Add getTotalHours() helper function to calculate baseline hours + logged session hours
- Update all calculations (cost-per-hour, ROI, summaries, etc.) to use total hours
- Modify handleSavePlayLogs and onQuickAddTime to preserve baseline hours field
- Add totalHours property to GameWithMetrics for easier access in components
- Update PlayLogModal to display baseline, logged, and total hours separately

This allows tracking historical hours (baseline) while adding detailed play sessions,
with all value calculations using the combined total.