### PR TITLE
Expand game images and click-to-expand functionality in stats page

### DIFF
--- a/app/apps/game-analytics/components/FunStatsPanel.tsx
+++ b/app/apps/game-analytics/components/FunStatsPanel.tsx
@@ -45,6 +45,7 @@ type ModalType = 'centuryClub' | 'patientGamer' | 'freeGames' | 'quickFix' | 'sh
 
 export function FunStatsPanel({ games }: FunStatsPanelProps) {
   const [activeModal, setActiveModal] = useState<ModalType>(null);
+  const [showAllRegrets, setShowAllRegrets] = useState(false);
   // Existing stats
   const hiddenGems = findHiddenGems(games);
   const regretPurchases = findRegretPurchases(games);
@@ -232,16 +233,24 @@ export function FunStatsPanel({ games }: FunStatsPanelProps) {
           <div className="space-y-2">
             {hiddenGems.slice(0, 3).map((gem, idx) => (
               <div key={gem.game.id} className="flex items-center gap-3 p-2 bg-white/5 rounded-lg">
-                <div className="flex items-center justify-center w-6 h-6 rounded-full bg-emerald-500/20 text-emerald-400 text-xs font-bold">
+                <div className="flex items-center justify-center w-6 h-6 rounded-full bg-emerald-500/20 text-emerald-400 text-xs font-bold shrink-0">
                   {idx + 1}
                 </div>
+                {gem.game.thumbnail && (
+                  <img
+                    src={gem.game.thumbnail}
+                    alt={gem.game.name}
+                    className="w-10 h-10 object-cover rounded shrink-0"
+                    loading="lazy"
+                  />
+                )}
                 <div className="flex-1 min-w-0">
                   <div className="text-sm font-medium text-white/90 truncate">{gem.game.name}</div>
                   <div className="text-xs text-white/40">
                     ${gem.game.price} • {gem.game.hours}h • {gem.game.rating}/10
                   </div>
                 </div>
-                <div className="text-xs text-emerald-400 font-medium">
+                <div className="text-xs text-emerald-400 font-medium shrink-0">
                   ${(gem.game.price / gem.game.hours).toFixed(2)}/h
                 </div>
               </div>
@@ -260,12 +269,20 @@ export function FunStatsPanel({ games }: FunStatsPanelProps) {
           </div>
           <div className="space-y-2">
             {shelfWarmers.slice(0, 3).map((warmer) => (
-              <div key={warmer.game.id} className="flex items-center justify-between p-2 bg-white/5 rounded-lg">
+              <div key={warmer.game.id} className="flex items-center gap-3 p-2 bg-white/5 rounded-lg">
+                {warmer.game.thumbnail && (
+                  <img
+                    src={warmer.game.thumbnail}
+                    alt={warmer.game.name}
+                    className="w-10 h-10 object-cover rounded shrink-0"
+                    loading="lazy"
+                  />
+                )}
                 <div className="flex-1 min-w-0">
                   <div className="text-sm font-medium text-white/90 truncate">{warmer.game.name}</div>
                   <div className="text-xs text-white/40">${warmer.game.price}</div>
                 </div>
-                <div className="text-right">
+                <div className="text-right shrink-0">
                   <div className="text-sm font-medium text-yellow-400">{Math.floor(warmer.daysSitting)}</div>
                   <div className="text-xs text-white/30">days</div>
                 </div>
@@ -279,21 +296,39 @@ export function FunStatsPanel({ games }: FunStatsPanelProps) {
       {/* Regret Purchases */}
       {regretPurchases.length > 0 && (
         <div className="p-4 bg-gradient-to-br from-red-500/10 to-pink-500/10 border border-red-500/20 rounded-xl">
-          <div className="flex items-center gap-2 mb-3">
-            <Frown size={16} className="text-red-400" />
-            <h4 className="text-sm font-medium text-white">Buyer&apos;s Remorse</h4>
-            <span className="text-xs text-white/30">Could use more love</span>
+          <div className="flex items-center justify-between mb-3">
+            <div className="flex items-center gap-2">
+              <Frown size={16} className="text-red-400" />
+              <h4 className="text-sm font-medium text-white">Buyer&apos;s Remorse</h4>
+              <span className="text-xs text-white/30">Could use more love</span>
+            </div>
+            {regretPurchases.length > 3 && (
+              <button
+                onClick={() => setShowAllRegrets(!showAllRegrets)}
+                className="text-xs text-white/40 hover:text-white/70 transition-all"
+              >
+                {showAllRegrets ? 'Show Less' : `Show All (${regretPurchases.length})`}
+              </button>
+            )}
           </div>
           <div className="space-y-2">
-            {regretPurchases.slice(0, 3).map((regret) => (
-              <div key={regret.game.id} className="flex items-center justify-between p-2 bg-white/5 rounded-lg">
+            {(showAllRegrets ? regretPurchases : regretPurchases.slice(0, 3)).map((regret) => (
+              <div key={regret.game.id} className="flex items-center gap-3 p-2 bg-white/5 rounded-lg">
+                {regret.game.thumbnail && (
+                  <img
+                    src={regret.game.thumbnail}
+                    alt={regret.game.name}
+                    className="w-10 h-10 object-cover rounded shrink-0"
+                    loading="lazy"
+                  />
+                )}
                 <div className="flex-1 min-w-0">
                   <div className="text-sm font-medium text-white/90 truncate">{regret.game.name}</div>
                   <div className="text-xs text-white/40">
                     ${regret.game.price} • {regret.game.hours}h played
                   </div>
                 </div>
-                <div className="text-xs text-red-400">
+                <div className="text-xs text-red-400 shrink-0">
                   Regret: {regret.regretScore.toFixed(0)}
                 </div>
               </div>
@@ -312,10 +347,22 @@ export function FunStatsPanel({ games }: FunStatsPanelProps) {
             <span className="text-xs text-white/30">Best $/hour</span>
           </div>
           <div className="p-3 bg-white/5 rounded-lg">
-            <div className="text-sm font-medium text-white/90 mb-2">{valueChampion.game.name}</div>
-            <div className="flex items-center justify-between text-xs">
-              <span className="text-white/40">{valueChampion.game.hours}h • ${valueChampion.game.price}</span>
-              <span className="text-lg font-bold text-emerald-400">${valueChampion.costPerHour.toFixed(2)}/hr</span>
+            <div className="flex items-center gap-3 mb-2">
+              {valueChampion.game.thumbnail && (
+                <img
+                  src={valueChampion.game.thumbnail}
+                  alt={valueChampion.game.name}
+                  className="w-12 h-12 object-cover rounded shrink-0"
+                  loading="lazy"
+                />
+              )}
+              <div className="flex-1 min-w-0">
+                <div className="text-sm font-medium text-white/90 truncate">{valueChampion.game.name}</div>
+                <div className="text-xs text-white/40">{valueChampion.game.hours}h • ${valueChampion.game.price}</div>
+              </div>
+            </div>
+            <div className="flex items-center justify-center">
+              <span className="text-2xl font-bold text-emerald-400">${valueChampion.costPerHour.toFixed(2)}/hr</span>
             </div>
           </div>
         </div>
@@ -377,27 +424,57 @@ export function FunStatsPanel({ games }: FunStatsPanelProps) {
             {fastestCompletion && (
               <div className="p-2 bg-white/5 rounded-lg">
                 <div className="text-xs text-white/40 mb-1">⚡ Speed Demon</div>
-                <div className="flex items-center justify-between">
-                  <span className="text-sm text-white/80">{fastestCompletion.game.name}</span>
-                  <span className="text-sm font-medium text-yellow-400">{fastestCompletion.days}d</span>
+                <div className="flex items-center gap-3">
+                  {fastestCompletion.game.thumbnail && (
+                    <img
+                      src={fastestCompletion.game.thumbnail}
+                      alt={fastestCompletion.game.name}
+                      className="w-10 h-10 object-cover rounded shrink-0"
+                      loading="lazy"
+                    />
+                  )}
+                  <div className="flex-1 min-w-0 flex items-center justify-between">
+                    <span className="text-sm text-white/80 truncate">{fastestCompletion.game.name}</span>
+                    <span className="text-sm font-medium text-yellow-400 shrink-0 ml-2">{fastestCompletion.days}d</span>
+                  </div>
                 </div>
               </div>
             )}
             {slowestCompletion && (
               <div className="p-2 bg-white/5 rounded-lg">
                 <div className="text-xs text-white/40 mb-1">🐌 Slow Burn</div>
-                <div className="flex items-center justify-between">
-                  <span className="text-sm text-white/80">{slowestCompletion.game.name}</span>
-                  <span className="text-sm font-medium text-orange-400">{slowestCompletion.days}d</span>
+                <div className="flex items-center gap-3">
+                  {slowestCompletion.game.thumbnail && (
+                    <img
+                      src={slowestCompletion.game.thumbnail}
+                      alt={slowestCompletion.game.name}
+                      className="w-10 h-10 object-cover rounded shrink-0"
+                      loading="lazy"
+                    />
+                  )}
+                  <div className="flex-1 min-w-0 flex items-center justify-between">
+                    <span className="text-sm text-white/80 truncate">{slowestCompletion.game.name}</span>
+                    <span className="text-sm font-medium text-orange-400 shrink-0 ml-2">{slowestCompletion.days}d</span>
+                  </div>
                 </div>
               </div>
             )}
             {longestSession && (
               <div className="p-2 bg-white/5 rounded-lg">
                 <div className="text-xs text-white/40 mb-1">🎯 Marathon Session</div>
-                <div className="flex items-center justify-between">
-                  <span className="text-sm text-white/80">{longestSession.game.name}</span>
-                  <span className="text-sm font-medium text-red-400">{longestSession.hours.toFixed(1)}h</span>
+                <div className="flex items-center gap-3">
+                  {longestSession.game.thumbnail && (
+                    <img
+                      src={longestSession.game.thumbnail}
+                      alt={longestSession.game.name}
+                      className="w-10 h-10 object-cover rounded shrink-0"
+                      loading="lazy"
+                    />
+                  )}
+                  <div className="flex-1 min-w-0 flex items-center justify-between">
+                    <span className="text-sm text-white/80 truncate">{longestSession.game.name}</span>
+                    <span className="text-sm font-medium text-red-400 shrink-0 ml-2">{longestSession.hours.toFixed(1)}h</span>
+                  </div>
                 </div>
               </div>
             )}

--- a/app/apps/game-analytics/components/PeriodStatsPanel.tsx
+++ b/app/apps/game-analytics/components/PeriodStatsPanel.tsx
@@ -81,13 +81,23 @@ export function PeriodStatsPanel({ games }: PeriodStatsPanelProps) {
 
           {weekStats.mostPlayedGame && (
             <div className="p-3 bg-white/5 rounded-xl">
-              <div className="flex items-center gap-2 mb-1">
+              <div className="flex items-center gap-2 mb-2">
                 <Gamepad2 size={14} className="text-white/40" />
                 <span className="text-xs text-white/40">Most Played</span>
               </div>
-              <div className="flex items-center justify-between">
-                <span className="text-sm font-medium text-white/90">{weekStats.mostPlayedGame.name}</span>
-                <span className="text-sm text-blue-400">{weekStats.mostPlayedGame.hours.toFixed(1)}h</span>
+              <div className="flex items-center gap-3">
+                {weekStats.mostPlayedGame.thumbnail && (
+                  <img
+                    src={weekStats.mostPlayedGame.thumbnail}
+                    alt={weekStats.mostPlayedGame.name}
+                    className="w-12 h-12 object-cover rounded"
+                    loading="lazy"
+                  />
+                )}
+                <div className="flex-1 min-w-0 flex items-center justify-between">
+                  <span className="text-sm font-medium text-white/90 truncate">{weekStats.mostPlayedGame.name}</span>
+                  <span className="text-sm text-blue-400 font-semibold shrink-0 ml-2">{weekStats.mostPlayedGame.hours.toFixed(1)}h</span>
+                </div>
               </div>
             </div>
           )}
@@ -108,11 +118,21 @@ export function PeriodStatsPanel({ games }: PeriodStatsPanelProps) {
               {showWeekGames && (
                 <div className="mt-2 space-y-1">
                   {weekGames.map(({ game, hours, sessions }) => (
-                    <div key={game.id} className="flex items-center justify-between px-3 py-2 bg-white/[0.03] rounded-lg">
-                      <span className="text-sm text-white/80">{game.name}</span>
-                      <div className="flex items-center gap-3">
-                        <span className="text-xs text-cyan-400">{sessions} session{sessions !== 1 ? 's' : ''}</span>
-                        <span className="text-sm text-blue-400 font-medium">{hours.toFixed(1)}h</span>
+                    <div key={game.id} className="flex items-center gap-3 px-3 py-2 bg-white/[0.03] rounded-lg">
+                      {game.thumbnail && (
+                        <img
+                          src={game.thumbnail}
+                          alt={game.name}
+                          className="w-10 h-10 object-cover rounded shrink-0"
+                          loading="lazy"
+                        />
+                      )}
+                      <div className="flex-1 min-w-0 flex items-center justify-between">
+                        <span className="text-sm text-white/80 truncate">{game.name}</span>
+                        <div className="flex items-center gap-3 shrink-0 ml-3">
+                          <span className="text-xs text-cyan-400">{sessions} session{sessions !== 1 ? 's' : ''}</span>
+                          <span className="text-sm text-blue-400 font-medium">{hours.toFixed(1)}h</span>
+                        </div>
                       </div>
                     </div>
                   ))}
@@ -153,13 +173,23 @@ export function PeriodStatsPanel({ games }: PeriodStatsPanelProps) {
 
           {monthStats.mostPlayedGame && (
             <div className="p-3 bg-white/5 rounded-xl">
-              <div className="flex items-center gap-2 mb-1">
+              <div className="flex items-center gap-2 mb-2">
                 <Gamepad2 size={14} className="text-white/40" />
                 <span className="text-xs text-white/40">Most Played</span>
               </div>
-              <div className="flex items-center justify-between">
-                <span className="text-sm font-medium text-white/90">{monthStats.mostPlayedGame.name}</span>
-                <span className="text-sm text-purple-400">{monthStats.mostPlayedGame.hours.toFixed(1)}h</span>
+              <div className="flex items-center gap-3">
+                {monthStats.mostPlayedGame.thumbnail && (
+                  <img
+                    src={monthStats.mostPlayedGame.thumbnail}
+                    alt={monthStats.mostPlayedGame.name}
+                    className="w-12 h-12 object-cover rounded"
+                    loading="lazy"
+                  />
+                )}
+                <div className="flex-1 min-w-0 flex items-center justify-between">
+                  <span className="text-sm font-medium text-white/90 truncate">{monthStats.mostPlayedGame.name}</span>
+                  <span className="text-sm text-purple-400 font-semibold shrink-0 ml-2">{monthStats.mostPlayedGame.hours.toFixed(1)}h</span>
+                </div>
               </div>
             </div>
           )}
@@ -180,11 +210,21 @@ export function PeriodStatsPanel({ games }: PeriodStatsPanelProps) {
               {showMonthGames && (
                 <div className="mt-2 space-y-1">
                   {monthGames.map(({ game, hours, sessions }) => (
-                    <div key={game.id} className="flex items-center justify-between px-3 py-2 bg-white/[0.03] rounded-lg">
-                      <span className="text-sm text-white/80">{game.name}</span>
-                      <div className="flex items-center gap-3">
-                        <span className="text-xs text-cyan-400">{sessions} session{sessions !== 1 ? 's' : ''}</span>
-                        <span className="text-sm text-purple-400 font-medium">{hours.toFixed(1)}h</span>
+                    <div key={game.id} className="flex items-center gap-3 px-3 py-2 bg-white/[0.03] rounded-lg">
+                      {game.thumbnail && (
+                        <img
+                          src={game.thumbnail}
+                          alt={game.name}
+                          className="w-10 h-10 object-cover rounded shrink-0"
+                          loading="lazy"
+                        />
+                      )}
+                      <div className="flex-1 min-w-0 flex items-center justify-between">
+                        <span className="text-sm text-white/80 truncate">{game.name}</span>
+                        <div className="flex items-center gap-3 shrink-0 ml-3">
+                          <span className="text-xs text-cyan-400">{sessions} session{sessions !== 1 ? 's' : ''}</span>
+                          <span className="text-sm text-purple-400 font-medium">{hours.toFixed(1)}h</span>
+                        </div>
                       </div>
                     </div>
                   ))}

--- a/app/apps/game-analytics/components/StatsView.tsx
+++ b/app/apps/game-analytics/components/StatsView.tsx
@@ -83,6 +83,7 @@ export function StatsView({ games, summary, budgets = [], onSetBudget }: StatsVi
   const [showDiscountGames, setShowDiscountGames] = useState(false);
   const [showAllGamesPlayed, setShowAllGamesPlayed] = useState(false);
   const [showROIRankings, setShowROIRankings] = useState(false);
+  const [showAllFranchises, setShowAllFranchises] = useState(false);
 
   const isAllTime = selectedPeriod === 'all';
   const selectedYear = isAllTime ? currentYear : selectedPeriod;
@@ -632,12 +633,22 @@ export function StatsView({ games, summary, budgets = [], onSetBudget }: StatsVi
         {/* Franchise Stats */}
         {franchiseStats.length > 0 && (
           <div className="p-4 bg-white/[0.02] border border-white/5 rounded-xl">
-            <h3 className="text-sm font-medium text-white/70 mb-3 flex items-center gap-2">
-              <Layers size={14} className="text-purple-400" />
-              {isAllTime ? 'All Time' : selectedYear} Franchise Stats
-            </h3>
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-sm font-medium text-white/70 flex items-center gap-2">
+                <Layers size={14} className="text-purple-400" />
+                {isAllTime ? 'All Time' : selectedYear} Franchise Stats
+              </h3>
+              {franchiseStats.length > 6 && (
+                <button
+                  onClick={() => setShowAllFranchises(!showAllFranchises)}
+                  className="text-xs text-white/40 hover:text-white/70 transition-all"
+                >
+                  {showAllFranchises ? 'Show Less' : `Show All (${franchiseStats.length})`}
+                </button>
+              )}
+            </div>
             <div className="space-y-3">
-              {franchiseStats.slice(0, 6).map((franchise, idx) => (
+              {(showAllFranchises ? franchiseStats : franchiseStats.slice(0, 6)).map((franchise, idx) => (
                 <div key={idx} className="p-3 bg-white/[0.03] rounded-lg">
                   <div className="flex items-center justify-between mb-2">
                     <span className="text-sm font-medium text-white/90">{franchise.name}</span>
@@ -666,11 +677,6 @@ export function StatsView({ games, summary, budgets = [], onSetBudget }: StatsVi
                   </div>
                 </div>
               ))}
-              {franchiseStats.length > 6 && (
-                <p className="text-[10px] text-white/30 text-center pt-1">
-                  +{franchiseStats.length - 6} more franchises
-                </p>
-              )}
             </div>
           </div>
         )}

--- a/app/apps/game-analytics/lib/calculations.ts
+++ b/app/apps/game-analytics/lib/calculations.ts
@@ -336,7 +336,7 @@ export interface PeriodStats {
   gamesPlayed: Game[];
   totalHours: number;
   totalSessions: number;
-  mostPlayedGame: { name: string; hours: number } | null;
+  mostPlayedGame: { name: string; hours: number; thumbnail?: string } | null;
   averageSessionLength: number;
   uniqueGames: number;
 }
@@ -373,7 +373,7 @@ export function getPeriodStats(games: Game[], days: number): PeriodStats {
     gamesPlayed,
     totalHours,
     totalSessions,
-    mostPlayedGame: mostPlayedEntry ? { name: mostPlayedEntry.game.name, hours: mostPlayedEntry.hours } : null,
+    mostPlayedGame: mostPlayedEntry ? { name: mostPlayedEntry.game.name, hours: mostPlayedEntry.hours, thumbnail: mostPlayedEntry.game.thumbnail } : null,
     averageSessionLength: totalSessions > 0 ? totalHours / totalSessions : 0,
     uniqueGames: gamesPlayed.length,
   };
@@ -409,7 +409,7 @@ export function getPeriodStatsForRange(games: Game[], startDate: Date, endDate: 
     gamesPlayed,
     totalHours,
     totalSessions,
-    mostPlayedGame: mostPlayedEntry ? { name: mostPlayedEntry.game.name, hours: mostPlayedEntry.hours } : null,
+    mostPlayedGame: mostPlayedEntry ? { name: mostPlayedEntry.game.name, hours: mostPlayedEntry.hours, thumbnail: mostPlayedEntry.game.thumbnail } : null,
     averageSessionLength: totalSessions > 0 ? totalHours / totalSessions : 0,
     uniqueGames: gamesPlayed.length,
   };


### PR DESCRIPTION
Enhanced the stats page with more game thumbnails and expandable sections:

PeriodStatsPanel improvements:
- Added game thumbnails to "Most Played" displays for Week and Month sections
- Added game thumbnails to expandable games lists in both sections
- Updated PeriodStats type to include thumbnail field

FunStatsPanel improvements:
- Added game thumbnails to Hidden Gems preview
- Added game thumbnails to Shelf Warmers
- Added game thumbnails to Buyer's Remorse section
- Added game thumbnails to Value Champion card
- Added game thumbnails to Speed Records (fastest/slowest/longest)
- Added click-to-expand functionality for Buyer's Remorse section

StatsView improvements:
- Added click-to-expand functionality for Franchise Stats section

These changes provide better visual context throughout the stats page and
allow users to expand sections to see complete lists instead of just previews.