### PR TITLE
Fix: Filter out undefined category field when creating tasks in Firestore

### DIFF
--- a/app/apps/todo-app/lib/storage.ts
+++ b/app/apps/todo-app/lib/storage.ts
@@ -117,7 +117,15 @@ export class FirebaseRepository implements TaskRepository {
       updatedAt: now,
     };
 
-    await setDoc(doc(this.db, COLLECTION_NAME, task.id), task);
+    // Filter out undefined values - Firestore doesn't accept them
+    const cleanTask: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(task)) {
+      if (value !== undefined) {
+        cleanTask[key] = value;
+      }
+    }
+
+    await setDoc(doc(this.db, COLLECTION_NAME, task.id), cleanTask);
     return task;
   }
 


### PR DESCRIPTION
When tasks are created without a category (no @mention), the category field
was being set to undefined and passed to Firestore's setDoc(). Firestore
rejects documents with undefined field values.

Fixed by filtering out undefined values before saving to Firestore, matching
the existing pattern used in the update() method. Tasks without categories
will simply not have a category field in the document.