### PR TITLE
Add search bar to Games tab for instant library filtering

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -5,6 +5,15 @@ entry below is one run. Newest entries first.
 
 ---
 
+## 2026-05-22 18:00 — Games Tab — Game search bar
+
+**Files**: app/apps/game-analytics/page.tsx
+**Risk**: not risky
+
+Added a full-width search bar to the Games tab that filters by name, genre, platform, franchise, and notes. Shows a live result count ("3 of 42 games") while typing, an X to clear, and a helpful empty state with a "Clear search" link when no games match. Users with large libraries can now find any game instantly without scrolling.
+
+FOLLOW-UP: Consider adding keyboard shortcut (Cmd/Ctrl+K) to focus the search bar, and optionally persist the search query across tab switches.
+
 ## 2026-05-22 14:00 — Infrastructure — Bootstrap update logs surface
 
 **Files**: UPDATE.md, app/apps/game-analytics/data/whats-new.json, app/apps/game-analytics/components/WhatsNewModal.tsx, app/apps/game-analytics/page.tsx

--- a/app/apps/game-analytics/data/whats-new.json
+++ b/app/apps/game-analytics/data/whats-new.json
@@ -2,6 +2,12 @@
   "entries": [
     {
       "date": "2026-05-22",
+      "area": "Games tab",
+      "title": "Search your library instantly",
+      "body": "A search bar now lives at the top of the Games tab. Type a game name, genre, or platform and your list narrows in real time. Works great when you have a big library and just want to find that one game quickly."
+    },
+    {
+      "date": "2026-05-22",
       "area": "What's new",
       "title": "Updates live here now",
       "body": "This is the new What's New panel. When the app changes, you'll see a friendly summary here so you always know what's different."

--- a/app/apps/game-analytics/page.tsx
+++ b/app/apps/game-analytics/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useMemo, useEffect, useCallback, useRef } from 'react';
-import { Plus, Sparkles, Gamepad2, Clock, DollarSign, Star, TrendingUp, Eye, Trophy, Flame, BarChart3, Calendar, List, MessageCircle, ListOrdered, ListPlus, Check, Heart, ChevronUp, ChevronDown, Compass, Zap, Target, ArrowUpRight, ArrowDownRight, Minus, Shield, MoreVertical, Download, Gift, ShoppingCart } from 'lucide-react';
+import { Plus, Sparkles, Gamepad2, Clock, DollarSign, Star, TrendingUp, Eye, Trophy, Flame, BarChart3, Calendar, List, MessageCircle, ListOrdered, ListPlus, Check, Heart, ChevronUp, ChevronDown, Compass, Zap, Target, ArrowUpRight, ArrowDownRight, Minus, Shield, MoreVertical, Download, Gift, ShoppingCart, Search, X } from 'lucide-react';
 import { useGames } from './hooks/useGames';
 import { useAnalytics, GameWithMetrics } from './hooks/useAnalytics';
 import { useBudget } from './hooks/useBudget';
@@ -202,6 +202,7 @@ export default function GameAnalyticsPage() {
     if (typeof window === 'undefined') return false;
     return localStorage.getItem('ga-group-sections') === 'true';
   });
+  const [searchQuery, setSearchQuery] = useState('');
   const [recapCollapsed, setRecapCollapsed] = useState(() => {
     if (typeof window === 'undefined') return false;
     return localStorage.getItem('ga-recap-collapsed') === 'true';
@@ -447,6 +448,17 @@ export default function GameAnalyticsPage() {
       if (viewMode === 'owned') return g.status !== 'Wishlist';
       if (viewMode === 'wishlist') return g.status === 'Wishlist';
       return true;
+    })
+    .filter(g => {
+      if (!searchQuery.trim()) return true;
+      const q = searchQuery.trim().toLowerCase();
+      return (
+        g.name.toLowerCase().includes(q) ||
+        (g.genre && g.genre.toLowerCase().includes(q)) ||
+        (g.platform && g.platform.toLowerCase().includes(q)) ||
+        (g.franchise && g.franchise.toLowerCase().includes(q)) ||
+        (g.notes && g.notes.toLowerCase().includes(q))
+      );
     })
     .sort((a, b) => {
       switch (sortBy) {
@@ -976,6 +988,38 @@ export default function GameAnalyticsPage() {
 
             {/* View Mode Filter & Sort (only for games tab) */}
             {tabMode === 'games' && (
+              <div className="flex flex-col gap-3">
+                {/* Search bar */}
+                {games.length > 0 && (
+                  <div className="space-y-1">
+                    <div className="relative">
+                      <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-white/30 pointer-events-none" />
+                      <input
+                        type="text"
+                        value={searchQuery}
+                        onChange={e => setSearchQuery(e.target.value)}
+                        placeholder="Search games, genres, platforms…"
+                        className="w-full pl-8 pr-8 py-2 bg-white/[0.03] border border-white/10 text-white text-sm rounded-lg placeholder:text-white/25 focus:outline-none focus:border-purple-500/40 focus:bg-white/[0.05] transition-all"
+                      />
+                      {searchQuery && (
+                        <button
+                          onClick={() => setSearchQuery('')}
+                          className="absolute right-2.5 top-1/2 -translate-y-1/2 text-white/30 hover:text-white/60 transition-colors"
+                        >
+                          <X size={14} />
+                        </button>
+                      )}
+                    </div>
+                    {searchQuery.trim() && (
+                      <p className="text-[11px] text-white/30 px-1">
+                        {filteredGames.length === 0
+                          ? 'No matches'
+                          : `${filteredGames.length} of ${gamesWithMetrics.filter(g => viewMode === 'owned' ? g.status !== 'Wishlist' : viewMode === 'wishlist' ? g.status === 'Wishlist' : true).length} game${filteredGames.length !== 1 ? 's' : ''}`
+                        }
+                      </p>
+                    )}
+                  </div>
+                )}
               <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3">
                 <div className="flex items-center gap-1 bg-white/[0.02] rounded-lg p-1">
                   {(['all', 'owned', 'wishlist'] as ViewMode[]).map((mode) => (
@@ -1075,6 +1119,7 @@ export default function GameAnalyticsPage() {
                   </div>
                 </div>
               </div>
+            </div>
             )}
           </div>
 
@@ -1089,7 +1134,17 @@ export default function GameAnalyticsPage() {
                 </div>
               ) : filteredGames.length === 0 ? (
                 <div className="text-center py-16">
-                  <p className="text-white/30 text-sm">No games in this category</p>
+                  {searchQuery.trim() ? (
+                    <>
+                      <Search size={32} className="mx-auto mb-3 text-white/10" />
+                      <p className="text-white/30 text-sm">No games match &ldquo;{searchQuery}&rdquo;</p>
+                      <button onClick={() => setSearchQuery('')} className="mt-2 text-xs text-purple-400/70 hover:text-purple-400 transition-colors">
+                        Clear search
+                      </button>
+                    </>
+                  ) : (
+                    <p className="text-white/30 text-sm">No games in this category</p>
+                  )}
                 </div>
               ) : (
                 <GameCardList


### PR DESCRIPTION
## Summary
Added a full-width search bar to the Games tab that enables users to instantly filter their game library by name, genre, platform, franchise, and notes. This is particularly useful for users with large libraries who need to quickly locate a specific game without scrolling.

## Key Changes
- **Search input component**: Added a search bar with icon and clear button (X) that appears at the top of the Games tab when games are present
- **Multi-field filtering**: Search queries match against game name, genre, platform, franchise, and notes (case-insensitive)
- **Live result counter**: Displays "X of Y games" while searching to show filtered results count
- **Empty state handling**: Shows a helpful message with a "Clear search" link when no games match the query
- **Icon imports**: Added `Search` and `X` icons from lucide-react
- **State management**: Added `searchQuery` state to track the current search input

## Implementation Details
- Search filtering is applied after view mode filtering (owned/wishlist/all) but before sorting
- The search bar only renders when there are games to search through
- Result counter intelligently accounts for the current view mode filter
- Clear button only appears when there's an active search query
- Styling matches the existing UI with subtle borders and hover states

## Documentation
Updated UPDATE.md and whats-new.json with user-facing feature announcement.

## Follow-up Opportunities
- Add keyboard shortcut (Cmd/Ctrl+K) to focus the search bar
- Persist search query across tab switches
- Add search history or recent searches

https://claude.ai/code/session_01K3DjwdqJndbF6ucjG449SM