### PR TITLE
Add decimal ratings, AI voice review interview, and reset confirmation

### DIFF
--- a/app/apps/game-analytics/components/AIReviewInterview.tsx
+++ b/app/apps/game-analytics/components/AIReviewInterview.tsx
@@ -1,0 +1,299 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Mic, Square, Loader2, Sparkles, X, RefreshCw, Check, Pencil } from 'lucide-react';
+import clsx from 'clsx';
+import { Game } from '../lib/types';
+import { formatRating } from '../lib/calculations';
+import {
+  conductReviewInterview,
+  synthesizeGameReview,
+  buildTasteSummary,
+  ReviewGameContext,
+  ReviewInterviewTurn,
+} from '../lib/ai-service';
+import { useAudioRecorder } from '../hooks/useAudioRecorder';
+
+interface AIReviewInterviewProps {
+  game: ReviewGameContext;
+  allGames: Game[];
+  initialReview?: string;
+  onComplete: (review: string) => void;
+  onClose: () => void;
+}
+
+const MAX_QUESTIONS = 5;
+
+type Phase = 'loading' | 'interviewing' | 'processing' | 'synthesizing' | 'review' | 'unsupported';
+
+export function AIReviewInterview({ game, allGames, initialReview, onComplete, onClose }: AIReviewInterviewProps) {
+  const { isRecording, isSupported, error: recorderError, startRecording, stopRecording, cancelRecording } = useAudioRecorder();
+
+  const [phase, setPhase] = useState<Phase>(isSupported ? 'loading' : 'unsupported');
+  const [history, setHistory] = useState<ReviewInterviewTurn[]>([]);
+  const [currentQuestion, setCurrentQuestion] = useState('');
+  const [finalReview, setFinalReview] = useState(initialReview || '');
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [elapsed, setElapsed] = useState(0);
+
+  const tasteSummary = useMemo(() => buildTasteSummary(allGames, game.name), [allGames, game.name]);
+  const questionsAsked = history.filter(t => t.role === 'interviewer').length + (currentQuestion ? 1 : 0);
+  const transcriptEndRef = useRef<HTMLDivElement>(null);
+
+  // Lock body scroll
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => { document.body.style.overflow = ''; };
+  }, []);
+
+  // Recording timer
+  useEffect(() => {
+    if (!isRecording) { setElapsed(0); return; }
+    const id = setInterval(() => setElapsed(e => e + 1), 1000);
+    return () => clearInterval(id);
+  }, [isRecording]);
+
+  // Auto-scroll transcript
+  useEffect(() => {
+    transcriptEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [history, currentQuestion]);
+
+  // Kick off the opening question
+  useEffect(() => {
+    if (phase !== 'loading') return;
+    let cancelled = false;
+    (async () => {
+      const res = await conductReviewInterview({
+        game, tasteSummary, history: [], audio: null, questionsAsked: 0, maxQuestions: MAX_QUESTIONS,
+      });
+      if (cancelled) return;
+      if (res.error && !res.nextQuestion) {
+        setErrorMsg('Could not reach the AI. You can write your review manually below.');
+        setPhase('review');
+        return;
+      }
+      setCurrentQuestion(res.nextQuestion);
+      setPhase('interviewing');
+    })();
+    return () => { cancelled = true; };
+  }, [phase, game, tasteSummary]);
+
+  const synthesize = useCallback(async (fullHistory: ReviewInterviewTurn[]) => {
+    setPhase('synthesizing');
+    const res = await synthesizeGameReview({ game, tasteSummary, history: fullHistory });
+    if (res.error) setErrorMsg('AI had trouble writing the review — here are your own words to edit.');
+    setFinalReview(res.review);
+    setPhase('review');
+  }, [game, tasteSummary]);
+
+  const handleStop = useCallback(async () => {
+    const audio = await stopRecording();
+    if (!audio) {
+      setErrorMsg('No audio captured — try again.');
+      return;
+    }
+    setPhase('processing');
+    setErrorMsg(null);
+
+    const historyWithQuestion: ReviewInterviewTurn[] = [
+      ...history,
+      { role: 'interviewer', text: currentQuestion },
+    ];
+
+    const res = await conductReviewInterview({
+      game,
+      tasteSummary,
+      history: historyWithQuestion,
+      audio,
+      questionsAsked: historyWithQuestion.filter(t => t.role === 'interviewer').length,
+      maxQuestions: MAX_QUESTIONS,
+    });
+
+    if (res.error && !res.transcript) {
+      setErrorMsg('Could not process that answer. You can wrap up or try again.');
+      setCurrentQuestion(currentQuestion); // keep same question
+      setPhase('interviewing');
+      return;
+    }
+
+    const newHistory: ReviewInterviewTurn[] = [
+      ...historyWithQuestion,
+      { role: 'player', text: res.transcript },
+    ];
+    setHistory(newHistory);
+    setCurrentQuestion('');
+
+    if (res.done || !res.nextQuestion) {
+      await synthesize(newHistory);
+    } else {
+      setCurrentQuestion(res.nextQuestion);
+      setPhase('interviewing');
+    }
+  }, [stopRecording, history, currentQuestion, game, tasteSummary, synthesize]);
+
+  const handleWrapUp = useCallback(() => {
+    if (isRecording) cancelRecording();
+    // Drop any unanswered pending question — synthesize from answered turns.
+    if (history.filter(t => t.role === 'player').length === 0) {
+      setPhase('review');
+      return;
+    }
+    synthesize(history);
+  }, [isRecording, cancelRecording, history, synthesize]);
+
+  const handleRegenerate = useCallback(() => {
+    synthesize(history);
+  }, [synthesize, history]);
+
+  const mmss = `${Math.floor(elapsed / 60)}:${String(elapsed % 60).padStart(2, '0')}`;
+  const answeredCount = history.filter(t => t.role === 'player').length;
+
+  return (
+    <div className="fixed inset-0 z-[60]">
+      <div className="absolute inset-0 bg-black/80 backdrop-blur-sm" onClick={onClose} />
+
+      <div className="absolute bottom-0 left-0 right-0 bg-[#12121a] rounded-t-2xl max-h-[92vh] flex flex-col animate-bottom-sheet-up">
+        {/* Header */}
+        <div className="flex-shrink-0 pt-3 pb-3 px-4 border-b border-white/5">
+          <div className="w-10 h-1 rounded-full bg-white/20 mx-auto mb-3" />
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2 min-w-0">
+              <Sparkles size={16} className="text-purple-400 shrink-0" />
+              <div className="min-w-0">
+                <h2 className="text-sm font-semibold text-white truncate">Reflect on {game.name}</h2>
+                <p className="text-[11px] text-white/40">
+                  {formatRating(game.rating)}/10 · AI interview
+                </p>
+              </div>
+            </div>
+            <button onClick={onClose} className="text-white/40 active:text-white/70 rounded-lg p-1.5">
+              <X size={20} />
+            </button>
+          </div>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-4 py-4">
+          {phase === 'unsupported' ? (
+            <div className="text-center py-8 space-y-3">
+              <p className="text-white/70 text-sm">Voice recording isn&apos;t supported in this browser.</p>
+              <p className="text-white/40 text-xs">Try Chrome, Edge, or Safari — or write your review manually.</p>
+              <button
+                onClick={() => setPhase('review')}
+                className="mt-2 px-4 py-2 rounded-xl bg-white/10 text-white/80 text-sm font-medium active:bg-white/15"
+              >
+                Write manually
+              </button>
+            </div>
+          ) : phase === 'review' ? (
+            <div className="space-y-3">
+              <label className="block text-xs font-medium text-white/50">Your review</label>
+              <textarea
+                value={finalReview}
+                onChange={e => setFinalReview(e.target.value)}
+                rows={7}
+                placeholder="Your review will appear here — edit freely."
+                className="w-full px-3 py-2.5 bg-white/[0.03] border border-white/5 text-white rounded-xl text-sm focus:outline-none focus:bg-white/[0.05] focus:border-white/10 transition-all resize-none placeholder:text-white/30 leading-relaxed"
+              />
+              {errorMsg && <p className="text-[11px] text-amber-400/80">{errorMsg}</p>}
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {/* Conversation transcript */}
+              {history.map((turn, i) => (
+                <div
+                  key={i}
+                  className={clsx(
+                    'rounded-xl px-3 py-2 text-sm max-w-[88%]',
+                    turn.role === 'interviewer'
+                      ? 'bg-purple-500/10 text-purple-200/90 self-start'
+                      : 'bg-white/[0.05] text-white/80 ml-auto'
+                  )}
+                >
+                  {turn.role === 'interviewer' && (
+                    <div className="text-[9px] uppercase tracking-wider text-purple-400/60 mb-0.5">Interviewer</div>
+                  )}
+                  {turn.text}
+                </div>
+              ))}
+
+              {/* Current question */}
+              {currentQuestion && (
+                <div className="rounded-xl px-3 py-2.5 text-sm bg-purple-500/15 text-purple-100 border border-purple-500/20">
+                  <div className="text-[9px] uppercase tracking-wider text-purple-400/70 mb-0.5">Question {answeredCount + 1}</div>
+                  {currentQuestion}
+                </div>
+              )}
+
+              {(phase === 'loading' || phase === 'processing' || phase === 'synthesizing') && (
+                <div className="flex items-center gap-2 text-white/40 text-xs px-1 py-2">
+                  <Loader2 size={14} className="animate-spin" />
+                  {phase === 'loading' && 'Thinking of a good opener…'}
+                  {phase === 'processing' && 'Listening & transcribing…'}
+                  {phase === 'synthesizing' && 'Writing your review…'}
+                </div>
+              )}
+
+              {errorMsg && <p className="text-[11px] text-amber-400/80 px-1">{errorMsg}</p>}
+              {recorderError && <p className="text-[11px] text-red-400/80 px-1">{recorderError}</p>}
+
+              <div ref={transcriptEndRef} />
+            </div>
+          )}
+        </div>
+
+        {/* Footer controls */}
+        <div className="flex-shrink-0 px-4 py-3 bg-[#12121a] border-t border-white/5">
+          {phase === 'review' ? (
+            <div className="flex gap-3">
+              {history.length > 0 && (
+                <button
+                  onClick={handleRegenerate}
+                  className="flex items-center justify-center gap-1.5 px-4 py-3 rounded-xl bg-white/5 text-white/70 text-sm font-medium active:bg-white/10"
+                >
+                  <RefreshCw size={14} /> Redo
+                </button>
+              )}
+              <button
+                onClick={() => onComplete(finalReview)}
+                disabled={!finalReview.trim()}
+                className="flex-1 flex items-center justify-center gap-1.5 px-4 py-3 rounded-xl bg-purple-600 text-white text-sm font-medium active:bg-purple-500 disabled:opacity-50"
+              >
+                <Check size={16} /> Use this review
+              </button>
+            </div>
+          ) : phase === 'interviewing' ? (
+            <div className="flex items-center gap-3">
+              <button
+                onClick={isRecording ? handleStop : startRecording}
+                className={clsx(
+                  'flex-1 flex items-center justify-center gap-2 px-4 py-3.5 rounded-xl text-sm font-semibold transition-all',
+                  isRecording
+                    ? 'bg-red-500/90 text-white animate-pulse'
+                    : 'bg-purple-600 text-white active:bg-purple-500'
+                )}
+              >
+                {isRecording ? (<><Square size={16} className="fill-white" /> Stop · {mmss}</>) : (<><Mic size={18} /> Hold answer</>)}
+              </button>
+              {answeredCount > 0 && !isRecording && (
+                <button
+                  onClick={handleWrapUp}
+                  className="flex items-center gap-1.5 px-4 py-3.5 rounded-xl bg-white/5 text-white/70 text-sm font-medium active:bg-white/10"
+                >
+                  <Pencil size={14} /> Wrap up
+                </button>
+              )}
+            </div>
+          ) : (
+            <button
+              disabled
+              className="w-full px-4 py-3.5 rounded-xl bg-white/5 text-white/40 text-sm font-medium flex items-center justify-center gap-2"
+            >
+              <Loader2 size={16} className="animate-spin" /> Working…
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/apps/game-analytics/components/GameForm.tsx
+++ b/app/apps/game-analytics/components/GameForm.tsx
@@ -3,13 +3,15 @@
 import { useState, useRef, useEffect } from 'react';
 import { ChevronDown, X, Tag, DollarSign, Calendar, MessageSquare, Sparkles } from 'lucide-react';
 import { Game, GameStatus, PurchaseSource, SubscriptionSource } from '../lib/types';
-import { calculateCostPerHour, getValueRating } from '../lib/calculations';
+import { calculateCostPerHour, getValueRating, formatRating, getTotalHours } from '../lib/calculations';
+import { AIReviewInterview } from './AIReviewInterview';
 import clsx from 'clsx';
 
 interface GameFormProps {
   onSubmit: (game: Omit<Game, 'id' | 'userId' | 'createdAt' | 'updatedAt'>) => Promise<void>;
   onClose: () => void;
   initialGame?: Game;
+  allGames?: Game[];
   existingFranchises?: string[];
 }
 
@@ -97,8 +99,9 @@ function Section({ title, icon, defaultOpen = false, children, badge }: {
   );
 }
 
-export function GameForm({ onSubmit, onClose, initialGame, existingFranchises = [] }: GameFormProps) {
+export function GameForm({ onSubmit, onClose, initialGame, allGames = [], existingFranchises = [] }: GameFormProps) {
   const [loading, setLoading] = useState(false);
+  const [showInterview, setShowInterview] = useState(false);
   const [formData, setFormData] = useState({
     name: initialGame?.name || '',
     price: initialGame?.price !== undefined ? initialGame.price.toString() : '',
@@ -367,18 +370,27 @@ export function GameForm({ onSubmit, onClose, initialGame, existingFranchises = 
               </div>
             )}
 
-            {/* Rating — tap-to-rate circles */}
-            {showRating && (
+            {/* Rating — tap whole number, then fine-tune the decimal */}
+            {showRating && (() => {
+              const whole = Math.floor(formData.rating);
+              const decimal = Math.round((formData.rating - whole) * 10);
+              const labelKey = Math.min(10, Math.max(1, Math.round(formData.rating)));
+              return (
               <div>
                 <div className="flex items-center justify-between mb-2">
                   <label className="text-xs font-medium text-white/50">Your Rating</label>
-                  <span className={clsx(
-                    'text-xs font-semibold px-2 py-0.5 rounded-full',
-                    getRatingColor(formData.rating)
-                  )}>
-                    {RATING_LABELS[formData.rating]}
-                  </span>
+                  <div className="flex items-center gap-2">
+                    <span className="text-lg font-black text-white tabular-nums leading-none">{formatRating(formData.rating)}</span>
+                    <span className={clsx(
+                      'text-xs font-semibold px-2 py-0.5 rounded-full',
+                      getRatingColor(formData.rating)
+                    )}>
+                      {RATING_LABELS[labelKey]}
+                    </span>
+                  </div>
                 </div>
+
+                {/* Whole-number circles */}
                 <div className="flex gap-1.5 justify-between">
                   {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(n => (
                     <button
@@ -387,7 +399,7 @@ export function GameForm({ onSubmit, onClose, initialGame, existingFranchises = 
                       onClick={() => setFormData({ ...formData, rating: n })}
                       className={clsx(
                         'w-8 h-8 rounded-full text-xs font-bold transition-all flex items-center justify-center',
-                        formData.rating === n
+                        whole === n
                           ? getRatingColor(n)
                           : n <= formData.rating
                             ? 'bg-white/10 text-white/60'
@@ -398,8 +410,51 @@ export function GameForm({ onSubmit, onClose, initialGame, existingFranchises = 
                     </button>
                   ))}
                 </div>
+
+                {/* Fine-tune decimals */}
+                <div className="mt-2.5">
+                  <div className="flex items-center justify-between mb-1.5">
+                    <span className="text-[10px] text-white/30">Fine-tune</span>
+                    <span className="text-[10px] text-white/40 tabular-nums">{whole}.{decimal}</span>
+                  </div>
+                  <div className="flex gap-1 justify-between">
+                    {[0, 1, 2, 3, 4, 5, 6, 7, 8, 9].map(d => {
+                      const disabled = whole >= 10 && d > 0;
+                      const selected = decimal === d;
+                      return (
+                        <button
+                          key={d}
+                          type="button"
+                          disabled={disabled}
+                          onClick={() => setFormData({ ...formData, rating: Math.min(10, whole + d / 10) })}
+                          className={clsx(
+                            'flex-1 h-7 rounded-lg text-[11px] font-semibold transition-all',
+                            disabled
+                              ? 'bg-white/[0.02] text-white/10 cursor-not-allowed'
+                              : selected
+                                ? 'bg-purple-500 text-white'
+                                : 'bg-white/[0.04] text-white/40 active:bg-white/[0.08]'
+                          )}
+                        >
+                          .{d}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                {/* Reflect with AI — voice interview that writes the review */}
+                <button
+                  type="button"
+                  onClick={() => setShowInterview(true)}
+                  className="mt-3 w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl bg-gradient-to-r from-purple-600/20 to-blue-600/20 border border-purple-500/30 text-purple-200 text-sm font-medium active:scale-[0.98] transition-all"
+                >
+                  <Sparkles size={14} /> Reflect with AI
+                  {formData.review && <span className="text-[10px] text-purple-300/60">· review saved</span>}
+                </button>
               </div>
-            )}
+              );
+            })()}
 
             {/* --- Collapsible Sections --- */}
 
@@ -631,6 +686,27 @@ export function GameForm({ onSubmit, onClose, initialGame, existingFranchises = 
           </button>
         </div>
       </div>
+
+      {/* AI Review Interview */}
+      {showInterview && (
+        <AIReviewInterview
+          game={{
+            name: formData.name.trim() || initialGame?.name || 'this game',
+            rating: formData.rating,
+            genre: formData.genre || undefined,
+            hours: parseFloat(formData.hours) || (initialGame ? getTotalHours(initialGame) : 0),
+            status: formData.status,
+            platform: formData.platform || undefined,
+          }}
+          allGames={allGames}
+          initialReview={formData.review}
+          onComplete={(review) => {
+            setFormData(prev => ({ ...prev, review }));
+            setShowInterview(false);
+          }}
+          onClose={() => setShowInterview(false)}
+        />
+      )}
     </div>
   );
 }

--- a/app/apps/game-analytics/components/GameListModal.tsx
+++ b/app/apps/game-analytics/components/GameListModal.tsx
@@ -2,7 +2,7 @@
 
 import { X } from 'lucide-react';
 import { Game } from '../lib/types';
-import { getTotalHours } from '../lib/calculations';
+import { getTotalHours, formatRating } from '../lib/calculations';
 
 interface GameListModalProps {
   title: string;
@@ -69,7 +69,7 @@ export function GameListModal({ title, games, isOpen, onClose, renderGameInfo }:
                         renderGameInfo(game)
                       ) : (
                         <div className="text-xs text-white/40 mt-0.5">
-                          ${game.price} • {getTotalHours(game).toFixed(1)}h • {game.rating}/10
+                          ${game.price} • {getTotalHours(game).toFixed(1)}h • {formatRating(game.rating)}/10
                         </div>
                       )}
                     </div>

--- a/app/apps/game-analytics/components/LeaderboardTab.tsx
+++ b/app/apps/game-analytics/components/LeaderboardTab.tsx
@@ -794,7 +794,11 @@ export function LeaderboardTab({ gamesWithMetrics, userId, eloTierConfig }: Lead
                   >Auto-assign</button>
                   {assignedCount > 0 && (
                     <button
-                      onClick={clearAll}
+                      onClick={() => {
+                        if (window.confirm(`Reset all ${assignedCount} tier assignment${assignedCount === 1 ? '' : 's'}?\n\nThis clears your tier picks for this period and cannot be undone.`)) {
+                          clearAll();
+                        }
+                      }}
                       className="text-[10px] text-white/25 hover:text-white/50 transition-colors"
                     >Reset</button>
                   )}

--- a/app/apps/game-analytics/components/StatsView.tsx
+++ b/app/apps/game-analytics/components/StatsView.tsx
@@ -50,7 +50,7 @@ import {
   Heart,
 } from 'lucide-react';
 import { Game, GameStatus, AnalyticsSummary, BudgetSettings } from '../lib/types';
-import { calculateSummary, getCumulativeSpending, getHoursByMonth, getSpendingByMonth, parseLocalDate, getLibraryHealth } from '../lib/calculations';
+import { calculateSummary, getCumulativeSpending, getHoursByMonth, getSpendingByMonth, parseLocalDate, getLibraryHealth, getRatingTierBands, getCloseRatingGroups, getRatingDistributionFine, formatRating } from '../lib/calculations';
 import { GameWithMetrics } from '../hooks/useAnalytics';
 import { PeriodStatsPanel } from './PeriodStatsPanel';
 import { FunStatsPanel } from './FunStatsPanel';
@@ -251,11 +251,11 @@ export function StatsView({ games, summary, budgets = [], onSetBudget, trophies,
     costPerHour: g.metrics.costPerHour,
   }));
 
-  // Rating distribution
-  const ratingDistribution = Array.from({ length: 10 }, (_, i) => ({
-    rating: i + 1,
-    count: playedGames.filter(g => g.rating === i + 1).length,
-  }));
+  // Rating distribution — fine 0.5-point bands, plus rarity tiers and close-rating clusters
+  const ratingDistribution = getRatingDistributionFine(games);
+  const ratingTierBands = getRatingTierBands(games);
+  const closeRatingGroups = getCloseRatingGroups(games);
+  const topTierBand = ratingTierBands.find(b => b.count > 0);
 
   // Hours by genre for radar chart
   const genreHoursData = Object.entries(summary.hoursByGenre)
@@ -1374,28 +1374,93 @@ export function StatsView({ games, summary, budgets = [], onSetBudget, trophies,
           </ChartCard>
         )}
 
-        {/* Rating Distribution */}
-        <ChartCard title="Rating Distribution" icon={<Star size={16} />}>
-          <ResponsiveContainer width="100%" height={250}>
-            <BarChart data={ratingDistribution}>
-              <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
-              <XAxis dataKey="rating" tick={{ fill: 'rgba(255,255,255,0.4)', fontSize: 10 }} />
-              <YAxis tick={{ fill: 'rgba(255,255,255,0.4)', fontSize: 10 }} />
-              <Tooltip content={({ active, payload, label }) => {
-                if (active && payload && payload.length) {
-                  return (
-                    <div className="bg-[#1a1a24] border border-white/10 rounded-lg px-3 py-2 text-sm">
-                      <p className="text-white/90 font-medium">Rating: {label}/10</p>
-                      <p className="text-white/60">{payload[0].value} games</p>
+        {/* Rating Distribution — fine 0.5-point bands */}
+        {ratingDistribution.length > 0 && (
+          <ChartCard title="Rating Distribution" icon={<Star size={16} />}>
+            <ResponsiveContainer width="100%" height={250}>
+              <BarChart data={ratingDistribution}>
+                <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
+                <XAxis dataKey="band" tick={{ fill: 'rgba(255,255,255,0.4)', fontSize: 10 }} interval={0} />
+                <YAxis allowDecimals={false} tick={{ fill: 'rgba(255,255,255,0.4)', fontSize: 10 }} />
+                <Tooltip content={({ active, payload }) => {
+                  if (active && payload && payload.length) {
+                    const d = payload[0].payload as { band: string; min: number; max: number; count: number };
+                    return (
+                      <div className="bg-[#1a1a24] border border-white/10 rounded-lg px-3 py-2 text-sm">
+                        <p className="text-white/90 font-medium">{formatRating(d.min)}–{formatRating(d.max)}</p>
+                        <p className="text-white/60">{d.count} {d.count === 1 ? 'game' : 'games'}</p>
+                      </div>
+                    );
+                  }
+                  return null;
+                }} />
+                <Bar dataKey="count" fill="#f59e0b" radius={[4, 4, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </ChartCard>
+        )}
+
+        {/* Rating Breakdown — rarity tier bands + close-rating comparison */}
+        {ratingTierBands.some(b => b.count > 0) && (
+          <ChartCard title="Rating Breakdown" icon={<Star size={16} />}>
+            <div className="space-y-4">
+              {/* Headline: how rare the top tier is */}
+              {topTierBand && (
+                <p className="text-sm text-white/60">
+                  Only <span className="font-bold text-white">{topTierBand.count}</span>{' '}
+                  {topTierBand.count === 1 ? 'game' : 'games'} in your library{' '}
+                  {topTierBand.count === 1 ? 'sits' : 'sit'} in the{' '}
+                  <span className="font-semibold" style={{ color: topTierBand.color }}>{topTierBand.label}</span>{' '}
+                  tier ({topTierBand.range}) — {topTierBand.percentage}% of everything you&apos;ve rated.
+                </p>
+              )}
+
+              {/* Tier bands */}
+              <div className="space-y-1.5">
+                {ratingTierBands.filter(b => b.count > 0).map(band => (
+                  <div key={band.label} className="flex items-center gap-2">
+                    <div className="w-24 shrink-0 text-xs font-medium" style={{ color: band.color }}>
+                      {band.label}
                     </div>
-                  );
-                }
-                return null;
-              }} />
-              <Bar dataKey="count" fill="#f59e0b" radius={[4, 4, 0, 0]} />
-            </BarChart>
-          </ResponsiveContainer>
-        </ChartCard>
+                    <div className="w-12 shrink-0 text-[10px] text-white/30 tabular-nums">{band.range}</div>
+                    <div className="flex-1 h-2.5 rounded-full bg-white/[0.04] overflow-hidden">
+                      <div className="h-full rounded-full transition-all" style={{ width: `${band.percentage}%`, backgroundColor: band.color }} />
+                    </div>
+                    <div className="w-14 shrink-0 text-right text-xs text-white/50 tabular-nums">
+                      {band.count} · {band.percentage}%
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {/* Close-rating comparison */}
+              {closeRatingGroups.length > 0 && (
+                <div className="pt-2 border-t border-white/5">
+                  <p className="text-[11px] uppercase tracking-wider text-white/30 mb-2">Games neck-and-neck</p>
+                  <div className="space-y-2.5">
+                    {closeRatingGroups.slice(0, 4).map(group => (
+                      <div key={group.label}>
+                        <div className="text-[11px] text-white/40 mb-1">{group.label}</div>
+                        <div className="flex flex-wrap gap-1.5">
+                          {group.games.map(g => (
+                            <span
+                              key={g.name}
+                              className="inline-flex items-center gap-1 px-2 py-1 rounded-lg bg-white/[0.04] text-xs text-white/70"
+                              title={`${g.hours.toFixed(0)}h${g.genre ? ' · ' + g.genre : ''}`}
+                            >
+                              <span className="truncate max-w-[120px]">{g.name}</span>
+                              <span className="font-bold text-amber-400 tabular-nums">{formatRating(g.rating)}</span>
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          </ChartCard>
+        )}
 
         {/* Platform Distribution */}
         {platformData.length > 1 && (

--- a/app/apps/game-analytics/hooks/useAudioRecorder.ts
+++ b/app/apps/game-analytics/hooks/useAudioRecorder.ts
@@ -1,0 +1,137 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+
+export interface RecordedAudio {
+  base64: string;   // raw base64 (no data: prefix)
+  mimeType: string; // normalized mime type without codec suffix
+}
+
+export interface AudioRecorderControls {
+  isRecording: boolean;
+  isSupported: boolean;
+  error: string | null;
+  startRecording: () => Promise<void>;
+  stopRecording: () => Promise<RecordedAudio | null>;
+  cancelRecording: () => void;
+}
+
+// Prefer formats Gemini documents support for first (ogg/mp4), fall back to webm.
+const MIME_CANDIDATES = [
+  'audio/ogg;codecs=opus',
+  'audio/mp4',
+  'audio/webm;codecs=opus',
+  'audio/webm',
+];
+
+function pickMimeType(): string {
+  if (typeof MediaRecorder === 'undefined') return '';
+  for (const c of MIME_CANDIDATES) {
+    if (MediaRecorder.isTypeSupported(c)) return c;
+  }
+  return '';
+}
+
+function blobToBase64(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      const result = reader.result as string;
+      resolve(result.split(',')[1] || '');
+    };
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
+}
+
+export function useAudioRecorder(): AudioRecorderControls {
+  const [isRecording, setIsRecording] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const streamRef = useRef<MediaStream | null>(null);
+
+  const isSupported =
+    typeof navigator !== 'undefined' &&
+    !!navigator.mediaDevices?.getUserMedia &&
+    typeof MediaRecorder !== 'undefined';
+
+  const cleanupStream = useCallback(() => {
+    streamRef.current?.getTracks().forEach(t => t.stop());
+    streamRef.current = null;
+  }, []);
+
+  const startRecording = useCallback(async () => {
+    setError(null);
+    if (!isSupported) {
+      setError('Voice recording is not supported in this browser. Try Chrome, Edge, or Safari.');
+      return;
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+      const mimeType = pickMimeType();
+      const recorder = mimeType
+        ? new MediaRecorder(stream, { mimeType })
+        : new MediaRecorder(stream);
+      chunksRef.current = [];
+      recorder.ondataavailable = (e) => {
+        if (e.data.size > 0) chunksRef.current.push(e.data);
+      };
+      recorderRef.current = recorder;
+      recorder.start();
+      setIsRecording(true);
+    } catch (e) {
+      cleanupStream();
+      setError(
+        e instanceof Error && e.name === 'NotAllowedError'
+          ? 'Microphone permission denied. Enable it to record.'
+          : 'Could not access the microphone.'
+      );
+    }
+  }, [isSupported, cleanupStream]);
+
+  const stopRecording = useCallback((): Promise<RecordedAudio | null> => {
+    return new Promise((resolve) => {
+      const recorder = recorderRef.current;
+      if (!recorder || recorder.state === 'inactive') {
+        setIsRecording(false);
+        resolve(null);
+        return;
+      }
+      recorder.onstop = async () => {
+        const fullType = recorder.mimeType || 'audio/webm';
+        const blob = new Blob(chunksRef.current, { type: fullType });
+        cleanupStream();
+        setIsRecording(false);
+        recorderRef.current = null;
+        if (blob.size === 0) {
+          resolve(null);
+          return;
+        }
+        try {
+          const base64 = await blobToBase64(blob);
+          resolve({ base64, mimeType: fullType.split(';')[0] });
+        } catch {
+          resolve(null);
+        }
+      };
+      recorder.stop();
+    });
+  }, [cleanupStream]);
+
+  const cancelRecording = useCallback(() => {
+    const recorder = recorderRef.current;
+    if (recorder && recorder.state !== 'inactive') {
+      recorder.onstop = null;
+      try { recorder.stop(); } catch { /* noop */ }
+    }
+    cleanupStream();
+    chunksRef.current = [];
+    recorderRef.current = null;
+    setIsRecording(false);
+  }, [cleanupStream]);
+
+  return { isRecording, isSupported, error, startRecording, stopRecording, cancelRecording };
+}

--- a/app/apps/game-analytics/lib/ai-service.ts
+++ b/app/apps/game-analytics/lib/ai-service.ts
@@ -2,8 +2,8 @@
 
 import { getAI, getGenerativeModel, GoogleAIBackend } from 'firebase/ai';
 import { initializeApp, getApps } from 'firebase/app';
-import { WeekInReviewData, MonthInReviewData, OscarAward } from './calculations';
-import { Game } from './types';
+import { WeekInReviewData, MonthInReviewData, OscarAward, buildTasteProfile } from './calculations';
+import { Game, TasteProfile } from './types';
 
 const firebaseConfig = {
   apiKey: "AIzaSyBS3IVvszDrm_zjjXu8TATgs1H-FlegHtM",
@@ -521,3 +521,197 @@ Pitch rules: each pitch is exactly 1 sentence, specific to that game's data, no 
     return { opening: '', pitches: {} };
   }
 }
+
+// ── AI REVIEW INTERVIEW ────────────────────────────────────────────
+// Gemini conducts a voice interview about a game: it transcribes the
+// player's spoken answers, reads them in light of the player's taste,
+// asks adaptive follow-ups, then synthesizes a reflective written review.
+
+export interface ReviewGameContext {
+  name: string;
+  rating: number;
+  genre?: string;
+  hours: number;
+  status: string;
+  platform?: string;
+}
+
+export interface ReviewInterviewTurn {
+  role: 'interviewer' | 'player';
+  text: string;
+}
+
+export interface ReviewInterviewResponse {
+  transcript: string;   // what the player just said (from audio); '' for the opening turn
+  nextQuestion: string; // '' when the interview is complete
+  done: boolean;
+  error?: string;
+}
+
+export interface RecordedAudioInput {
+  base64: string;
+  mimeType: string;
+}
+
+/** Build a compact, prompt-friendly taste summary from the library. */
+export function buildTasteSummary(allGames: Game[], excludeGameName?: string): string {
+  const games = excludeGameName
+    ? allGames.filter(g => g.name !== excludeGameName)
+    : allGames;
+  if (games.length === 0) return 'No prior library data yet — this may be one of their first tracked games.';
+
+  const profile: TasteProfile = buildTasteProfile(games);
+  const genreDetail = profile.favoriteGenreDetails
+    .slice(0, 4)
+    .map(d => `${d.genre} (avg ${d.avgRating.toFixed(1)}/10 over ${d.count})`)
+    .join(', ');
+  const top = profile.topGames
+    .slice(0, 4)
+    .map(g => `${g.name} ${g.rating.toFixed(1)}/10`)
+    .join(', ');
+
+  return [
+    `Overall avg rating: ${profile.avgRating.toFixed(1)}/10.`,
+    profile.topGenres.length ? `Favorite genres: ${profile.topGenres.slice(0, 4).join(', ')}.` : '',
+    genreDetail ? `Genre ratings: ${genreDetail}.` : '',
+    top ? `Top-rated games: ${top}.` : '',
+    profile.avoidGenres.length ? `Tends to dislike: ${profile.avoidGenres.slice(0, 3).join(', ')}.` : '',
+  ].filter(Boolean).join(' ');
+}
+
+function gameContextLine(game: ReviewGameContext): string {
+  return `"${game.name}" — rated ${game.rating.toFixed(1)}/10, ${game.genre || 'unknown genre'}, ${game.hours.toFixed(0)}h played, status: ${game.status}${game.platform ? `, on ${game.platform}` : ''}.`;
+}
+
+function historyText(history: ReviewInterviewTurn[]): string {
+  if (history.length === 0) return '(no exchange yet)';
+  return history
+    .map(t => `${t.role === 'interviewer' ? 'Interviewer' : 'Player'}: ${t.text}`)
+    .join('\n');
+}
+
+function stripJsonFences(raw: string): string {
+  return raw.replace(/^```[a-z]*\n?/i, '').replace(/\n?```$/i, '').trim();
+}
+
+/**
+ * One interview turn. If `audio` is null, generates the opening question.
+ * Otherwise transcribes the spoken answer and decides the next follow-up
+ * (or finishes). Adaptive — references the player's words and taste.
+ */
+export async function conductReviewInterview(params: {
+  game: ReviewGameContext;
+  tasteSummary: string;
+  history: ReviewInterviewTurn[];
+  audio: RecordedAudioInput | null;
+  questionsAsked: number;
+  maxQuestions: number;
+}): Promise<ReviewInterviewResponse> {
+  const { game, tasteSummary, history, audio, questionsAsked, maxQuestions } = params;
+  const model = getAIModel();
+
+  const base = `You are a sharp, warm interviewer helping a gamer reflect on a game they just rated, so they can write an honest review. Be specific and conversational, never generic or fawning. Ask about ONE thing at a time.
+
+Game: ${gameContextLine(game)}
+Player's taste profile: ${tasteSummary}
+
+Conversation so far:
+${historyText(history)}`;
+
+  if (!audio) {
+    // Opening question
+    const prompt = `${base}
+
+Write the opening interview question. Make it specific to this game and their ${game.rating.toFixed(1)}/10 rating — if that rating is notably high or low versus their taste, lean into that. One short, natural question.
+
+Respond with ONLY valid JSON (no markdown): {"transcript": "", "nextQuestion": "<your question>", "done": false}`;
+    try {
+      const result = await model.generateContent(prompt);
+      const parsed = JSON.parse(stripJsonFences(result.response.text().trim()));
+      return {
+        transcript: '',
+        nextQuestion: String(parsed.nextQuestion || ''),
+        done: false,
+      };
+    } catch (e) {
+      console.error('Review interview (opening) error:', e);
+      return {
+        transcript: '',
+        nextQuestion: `What stood out most about ${game.name}?`,
+        done: false,
+        error: String(e),
+      };
+    }
+  }
+
+  const shouldWrap = questionsAsked + 1 >= maxQuestions;
+  const prompt = `${base}
+
+The player just answered by voice — audio is attached.
+1. Transcribe what they said accurately and concisely (clean up filler words, keep their meaning and voice).
+2. Then decide the next move:
+   - If there is more worth exploring AND you have asked fewer than ${maxQuestions} questions, ask ONE follow-up that digs into something specific they said, or how this game compares to their taste. ${shouldWrap ? 'You have now reached the question limit, so set done=true and nextQuestion="".' : ''}
+   - If you have enough for a rich, honest review, set done=true and nextQuestion="".
+
+Respond with ONLY valid JSON (no markdown): {"transcript": "<what they said>", "nextQuestion": "<next question or empty>", "done": <true|false>}`;
+
+  try {
+    const result = await model.generateContent([
+      { text: prompt },
+      { inlineData: { mimeType: audio.mimeType, data: audio.base64 } },
+    ]);
+    const parsed = JSON.parse(stripJsonFences(result.response.text().trim()));
+    const done = Boolean(parsed.done) || shouldWrap;
+    return {
+      transcript: String(parsed.transcript || ''),
+      nextQuestion: done ? '' : String(parsed.nextQuestion || ''),
+      done,
+    };
+  } catch (e) {
+    console.error('Review interview (turn) error:', e);
+    return {
+      transcript: '',
+      nextQuestion: '',
+      done: true,
+      error: String(e),
+    };
+  }
+}
+
+/**
+ * Synthesize the interview into a first-person, reflective written review.
+ */
+export async function synthesizeGameReview(params: {
+  game: ReviewGameContext;
+  tasteSummary: string;
+  history: ReviewInterviewTurn[];
+}): Promise<{ review: string; error?: string }> {
+  const { game, tasteSummary, history } = params;
+  const model = getAIModel();
+
+  const prompt = `Based on this interview, write the player's review of ${game.name} in their own first-person voice.
+
+Game: ${gameContextLine(game)}
+Player's taste profile: ${tasteSummary}
+
+Interview:
+${historyText(history)}
+
+Write 3-5 sentences. Capture their actual opinions and reasoning from the conversation — the highs, the lows, who it's for. Reflective and honest, like a thoughtful friend describing the game. No marketing fluff, no star ratings, no "in conclusion". Do not invent details they didn't mention.
+
+Return ONLY the review prose — no headings, no quotes, no JSON.`;
+
+  try {
+    const result = await model.generateContent(prompt);
+    return { review: result.response.text().trim() };
+  } catch (e) {
+    console.error('Review synthesis error:', e);
+    // Fallback: stitch the player's own answers together.
+    const fallback = history
+      .filter(t => t.role === 'player')
+      .map(t => t.text)
+      .join(' ');
+    return { review: fallback, error: String(e) };
+  }
+}
+

--- a/app/apps/game-analytics/lib/calculations.ts
+++ b/app/apps/game-analytics/lib/calculations.ts
@@ -2905,6 +2905,172 @@ export function getRatingBiasAnalysis(games: Game[]): RatingBiasData {
 }
 
 // ========================================================================
+// DECIMAL RATING SYSTEM — precise ratings, tier bands, ranks, comparisons
+// ========================================================================
+
+/** Format a rating to one decimal place (e.g. 8 → "8.0", 8.5 → "8.5"). */
+export function formatRating(rating: number): string {
+  return rating.toFixed(1);
+}
+
+export interface RatingTierBand {
+  label: string;      // e.g. "Masterpiece"
+  range: string;      // e.g. "9.5+"
+  min: number;
+  max: number;        // inclusive upper bound
+  count: number;
+  percentage: number; // % of rated games in this band
+  color: string;      // hex for UI
+  games: Array<{ name: string; rating: number }>;
+}
+
+// Bands ordered high → low. max is inclusive.
+const RATING_BANDS: Array<Omit<RatingTierBand, 'count' | 'percentage' | 'games'>> = [
+  { label: 'Masterpiece', range: '9.5–10', min: 9.5, max: 10, color: '#fbbf24' },
+  { label: 'Phenomenal', range: '9.0–9.4', min: 9.0, max: 9.49, color: '#f59e0b' },
+  { label: 'Excellent', range: '8.5–8.9', min: 8.5, max: 8.99, color: '#34d399' },
+  { label: 'Great', range: '8.0–8.4', min: 8.0, max: 8.49, color: '#10b981' },
+  { label: 'Good', range: '7.0–7.9', min: 7.0, max: 7.99, color: '#3b82f6' },
+  { label: 'Decent', range: '6.0–6.9', min: 6.0, max: 6.99, color: '#6366f1' },
+  { label: 'Mixed', range: '5.0–5.9', min: 5.0, max: 5.99, color: '#a855f7' },
+  { label: 'Weak', range: 'Under 5', min: 0, max: 4.99, color: '#ef4444' },
+];
+
+/**
+ * Rarity / tier bands — shows how rare each rating tier is in the library.
+ * Emphasizes that high ratings are special.
+ */
+export function getRatingTierBands(games: Game[]): RatingTierBand[] {
+  const rated = games.filter(g => g.rating > 0 && g.status !== 'Wishlist');
+  const total = rated.length;
+
+  return RATING_BANDS.map(band => {
+    const inBand = rated
+      .filter(g => g.rating >= band.min && g.rating <= band.max)
+      .sort((a, b) => b.rating - a.rating);
+    return {
+      ...band,
+      count: inBand.length,
+      percentage: total > 0 ? Math.round((inBand.length / total) * 100) : 0,
+      games: inBand.map(g => ({ name: g.name, rating: g.rating })),
+    };
+  });
+}
+
+export interface RatingRank {
+  rank: number;       // 1-based rank by rating (1 = highest)
+  total: number;      // total rated games
+  percentile: number; // "top X%" — lower is better
+  label: string;      // e.g. "#2 of 64 · top 3%"
+  isTop: boolean;     // top 10% of library
+}
+
+/**
+ * Where a game's precise rating ranks within the library.
+ * Ties share the better rank (standard competition ranking).
+ */
+export function getRatingRank(game: Game, allGames: Game[]): RatingRank {
+  const rated = allGames.filter(g => g.rating > 0 && g.status !== 'Wishlist');
+  const total = rated.length;
+
+  if (game.rating <= 0 || total === 0) {
+    return { rank: 0, total, percentile: 0, label: '', isTop: false };
+  }
+
+  const higher = rated.filter(g => g.rating > game.rating).length;
+  const rank = higher + 1;
+  const percentile = Math.max(1, Math.round((rank / total) * 100));
+  const isTop = percentile <= 10;
+
+  return {
+    rank,
+    total,
+    percentile,
+    label: `#${rank} of ${total} · top ${percentile}%`,
+    isTop,
+  };
+}
+
+export interface CloseRatingGroup {
+  label: string; // e.g. "9.0–9.4"
+  min: number;
+  max: number;
+  games: Array<{ name: string; rating: number; hours: number; genre?: string }>;
+}
+
+/**
+ * Group games into tight half-point bands so close ratings can be compared
+ * side by side (e.g. what separates your 8.5s from your 9.0s).
+ * Only returns bands with 2+ games. Sorted high → low.
+ */
+export function getCloseRatingGroups(games: Game[]): CloseRatingGroup[] {
+  const rated = games.filter(g => g.rating > 0 && g.status !== 'Wishlist');
+  if (rated.length === 0) return [];
+
+  const buckets = new Map<number, CloseRatingGroup>();
+
+  for (const g of rated) {
+    // Floor to nearest 0.5 band (e.g. 8.7 → 8.5, 9.2 → 9.0)
+    const bandMin = Math.floor(g.rating * 2) / 2;
+    const bandMax = Math.min(10, bandMin + 0.49);
+    if (!buckets.has(bandMin)) {
+      buckets.set(bandMin, {
+        label: `${formatRating(bandMin)}–${formatRating(Math.min(10, bandMin + 0.4))}`,
+        min: bandMin,
+        max: bandMax,
+        games: [],
+      });
+    }
+    buckets.get(bandMin)!.games.push({
+      name: g.name,
+      rating: g.rating,
+      hours: getTotalHours(g),
+      genre: g.genre,
+    });
+  }
+
+  return Array.from(buckets.values())
+    .filter(b => b.games.length >= 2)
+    .map(b => ({ ...b, games: b.games.sort((a, c) => c.rating - a.rating) }))
+    .sort((a, b) => b.min - a.min);
+}
+
+export interface FineRatingBucket {
+  band: string; // e.g. "8.5"
+  min: number;
+  max: number;
+  count: number;
+}
+
+/**
+ * Rating distribution in 0.5-point bands (trimmed to the populated range),
+ * so decimal differences between 8.5s and 9.5s are visible.
+ */
+export function getRatingDistributionFine(games: Game[]): FineRatingBucket[] {
+  const rated = games.filter(g => g.rating > 0 && g.status !== 'Wishlist');
+  if (rated.length === 0) return [];
+
+  const buckets: FineRatingBucket[] = [];
+  for (let v = 1; v <= 10; v += 0.5) {
+    const min = v;
+    const max = v === 10 ? 10 : v + 0.49;
+    buckets.push({
+      band: formatRating(v),
+      min,
+      max,
+      count: rated.filter(g => g.rating >= min && g.rating <= max).length,
+    });
+  }
+
+  // Trim leading/trailing empty bands to keep the chart focused.
+  let start = 0;
+  let end = buckets.length - 1;
+  while (start < end && buckets[start].count === 0) start++;
+  while (end > start && buckets[end].count === 0) end--;
+  return buckets.slice(start, end + 1);
+}
+
+// ========================================================================
 // ENHANCEMENT PHASE 2: Advanced Analytics
 // ========================================================================
 

--- a/app/apps/game-analytics/page.tsx
+++ b/app/apps/game-analytics/page.tsx
@@ -23,7 +23,7 @@ import { rankingRepository } from './lib/ranking-storage';
 import { BASELINE_GAMES_2025 } from './data/baseline-games';
 import { useAuthContext } from '@/lib/AuthContext';
 import { useToast } from '@/components/Toast';
-import { getROIRating, getWeekStatsForOffset, getGamesPlayedInTimeRange, getCompletionProbability, getGameHealthDot, getRelativeTime, getDaysContext, getSessionMomentum, getValueTrajectory, getGameSmartOneLiner, getFranchiseInfo, getProgressPercent, getShelfLife, parseLocalDate, getCardRarity, getRelationshipStatus, getGameStreak, getHeroNumber, getCardFreshness, getGameSections, getCardBackData, getContextualWhisper, getLibraryRank, getCardMoodPulse, getProgressRingData, getStatPopoverData, getWeekRecapData, getSmartNudges, getGamingCreditScore, getRotationStats, getSpendingForecast, getSpendingByMonth, getShelfLifeExpiry } from './lib/calculations';
+import { getROIRating, getWeekStatsForOffset, getGamesPlayedInTimeRange, getCompletionProbability, getGameHealthDot, getRelativeTime, getDaysContext, getSessionMomentum, getValueTrajectory, getGameSmartOneLiner, getFranchiseInfo, getProgressPercent, getShelfLife, parseLocalDate, getCardRarity, getRelationshipStatus, getGameStreak, getHeroNumber, getCardFreshness, getGameSections, getCardBackData, getContextualWhisper, getLibraryRank, getCardMoodPulse, getProgressRingData, getStatPopoverData, getWeekRecapData, getSmartNudges, getGamingCreditScore, getRotationStats, getSpendingForecast, getSpendingByMonth, getShelfLifeExpiry, formatRating, getRatingRank } from './lib/calculations';
 import { OnThisDayCard } from './components/OnThisDayCard';
 import { ActivityPulse } from './components/ActivityPulse';
 import { RandomPicker } from './components/RandomPicker';
@@ -1349,6 +1349,7 @@ export default function GameAnalyticsPage() {
           onSubmit={handleAddGame}
           onClose={handleCloseForm}
           initialGame={editingGame || undefined}
+          allGames={games}
           existingFranchises={Array.from(new Set(games.map(g => g.franchise).filter(Boolean) as string[]))}
         />
       )}
@@ -1750,6 +1751,7 @@ function NowPlayingCard({ game, allGames, onClick, onQuickLog, sortBy = 'hours',
   const momentum = getSessionMomentum(game);
   const whisper = getContextualWhisper(game, allGames);
   const libraryRank = getLibraryRank(game, allGames, sortBy);
+  const ratingRank = getRatingRank(game, allGames);
   const moodPulse = getCardMoodPulse(game);
   const progressRing = getProgressRingData(game, allGames);
   const shelfExpiry = getShelfLifeExpiry(game, allGames);
@@ -1904,8 +1906,14 @@ function NowPlayingCard({ game, allGames, onClick, onQuickLog, sortBy = 'hours',
               <Clock size={10} className="text-white/30" />
               <span>{game.totalHours}h</span>
             </div>
-            <div className="flex items-center gap-0.5">
+            <div className="flex items-center gap-1" title={ratingRank.label || undefined}>
               <RatingStars rating={game.rating} size={9} />
+              {game.rating > 0 && (
+                <span className="text-[10px] font-semibold text-white/50 tabular-nums">{formatRating(game.rating)}</span>
+              )}
+              {ratingRank.isTop && (
+                <span className="text-[10px] font-semibold text-amber-400/70 tabular-nums">#{ratingRank.rank}</span>
+              )}
             </div>
             {game.totalHours > 0 && game.price > 0 && (
               <span className={clsx('text-xs font-medium', getValueColor(game.metrics.valueRating))}>
@@ -2009,6 +2017,7 @@ function PosterCard({ game, allGames, idx, onClick, onQuickLog, isInQueue, sortB
   const momentum = getSessionMomentum(game);
   const whisper = getContextualWhisper(game, allGames);
   const libraryRank = getLibraryRank(game, allGames, sortBy);
+  const ratingRank = getRatingRank(game, allGames);
   const moodPulse = getCardMoodPulse(game);
   const progressRing = getProgressRingData(game, allGames);
   const shelfExpiry = getShelfLifeExpiry(game, allGames);
@@ -2166,8 +2175,14 @@ function PosterCard({ game, allGames, idx, onClick, onQuickLog, isInQueue, sortB
               <Clock size={10} className="text-white/30" />
               <span>{game.totalHours}h</span>
             </div>
-            <div className="flex items-center gap-0.5">
+            <div className="flex items-center gap-1" title={ratingRank.label || undefined}>
               <RatingStars rating={game.rating} size={9} />
+              {game.rating > 0 && (
+                <span className="text-[10px] font-semibold text-white/50 tabular-nums">{formatRating(game.rating)}</span>
+              )}
+              {ratingRank.isTop && (
+                <span className="text-[10px] font-semibold text-amber-400/70 tabular-nums">#{ratingRank.rank}</span>
+              )}
             </div>
             {game.totalHours > 0 && game.price > 0 && (
               <span className={clsx('text-xs font-medium', getValueColor(game.metrics.valueRating))}>
@@ -2371,6 +2386,7 @@ function CompactCard({ game, allGames, idx, onClick, onLogTime, onToggleQueue, o
   const momentum = getSessionMomentum(game);
   const whisper = getContextualWhisper(game, allGames);
   const libraryRank = getLibraryRank(game, allGames, sortBy);
+  const ratingRank = getRatingRank(game, allGames);
   const moodPulse = getCardMoodPulse(game);
   const progressRing = getProgressRingData(game, allGames);
   const lastPlayedStr = game.playLogs && game.playLogs.length > 0
@@ -2555,9 +2571,12 @@ function CompactCard({ game, allGames, idx, onClick, onLogTime, onToggleQueue, o
               <div className="text-white/80 font-medium text-xs">{game.totalHours}h</div>
               <div className="text-[9px] text-white/25">played</div>
             </div>
-            <div className="p-1.5 bg-white/[0.02] rounded-lg">
+            <div className="p-1.5 bg-white/[0.02] rounded-lg" title={ratingRank.label || undefined}>
               <div className="flex justify-center"><RatingStars rating={game.rating} size={9} /></div>
-              <div className="text-[9px] text-white/25">{game.rating}/10</div>
+              <div className="text-[9px] text-white/25">
+                {formatRating(game.rating)}
+                {ratingRank.isTop && <span className="text-amber-400/70 font-semibold"> · #{ratingRank.rank}</span>}
+              </div>
             </div>
             <div className="p-1.5 bg-white/[0.02] rounded-lg">
               {game.totalHours > 0 && game.price > 0 ? (


### PR DESCRIPTION
- Ratings now support 0.1 precision via tap-whole-number-then-fine-tune
  UI; precise values shown across cards and lists
- New rating stats: fine 0.5-band distribution, rarity tier bands,
  per-game rank/percentile, and close-rating comparison
- "Reflect with AI": Gemini-powered voice interview that transcribes
  spoken answers, asks taste-aware follow-ups, and synthesizes a
  reflective review into the review field
- Tier-assignment Reset button now confirms before clearing

https://claude.ai/code/session_01C4onv9DbyZxJaeAMStjzjh