### PR TITLE
Add persistent game review chat

### DIFF
--- a/app/apps/game-analytics/components/GameBottomSheet.tsx
+++ b/app/apps/game-analytics/components/GameBottomSheet.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useMemo, useRef, useEffect } from 'react';
-import { Clock, ChevronDown, ChevronUp, ListPlus, Check, Heart, Edit3, Trash2, Trophy, Sparkles, Zap } from 'lucide-react';
+import { Clock, ChevronDown, ChevronUp, ListPlus, Check, Heart, Edit3, Trash2, Trophy, Sparkles, Zap, MessageCircle } from 'lucide-react';
 import { Game } from '../lib/types';
 import { GameWithMetrics } from '../hooks/useAnalytics';
 import {
@@ -36,6 +36,7 @@ interface GameBottomSheetProps {
   onOpenPlayLog: () => void;
   onToggleQueue: () => void;
   onToggleSpecial: () => void;
+  onOpenReviewChat: () => void;
   isInQueue: boolean;
 }
 
@@ -59,6 +60,7 @@ export function GameBottomSheet({
   onOpenPlayLog,
   onToggleQueue,
   onToggleSpecial,
+  onOpenReviewChat,
   isInQueue,
 }: GameBottomSheetProps) {
   const [showAwards, setShowAwards] = useState(false);
@@ -620,10 +622,44 @@ export function GameBottomSheet({
             </div>
           )}
 
-          {/* Review */}
+          {/* Review Chat */}
+          <div className="mx-5 mb-4">
+            {game.reviewMessages && game.reviewMessages.length > 0 ? (
+              <div>
+                <div className="flex items-center justify-between mb-2">
+                  <span className="text-sm font-medium text-white/70">Review Chat</span>
+                  <span className="text-[10px] text-white/30">{game.reviewMessages.length} messages</span>
+                </div>
+                <button
+                  onClick={onOpenReviewChat}
+                  className="w-full p-3 bg-purple-500/5 border border-purple-500/15 rounded-xl text-left active:bg-purple-500/10 transition-all"
+                >
+                  <p className="text-xs text-white/50 leading-relaxed line-clamp-2 mb-2">
+                    {game.reviewMessages[game.reviewMessages.length - 1].text}
+                  </p>
+                  <span className="flex items-center gap-1 text-[10px] text-purple-400/60">
+                    <MessageCircle size={10} /> Continue conversation
+                  </span>
+                </button>
+              </div>
+            ) : (
+              <button
+                onClick={onOpenReviewChat}
+                className="w-full p-3 bg-white/[0.02] border border-white/5 rounded-xl text-left active:bg-white/[0.04] transition-all flex items-center gap-2"
+              >
+                <MessageCircle size={14} className="text-purple-400/50 shrink-0" />
+                <div>
+                  <span className="text-xs text-white/40 block">Start a review conversation</span>
+                  <span className="text-[10px] text-white/20">AI-guided · saves as you go</span>
+                </div>
+              </button>
+            )}
+          </div>
+
+          {/* Static review (from game form) */}
           {game.review && (
             <div className="mx-5 mb-4">
-              <span className="text-sm font-medium text-white/70 block mb-2">Your Review</span>
+              <span className="text-sm font-medium text-white/70 block mb-2">Quick Review</span>
               <div className="p-4 bg-white/[0.03] rounded-xl border border-white/5">
                 <p className="text-sm text-white/50 leading-relaxed whitespace-pre-wrap">{game.review}</p>
               </div>
@@ -655,6 +691,17 @@ export function GameBottomSheet({
             className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2.5 bg-blue-600/20 active:bg-blue-600/30 text-blue-400 rounded-lg text-xs font-medium transition-all"
           >
             <Clock size={14} /> Log Time
+          </button>
+          <button
+            onClick={onOpenReviewChat}
+            className={
+              game.reviewMessages && game.reviewMessages.length > 0
+                ? 'px-3 py-2.5 rounded-lg text-xs font-medium transition-all flex items-center gap-1.5 bg-purple-500/20 text-purple-400 active:bg-purple-500/30'
+                : 'px-3 py-2.5 rounded-lg text-xs font-medium transition-all flex items-center gap-1.5 bg-white/5 text-white/50 active:bg-white/10'
+            }
+          >
+            <MessageCircle size={14} />
+            Review
           </button>
           <button
             onClick={onToggleQueue}

--- a/app/apps/game-analytics/components/GameReviewChat.tsx
+++ b/app/apps/game-analytics/components/GameReviewChat.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Loader2, MessageCircle, Send, Sparkles, X } from 'lucide-react';
+import clsx from 'clsx';
+import { v4 as uuidv4 } from 'uuid';
+import { Game, ReviewMessage } from '../lib/types';
+import { generateReviewChatResponse, buildTasteSummary } from '../lib/ai-service';
+import { formatRating } from '../lib/calculations';
+
+interface GameReviewChatProps {
+  game: Game;
+  allGames: Game[];
+  onSave: (messages: ReviewMessage[]) => void;
+  onClose: () => void;
+}
+
+function makeMsg(role: ReviewMessage['role'], text: string): ReviewMessage {
+  return { id: uuidv4(), role, text, timestamp: new Date().toISOString() };
+}
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) + ' · ' +
+    d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+}
+
+export function GameReviewChat({ game, allGames, onSave, onClose }: GameReviewChatProps) {
+  const [messages, setMessages] = useState<ReviewMessage[]>(game.reviewMessages || []);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const tasteSummary = buildTasteSummary(allGames, game.name);
+  const gameCtx = {
+    name: game.name,
+    rating: game.rating,
+    genre: game.genre,
+    hours: game.hours,
+    status: game.status,
+    platform: game.platform,
+  };
+
+  // Lock body scroll
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => { document.body.style.overflow = ''; };
+  }, []);
+
+  // Auto-scroll
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages, loading]);
+
+  // Send opening message if this is the first time
+  useEffect(() => {
+    if (messages.length > 0) return;
+    let cancelled = false;
+    setLoading(true);
+    generateReviewChatResponse({ game: gameCtx, tasteSummary, history: [], userMessage: null })
+      .then(text => {
+        if (cancelled) return;
+        const aiMsg = makeMsg('ai', text);
+        const initial = [aiMsg];
+        setMessages(initial);
+        onSave(initial);
+      })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleSend = useCallback(async () => {
+    const text = input.trim();
+    if (!text || loading) return;
+    setInput('');
+
+    const userMsg = makeMsg('user', text);
+    const withUser = [...messages, userMsg];
+    setMessages(withUser);
+    onSave(withUser);
+
+    setLoading(true);
+    try {
+      const history = withUser.map(m => ({ role: m.role, text: m.text }));
+      const aiText = await generateReviewChatResponse({
+        game: gameCtx,
+        tasteSummary,
+        history: history.slice(0, -1), // everything before the new user msg
+        userMessage: text,
+      });
+      const aiMsg = makeMsg('ai', aiText);
+      const withAi = [...withUser, aiMsg];
+      setMessages(withAi);
+      onSave(withAi);
+    } finally {
+      setLoading(false);
+    }
+  }, [input, messages, loading, gameCtx, tasteSummary, onSave]);
+
+  const hasReview = messages.length > 0;
+  const lastDate = hasReview ? messages[messages.length - 1].timestamp : null;
+
+  return (
+    <div className="fixed inset-0 z-[60]">
+      <div className="absolute inset-0 bg-black/80 backdrop-blur-sm" onClick={onClose} />
+
+      <div className="absolute bottom-0 left-0 right-0 bg-[#12121a] rounded-t-2xl flex flex-col animate-bottom-sheet-up"
+        style={{ maxHeight: '92vh' }}>
+        {/* Drag handle */}
+        <div className="flex-shrink-0 pt-3 pb-3 px-4 border-b border-white/5">
+          <div className="w-10 h-1 rounded-full bg-white/20 mx-auto mb-3" />
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2 min-w-0">
+              <MessageCircle size={16} className="text-purple-400 shrink-0" />
+              <div className="min-w-0">
+                <h2 className="text-sm font-semibold text-white truncate">Review · {game.name}</h2>
+                <p className="text-[11px] text-white/40">
+                  {formatRating(game.rating)}/10 ·{' '}
+                  {hasReview
+                    ? `${messages.length} message${messages.length === 1 ? '' : 's'} · last ${formatTime(lastDate!)}`
+                    : 'Start your review conversation'}
+                </p>
+              </div>
+            </div>
+            <button onClick={onClose} className="text-white/40 active:text-white/70 rounded-lg p-1.5">
+              <X size={20} />
+            </button>
+          </div>
+        </div>
+
+        {/* Messages */}
+        <div className="flex-1 overflow-y-auto px-4 py-4 space-y-3 min-h-0">
+          {messages.map((msg, i) => {
+            const isAi = msg.role === 'ai';
+            // Show date separator when conversation starts a new day
+            const prevDate = i > 0 ? messages[i - 1].timestamp.slice(0, 10) : null;
+            const thisDate = msg.timestamp.slice(0, 10);
+            const showDate = prevDate !== null && prevDate !== thisDate;
+
+            return (
+              <div key={msg.id}>
+                {showDate && (
+                  <div className="flex items-center gap-2 my-3">
+                    <div className="h-px flex-1 bg-white/5" />
+                    <span className="text-[10px] text-white/20">{new Date(thisDate).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}</span>
+                    <div className="h-px flex-1 bg-white/5" />
+                  </div>
+                )}
+                <div className={clsx(
+                  'flex',
+                  isAi ? 'justify-start' : 'justify-end'
+                )}>
+                  <div className={clsx(
+                    'max-w-[88%] rounded-2xl px-3.5 py-2.5 text-sm leading-relaxed',
+                    isAi
+                      ? 'bg-purple-500/10 text-purple-100/90 rounded-tl-sm'
+                      : 'bg-white/[0.07] text-white/85 rounded-tr-sm'
+                  )}>
+                    {isAi && (
+                      <div className="flex items-center gap-1 mb-1">
+                        <Sparkles size={9} className="text-purple-400/60" />
+                        <span className="text-[9px] uppercase tracking-wider text-purple-400/50">Review guide</span>
+                      </div>
+                    )}
+                    {msg.text}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+
+          {loading && (
+            <div className="flex items-center gap-2 text-white/30 text-xs px-1">
+              <Loader2 size={13} className="animate-spin" />
+              Thinking…
+            </div>
+          )}
+
+          <div ref={bottomRef} />
+        </div>
+
+        {/* Input */}
+        <div className="flex-shrink-0 px-4 pb-4 pt-3 bg-[#12121a] border-t border-white/5">
+          <div className="flex gap-2 items-end">
+            <textarea
+              ref={textareaRef}
+              value={input}
+              onChange={e => setInput(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter' && !e.shiftKey) {
+                  e.preventDefault();
+                  handleSend();
+                }
+              }}
+              rows={2}
+              placeholder="Share your thoughts… (Enter to send)"
+              disabled={loading}
+              className="flex-1 px-3 py-2.5 bg-white/[0.03] border border-white/5 text-white rounded-xl text-sm focus:outline-none focus:bg-white/[0.05] focus:border-white/10 transition-all resize-none placeholder:text-white/25 leading-relaxed disabled:opacity-50"
+            />
+            <button
+              onClick={handleSend}
+              disabled={!input.trim() || loading}
+              className="flex-shrink-0 p-2.5 rounded-xl bg-purple-600 text-white active:bg-purple-500 disabled:opacity-40 transition-all"
+            >
+              <Send size={16} />
+            </button>
+          </div>
+          <p className="text-[10px] text-white/20 mt-2 text-center">
+            Conversation saved automatically · comes back where you left off
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/apps/game-analytics/lib/ai-service.ts
+++ b/app/apps/game-analytics/lib/ai-service.ts
@@ -711,6 +711,80 @@ Respond with ONLY valid JSON (no markdown): {"transcript": "<what they said>", "
   }
 }
 
+// ── REVIEW CHAT ────────────────────────────────────────────────────
+// Persistent back-and-forth chat about a specific game.
+// Each call returns a single AI message. Caller saves history externally.
+
+const REVIEW_CATEGORIES = ['gameplay/mechanics', 'story/world', 'visuals/atmosphere', 'sound/music', 'value for money', 'replayability', 'who it\'s for'];
+
+export interface ReviewChatMessage {
+  role: 'user' | 'ai';
+  text: string;
+}
+
+export async function generateReviewChatResponse(params: {
+  game: ReviewGameContext;
+  tasteSummary: string;
+  history: ReviewChatMessage[];
+  userMessage: string | null; // null = opening message
+}): Promise<string> {
+  const { game, tasteSummary, history, userMessage } = params;
+  const model = getAIModel();
+
+  const gameInfo = `"${game.name}" — ${game.hours.toFixed(0)}h played, rated ${game.rating.toFixed(1)}/10, status: ${game.status}${game.genre ? `, genre: ${game.genre}` : ''}${game.platform ? `, on ${game.platform}` : ''}.`;
+
+  const historyText = history.length > 0
+    ? history.map(m => `${m.role === 'user' ? 'Player' : 'You'}: ${m.text}`).join('\n')
+    : '';
+
+  const coveredHints = history.map(m => m.text.toLowerCase()).join(' ');
+  const uncovered = REVIEW_CATEGORIES.filter(cat => {
+    const keywords = cat.split('/');
+    return !keywords.some(kw => coveredHints.includes(kw));
+  });
+
+  let prompt: string;
+
+  if (!userMessage) {
+    // Opening message — no user input yet
+    prompt = `You are a thoughtful friend helping a player reflect on a game they've spent time with. Your goal is to help them build a genuine, personal review through natural conversation over several messages.
+
+Game: ${gameInfo}
+Player's broader taste: ${tasteSummary}
+
+Write your opening message. Reference something specific from the data — their rating, hours, or status — to make it feel personal. Ask ONE focused question to kick things off. NOT "what did you think?" — something more specific, like what surprised them, how it compared to their expectations, or what they'd tell a friend.
+
+Keep it to 2-3 sentences total. Casual, warm, curious. No greeting like "Hey!" or "Hi there!".`;
+  } else {
+    prompt = `You are a thoughtful friend helping a player reflect on "${game.name}" and build a genuine personal review through conversation.
+
+Game: ${gameInfo}
+Player's broader taste: ${tasteSummary}
+
+Conversation so far:
+${historyText}
+
+Player just said: "${userMessage}"
+
+Respond naturally to what they said in 1-2 sentences. Then ask ONE specific follow-up question — either digging deeper into what they mentioned, or steering toward something not yet covered.
+
+Categories not yet touched: ${uncovered.length > 0 ? uncovered.join(', ') : 'all covered — feel free to wrap up or dig deeper'}.
+
+Stay casual and conversational. Respond to their actual words, don't just jump topics. 2-4 sentences total.`;
+  }
+
+  try {
+    const result = await model.generateContent(prompt);
+    return result.response.text().trim();
+  } catch (e) {
+    console.error('Review chat error:', e);
+    if (!userMessage) {
+      return `You've put ${game.hours.toFixed(0)} hours into ${game.name} and rated it ${game.rating.toFixed(1)}/10. What made you give it that score?`;
+    }
+    return "Tell me more about that — what specifically stood out?";
+  }
+}
+
 /**
  * Synthesize the interview into a first-person, reflective written review.
  */

--- a/app/apps/game-analytics/lib/types.ts
+++ b/app/apps/game-analytics/lib/types.ts
@@ -33,6 +33,13 @@ export interface PlayLog {
   vibe?: SessionVibe;
 }
 
+export interface ReviewMessage {
+  id: string;
+  role: 'user' | 'ai';
+  text: string;
+  timestamp: string;
+}
+
 export interface Game {
   id: string;
   userId: string;
@@ -51,6 +58,7 @@ export interface Game {
   subscriptionSource?: SubscriptionSource; // Which subscription service provided the game
   notes?: string;
   review?: string; // Personal review/thoughts about the game
+  reviewMessages?: ReviewMessage[]; // Persistent review chat conversation
   datePurchased?: string;
   startDate?: string; // When you started playing
   endDate?: string; // When you finished/stopped

--- a/app/apps/game-analytics/page.tsx
+++ b/app/apps/game-analytics/page.tsx
@@ -15,7 +15,7 @@ import { TimelineView } from './components/TimelineView';
 import { StatsView } from './components/StatsView';
 import { AIChatTab } from './components/AIChatTab';
 import { UpNextTab } from './components/UpNextTab';
-import { Game, GameStatus, PlayLog, GameRanking, GameAward, AwardPeriodType, GameTier, TierAssignmentMap } from './lib/types';
+import { Game, GameStatus, PlayLog, GameRanking, GameAward, AwardPeriodType, GameTier, TierAssignmentMap, ReviewMessage } from './lib/types';
 import { useTierAssignments } from './hooks/useTierAssignments';
 import { gameRepository } from './lib/storage';
 import { useRankings } from './hooks/useRankings';
@@ -44,6 +44,7 @@ import { TrophyShowcase } from './components/TrophyShowcase';
 import { TrophyToast } from './components/TrophyToast';
 import { ErrorLogPanel, ErrorLogButton } from './components/ErrorLogPanel';
 import { WhatsNewModal } from './components/WhatsNewModal';
+import { GameReviewChat } from './components/GameReviewChat';
 import clsx from 'clsx';
 
 type ViewMode = 'all' | 'owned' | 'wishlist';
@@ -190,6 +191,7 @@ export default function GameAnalyticsPage() {
   const [wrappedYear, setWrappedYear] = useState<number | null>(null);
   const [showAwardsHub, setShowAwardsHub] = useState(false);
   const [detailGame, setDetailGame] = useState<GameWithMetrics | null>(null);
+  const [reviewChatGame, setReviewChatGame] = useState<GameWithMetrics | null>(null);
   const [statsCollapsed, setStatsCollapsed] = useState(() => {
     if (typeof window === 'undefined') return false;
     return localStorage.getItem('ga-stats-collapsed') === 'true';
@@ -1467,7 +1469,27 @@ export default function GameAnalyticsPage() {
               showToast('Failed to update', 'error');
             }
           }}
+          onOpenReviewChat={() => {
+            setReviewChatGame(detailGame);
+            setDetailGame(null);
+          }}
           isInQueue={isInQueue(detailGame.id)}
+        />
+      )}
+
+      {/* Game Review Chat */}
+      {reviewChatGame && (
+        <GameReviewChat
+          game={reviewChatGame}
+          allGames={games}
+          onSave={async (messages: ReviewMessage[]) => {
+            try {
+              await updateGame(reviewChatGame.id, { reviewMessages: messages });
+            } catch (e) {
+              // silent — messages are kept in local state
+            }
+          }}
+          onClose={() => setReviewChatGame(null)}
         />
       )}
     </div>


### PR DESCRIPTION
Each game now has a saved review conversation that picks up where you left off. The AI covers broad areas (gameplay, story, visuals, sound, value, replayability) while following what the user is most engaged with.

- types.ts: Add ReviewMessage interface; add reviewMessages[] to Game
- ai-service.ts: Add generateReviewChatResponse — context-aware chat that tracks uncovered categories and ends each turn with a specific follow-up question
- GameReviewChat.tsx: New bottom-sheet chat modal; opening AI message fires on first visit; every message pair auto-saves to the game record; shows date separators across multi-session conversations
- GameBottomSheet.tsx: Add Review button to sticky actions bar (lit purple when chat exists); Review section shows last message preview with "Continue conversation" prompt or an invite to start
- page.tsx: Add reviewChatGame state, wire up onOpenReviewChat, render GameReviewChat with updateGame save callback

https://claude.ai/code/session_014qm4WuVfRyYDQyHyezrfQh