### PR TITLE
Add swipe navigation to story recaps for mobile

### DIFF
--- a/app/apps/game-analytics/components/MonthStoryMode.tsx
+++ b/app/apps/game-analytics/components/MonthStoryMode.tsx
@@ -31,6 +31,7 @@ import { MonthPersonalityScreen } from './story-screens/MonthPersonalityScreen';
 import { MonthVsLastScreen } from './story-screens/MonthVsLastScreen';
 import { MonthAIBlurbScreen } from './story-screens/MonthAIBlurbScreen';
 import { MonthClosingScreen } from './story-screens/MonthClosingScreen';
+import { useStorySwipe } from '../hooks/useStorySwipe';
 
 interface MonthStoryModeProps {
   data: MonthInReviewData;
@@ -230,6 +231,9 @@ export function MonthStoryMode({ data, allGames, onClose, monthTitle, updateGame
     return () => { document.body.style.overflow = ''; };
   }, []);
 
+  // Swipe navigation (mobile) — swipe left/right to move between screens
+  const { dragProps, guardClick } = useStorySwipe(goToNext, goToPrevious);
+
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     const rect = e.currentTarget.getBoundingClientRect();
     const x = e.clientX - rect.left;
@@ -288,7 +292,7 @@ export function MonthStoryMode({ data, allGames, onClose, monthTitle, updateGame
       {currentScreen > 0 && (
         <button
           onClick={goToPrevious}
-          className="absolute left-4 top-1/2 -translate-y-1/2 z-50 p-3 rounded-full bg-white/10 hover:bg-white/20 transition-all backdrop-blur-sm hidden md:flex items-center justify-center"
+          className="absolute left-4 top-1/2 -translate-y-1/2 z-50 p-3 rounded-full bg-white/10 hover:bg-white/20 transition-all backdrop-blur-sm flex items-center justify-center"
           aria-label="Previous screen"
         >
           <ChevronLeft size={24} className="text-white" />
@@ -297,7 +301,7 @@ export function MonthStoryMode({ data, allGames, onClose, monthTitle, updateGame
       {currentScreen < totalScreens - 1 && (
         <button
           onClick={goToNext}
-          className="absolute right-4 top-1/2 -translate-y-1/2 z-50 p-3 rounded-full bg-white/10 hover:bg-white/20 transition-all backdrop-blur-sm hidden md:flex items-center justify-center"
+          className="absolute right-4 top-1/2 -translate-y-1/2 z-50 p-3 rounded-full bg-white/10 hover:bg-white/20 transition-all backdrop-blur-sm flex items-center justify-center"
           aria-label="Next screen"
         >
           <ChevronRight size={24} className="text-white" />
@@ -305,11 +309,12 @@ export function MonthStoryMode({ data, allGames, onClose, monthTitle, updateGame
       )}
 
       {/* Screen container */}
-      <div className="h-full w-full cursor-pointer" onClick={handleClick}>
+      <div className="h-full w-full cursor-pointer" onClick={guardClick(handleClick)}>
         <AnimatePresence initial={false} custom={direction} mode="wait">
           <motion.div
             key={currentScreen}
             custom={direction}
+            {...dragProps}
             variants={variants}
             initial="enter"
             animate="center"

--- a/app/apps/game-analytics/components/QuarterStoryMode.tsx
+++ b/app/apps/game-analytics/components/QuarterStoryMode.tsx
@@ -25,6 +25,7 @@ import { QuarterVsLastScreen } from './story-screens/QuarterVsLastScreen';
 import { QuarterPlotTwistsScreen } from './story-screens/QuarterPlotTwistsScreen';
 import { QuarterAIBlurbScreen } from './story-screens/QuarterAIBlurbScreen';
 import { QuarterClosingScreen } from './story-screens/QuarterClosingScreen';
+import { useStorySwipe } from '../hooks/useStorySwipe';
 
 interface QuarterStoryModeProps {
   data: QuarterInReviewData;
@@ -170,6 +171,9 @@ export function QuarterStoryMode({ data, allGames, onClose, quarterTitle, update
     return () => { document.body.style.overflow = ''; };
   }, []);
 
+  // Swipe navigation (mobile) — swipe left/right to move between screens
+  const { dragProps, guardClick } = useStorySwipe(goToNext, goToPrevious);
+
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     const rect = e.currentTarget.getBoundingClientRect();
     if (e.clientX - rect.left < rect.width * 0.3) goToPrevious();
@@ -205,22 +209,23 @@ export function QuarterStoryMode({ data, allGames, onClose, quarterTitle, update
 
       {/* Nav arrows */}
       {currentScreen > 0 && (
-        <button onClick={goToPrevious} className="absolute left-4 top-1/2 -translate-y-1/2 z-50 p-3 rounded-full bg-white/10 hover:bg-white/20 transition-all backdrop-blur-sm hidden md:flex items-center justify-center">
+        <button onClick={goToPrevious} className="absolute left-4 top-1/2 -translate-y-1/2 z-50 p-3 rounded-full bg-white/10 hover:bg-white/20 transition-all backdrop-blur-sm flex items-center justify-center">
           <ChevronLeft size={24} className="text-white" />
         </button>
       )}
       {currentScreen < totalScreens - 1 && (
-        <button onClick={goToNext} className="absolute right-4 top-1/2 -translate-y-1/2 z-50 p-3 rounded-full bg-white/10 hover:bg-white/20 transition-all backdrop-blur-sm hidden md:flex items-center justify-center">
+        <button onClick={goToNext} className="absolute right-4 top-1/2 -translate-y-1/2 z-50 p-3 rounded-full bg-white/10 hover:bg-white/20 transition-all backdrop-blur-sm flex items-center justify-center">
           <ChevronRight size={24} className="text-white" />
         </button>
       )}
 
       {/* Screen container */}
-      <div className="h-full w-full cursor-pointer" onClick={handleClick}>
+      <div className="h-full w-full cursor-pointer" onClick={guardClick(handleClick)}>
         <AnimatePresence initial={false} custom={direction} mode="wait">
           <motion.div
             key={currentScreen}
             custom={direction}
+            {...dragProps}
             variants={variants}
             initial="enter"
             animate="center"

--- a/app/apps/game-analytics/components/WeekStoryMode.tsx
+++ b/app/apps/game-analytics/components/WeekStoryMode.tsx
@@ -36,6 +36,7 @@ import { AwardsHub } from './AwardsHub';
 import { generateMultipleBlurbs, AIBlurbType, AIBlurbResult } from '../lib/ai-service';
 import { useAwards, awardWeekKey, awardWeekLabel } from '../hooks/useAwards';
 import { GameWithMetrics } from '../hooks/useAnalytics';
+import { useStorySwipe } from '../hooks/useStorySwipe';
 
 interface WeekStoryModeProps {
   data: WeekInReviewData;
@@ -259,6 +260,9 @@ const ignoredGames = useMemo(() => getIgnoredGames(data, allGames), [data, allGa
     return () => { document.body.style.overflow = ''; };
   }, []);
 
+  // Swipe navigation (mobile) — swipe left/right to move between screens
+  const { dragProps, guardClick } = useStorySwipe(goToNext, goToPrevious);
+
   // Click navigation - left/right halves
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     const rect = e.currentTarget.getBoundingClientRect();
@@ -332,7 +336,7 @@ const ignoredGames = useMemo(() => getIgnoredGames(data, allGames), [data, allGa
       {currentScreen > 0 && (
         <button
           onClick={goToPrevious}
-          className="absolute left-4 top-1/2 -translate-y-1/2 z-50 p-3 rounded-full bg-white/10 hover:bg-white/20 transition-all backdrop-blur-sm hidden md:flex items-center justify-center"
+          className="absolute left-4 top-1/2 -translate-y-1/2 z-50 p-3 rounded-full bg-white/10 hover:bg-white/20 transition-all backdrop-blur-sm flex items-center justify-center"
           aria-label="Previous screen"
         >
           <ChevronLeft size={24} className="text-white" />
@@ -342,7 +346,7 @@ const ignoredGames = useMemo(() => getIgnoredGames(data, allGames), [data, allGa
       {currentScreen < totalScreens - 1 && (
         <button
           onClick={goToNext}
-          className="absolute right-4 top-1/2 -translate-y-1/2 z-50 p-3 rounded-full bg-white/10 hover:bg-white/20 transition-all backdrop-blur-sm hidden md:flex items-center justify-center"
+          className="absolute right-4 top-1/2 -translate-y-1/2 z-50 p-3 rounded-full bg-white/10 hover:bg-white/20 transition-all backdrop-blur-sm flex items-center justify-center"
           aria-label="Next screen"
         >
           <ChevronRight size={24} className="text-white" />
@@ -352,12 +356,13 @@ const ignoredGames = useMemo(() => getIgnoredGames(data, allGames), [data, allGa
       {/* Screen container with click navigation */}
       <div
         className="h-full w-full cursor-pointer"
-        onClick={handleClick}
+        onClick={guardClick(handleClick)}
       >
         <AnimatePresence initial={false} custom={direction} mode="wait">
           <motion.div
             key={currentScreen}
             custom={direction}
+            {...dragProps}
             variants={variants}
             initial="enter"
             animate="center"

--- a/app/apps/game-analytics/components/YearStoryMode.tsx
+++ b/app/apps/game-analytics/components/YearStoryMode.tsx
@@ -24,6 +24,7 @@ import { YearPlotTwistsScreen } from './story-screens/YearPlotTwistsScreen';
 import { YearPersonalityEvolutionScreen } from './story-screens/YearPersonalityEvolutionScreen';
 import { YearAIBlurbScreen } from './story-screens/YearAIBlurbScreen';
 import { YearClosingScreen } from './story-screens/YearClosingScreen';
+import { useStorySwipe } from '../hooks/useStorySwipe';
 
 interface YearStoryModeProps {
   data: YearInReviewFullData;
@@ -156,6 +157,9 @@ export function YearStoryMode({ data, allGames, onClose, yearTitle, chapterTitle
     return () => { document.body.style.overflow = ''; };
   }, []);
 
+  // Swipe navigation (mobile) — swipe left/right to move between screens
+  const { dragProps, guardClick } = useStorySwipe(goToNext, goToPrevious);
+
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     const rect = e.currentTarget.getBoundingClientRect();
     if (e.clientX - rect.left < rect.width * 0.3) goToPrevious(); else goToNext();
@@ -190,21 +194,22 @@ export function YearStoryMode({ data, allGames, onClose, yearTitle, chapterTitle
       </div>
 
       {currentScreen > 0 && (
-        <button onClick={goToPrevious} className="absolute left-4 top-1/2 -translate-y-1/2 z-50 p-3 rounded-full bg-white/10 hover:bg-white/20 transition-all backdrop-blur-sm hidden md:flex">
+        <button onClick={goToPrevious} className="absolute left-4 top-1/2 -translate-y-1/2 z-50 p-3 rounded-full bg-white/10 hover:bg-white/20 transition-all backdrop-blur-sm flex items-center justify-center">
           <ChevronLeft size={24} className="text-white" />
         </button>
       )}
       {currentScreen < totalScreens - 1 && (
-        <button onClick={goToNext} className="absolute right-4 top-1/2 -translate-y-1/2 z-50 p-3 rounded-full bg-white/10 hover:bg-white/20 transition-all backdrop-blur-sm hidden md:flex">
+        <button onClick={goToNext} className="absolute right-4 top-1/2 -translate-y-1/2 z-50 p-3 rounded-full bg-white/10 hover:bg-white/20 transition-all backdrop-blur-sm flex items-center justify-center">
           <ChevronRight size={24} className="text-white" />
         </button>
       )}
 
-      <div className="h-full w-full cursor-pointer" onClick={handleClick}>
+      <div className="h-full w-full cursor-pointer" onClick={guardClick(handleClick)}>
         <AnimatePresence initial={false} custom={direction} mode="wait">
           <motion.div
             key={currentScreen}
             custom={direction}
+            {...dragProps}
             variants={variants}
             initial="enter"
             animate="center"

--- a/app/apps/game-analytics/hooks/useStorySwipe.ts
+++ b/app/apps/game-analytics/hooks/useStorySwipe.ts
@@ -1,0 +1,79 @@
+'use client';
+
+import { useRef, useCallback, type MouseEvent as ReactMouseEvent } from 'react';
+import type { PanInfo } from 'framer-motion';
+
+// Swipe thresholds: trigger navigation on a deliberate horizontal drag or a quick flick
+const SWIPE_OFFSET_THRESHOLD = 50; // px dragged
+const SWIPE_VELOCITY_THRESHOLD = 300; // px/s flick
+
+type ClickHandler = (e: ReactMouseEvent<HTMLDivElement>) => void;
+
+interface StorySwipe {
+  // Spread onto the animating screen <motion.div> to enable horizontal swipe navigation
+  dragProps: {
+    drag: 'x';
+    dragDirectionLock: true;
+    dragConstraints: { left: 0; right: 0 };
+    dragElastic: number;
+    onDragStart: () => void;
+    onDragEnd: (e: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) => void;
+  };
+  // Wraps the existing tap handler so a swipe doesn't also register as a tap-advance
+  guardClick: (handler: ClickHandler) => ClickHandler;
+}
+
+/**
+ * Adds Instagram-story-style swipe navigation to a story modal.
+ * Swipe left → next screen, swipe right → previous screen. Tap navigation
+ * still works via `guardClick`, which suppresses the click that fires at the
+ * end of a swipe gesture.
+ */
+export function useStorySwipe(goToNext: () => void, goToPrevious: () => void): StorySwipe {
+  const swipedRef = useRef(false);
+
+  const onDragStart = useCallback(() => {
+    swipedRef.current = false;
+  }, []);
+
+  const onDragEnd = useCallback(
+    (_e: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) => {
+      const { offset, velocity } = info;
+      const swipedLeft = offset.x < -SWIPE_OFFSET_THRESHOLD || velocity.x < -SWIPE_VELOCITY_THRESHOLD;
+      const swipedRight = offset.x > SWIPE_OFFSET_THRESHOLD || velocity.x > SWIPE_VELOCITY_THRESHOLD;
+
+      if (swipedLeft) {
+        swipedRef.current = true;
+        goToNext();
+      } else if (swipedRight) {
+        swipedRef.current = true;
+        goToPrevious();
+      }
+    },
+    [goToNext, goToPrevious]
+  );
+
+  const guardClick = useCallback(
+    (handler: ClickHandler): ClickHandler =>
+      (e) => {
+        if (swipedRef.current) {
+          swipedRef.current = false;
+          return;
+        }
+        handler(e);
+      },
+    []
+  );
+
+  return {
+    dragProps: {
+      drag: 'x',
+      dragDirectionLock: true,
+      dragConstraints: { left: 0, right: 0 },
+      dragElastic: 0.4,
+      onDragStart,
+      onDragEnd,
+    },
+    guardClick,
+  };
+}


### PR DESCRIPTION
Story mode recaps (week/month/quarter/year) had no swipe gesture support
and hid their nav arrows on mobile, leaving invisible tap zones as the only
way to navigate on a phone. Add a shared useStorySwipe hook that enables
Instagram-style horizontal swipe (left = next, right = previous) and guards
the tap handler so a swipe doesn't double-fire as a tap. Also unhide the
prev/next arrow buttons on mobile.

https://claude.ai/code/session_01A5QVH5S9E3CTqstrDKfe1C