### PR TITLE
Add Story So Far chronicle to Game Analytics timeline

### DIFF
--- a/app/apps/game-analytics/components/StorySoFar.tsx
+++ b/app/apps/game-analytics/components/StorySoFar.tsx
@@ -1,0 +1,295 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { BookOpen, Clock, Gamepad2, ShoppingBag, RotateCcw, CheckCircle2, Sparkles } from 'lucide-react';
+import clsx from 'clsx';
+import { Game } from '../lib/types';
+import {
+  StoryRangeOption,
+  resolveStoryRange,
+  getGameChronicle,
+  chronicleStretchBlurb,
+  PlayStretch,
+  GameChroniclePurchase,
+  parseLocalDate,
+} from '../lib/calculations';
+import { generateChronicleBlurbs, ChronicleStretchInput } from '../lib/ai-game-service';
+
+interface StorySoFarProps {
+  games: Game[];
+}
+
+const RANGE_OPTIONS: { value: StoryRangeOption; label: string }[] = [
+  { value: 'this-month', label: 'This Month' },
+  { value: 'this-quarter', label: 'This Quarter' },
+  { value: 'last-3-months', label: 'Last 3 Months' },
+  { value: 'year-so-far', label: 'Year So Far' },
+  { value: 'last-year', label: 'Last Year' },
+  { value: 'this-year', label: 'This Year' },
+];
+
+function fmtDay(dateStr: string): string {
+  return parseLocalDate(dateStr).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+function fmtMonth(monthKey: string): string {
+  const [y, m] = monthKey.split('-').map(Number);
+  return new Date(y, m - 1, 1).toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+}
+
+function fmtHours(h: number): string {
+  if (h >= 1) return `${h % 1 === 0 ? h : h.toFixed(1)} hrs`;
+  return `${Math.round(h * 60)} min`;
+}
+
+function dateRangeLabel(st: PlayStretch): string {
+  if (st.startDate === st.endDate) return fmtDay(st.startDate);
+  return `${fmtDay(st.startDate)} – ${fmtDay(st.endDate)}`;
+}
+
+const CADENCE_STYLES: Record<PlayStretch['cadence'], string> = {
+  binge: 'bg-orange-500/15 text-orange-300 border-orange-500/30',
+  steady: 'bg-sky-500/15 text-sky-300 border-sky-500/30',
+  'one-off': 'bg-white/5 text-gray-400 border-white/10',
+};
+
+export function StorySoFar({ games }: StorySoFarProps) {
+  const [range, setRange] = useState<StoryRangeOption>('year-so-far');
+  const [blurbs, setBlurbs] = useState<Record<string, string>>({});
+  const [loadingBlurbs, setLoadingBlurbs] = useState(false);
+
+  const chronicle = useMemo(() => {
+    const resolved = resolveStoryRange(range);
+    return getGameChronicle(games, resolved);
+  }, [games, range]);
+
+  // Fetch AI blurbs for the current range (batched). Template blurbs show
+  // instantly; AI replaces them when ready.
+  useEffect(() => {
+    let cancelled = false;
+    if (chronicle.stretches.length === 0) {
+      setBlurbs({});
+      return;
+    }
+    const inputs: ChronicleStretchInput[] = chronicle.stretches.map(st => ({
+      key: st.key,
+      name: st.gameName,
+      genre: st.genre,
+      hours: st.totalHours,
+      days: st.daysActive,
+      sessions: st.sessionCount,
+      cadenceLabel: st.cadenceLabel,
+      isReturn: st.isReturn,
+      rating: st.rating,
+      completed: st.completedInStretch,
+      startLabel: fmtDay(st.startDate),
+    }));
+
+    setLoadingBlurbs(true);
+    generateChronicleBlurbs(range, inputs)
+      .then(map => {
+        if (!cancelled) setBlurbs(map);
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingBlurbs(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [chronicle, range]);
+
+  // Group stretches + purchases by month for the scrollable list (newest first).
+  const months = useMemo(() => {
+    return [...chronicle.monthKeys].reverse().map(monthKey => ({
+      monthKey,
+      stretches: chronicle.stretches.filter(s => s.monthKey === monthKey),
+      purchases: chronicle.purchases.filter(p => p.monthKey === monthKey),
+    }));
+  }, [chronicle]);
+
+  const isEmpty = chronicle.stretches.length === 0 && chronicle.purchases.length === 0;
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-gradient-to-b from-purple-500/[0.07] to-transparent p-4 sm:p-5">
+      {/* Header */}
+      <div className="mb-4 flex items-center gap-2">
+        <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-purple-500/20 text-purple-300">
+          <BookOpen size={18} />
+        </div>
+        <div>
+          <h2 className="text-lg font-bold text-white">Your Story So Far</h2>
+          <p className="text-xs text-gray-400">What you played, in order — and for how long.</p>
+        </div>
+      </div>
+
+      {/* Range picker */}
+      <div className="mb-4 flex flex-wrap gap-2">
+        {RANGE_OPTIONS.map(opt => (
+          <button
+            key={opt.value}
+            onClick={() => setRange(opt.value)}
+            className={clsx(
+              'rounded-full border px-3 py-1.5 text-xs font-medium transition-colors',
+              range === opt.value
+                ? 'border-purple-400/50 bg-purple-500/25 text-white'
+                : 'border-white/10 bg-white/[0.03] text-gray-400 hover:bg-white/[0.07]'
+            )}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Summary line */}
+      {!isEmpty && (
+        <div className="mb-5 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-300">
+          <span className="inline-flex items-center gap-1.5">
+            <Gamepad2 size={14} className="text-purple-300" />
+            <strong className="text-white">{chronicle.uniqueGames}</strong> game{chronicle.uniqueGames !== 1 ? 's' : ''}
+          </span>
+          <span className="inline-flex items-center gap-1.5">
+            <Clock size={14} className="text-purple-300" />
+            <strong className="text-white">{fmtHours(chronicle.totalHours)}</strong>
+          </span>
+          <span className="inline-flex items-center gap-1.5">
+            <Sparkles size={14} className="text-purple-300" />
+            <strong className="text-white">{chronicle.totalSessions}</strong> session{chronicle.totalSessions !== 1 ? 's' : ''}
+          </span>
+          {loadingBlurbs && (
+            <span className="inline-flex items-center gap-1.5 text-xs text-purple-300/70">
+              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-purple-300" />
+              writing your story…
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {isEmpty && (
+        <div className="rounded-xl border border-white/10 bg-white/[0.02] p-8 text-center">
+          <p className="text-sm text-gray-400">
+            No gaming activity in <strong className="text-gray-300">{chronicle.range.label.toLowerCase()}</strong> yet.
+            Pick another range, or log some play sessions to start your story.
+          </p>
+        </div>
+      )}
+
+      {/* The scrollable chronicle */}
+      <div className="space-y-7">
+        {months.map(({ monthKey, stretches, purchases }) => (
+          <div key={monthKey}>
+            {/* Month header */}
+            <div className="mb-3 flex items-center gap-3">
+              <h3 className="text-sm font-bold uppercase tracking-wider text-purple-300">{fmtMonth(monthKey)}</h3>
+              <div className="h-px flex-1 bg-gradient-to-r from-purple-500/30 to-transparent" />
+            </div>
+
+            <div className="space-y-2.5">
+              {/* Purchases that aren't also played stretches this month show as a buy note */}
+              {purchases
+                .filter(p => !stretches.some(s => s.gameId === p.gameId))
+                .map(p => (
+                  <PurchaseRow key={`buy-${p.gameId}`} purchase={p} />
+                ))}
+
+              {/* Play stretches */}
+              {stretches.map(st => (
+                <StretchRow
+                  key={st.key}
+                  stretch={st}
+                  blurb={blurbs[st.key] || chronicleStretchBlurb(st)}
+                  boughtThisMonth={purchases.some(p => p.gameId === st.gameId)}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function StretchRow({ stretch, blurb, boughtThisMonth }: { stretch: PlayStretch; blurb: string; boughtThisMonth: boolean }) {
+  return (
+    <div className="flex gap-3 rounded-xl border border-white/10 bg-white/[0.03] p-3 transition-colors hover:bg-white/[0.05]">
+      {/* Thumbnail */}
+      <div className="h-14 w-14 shrink-0 overflow-hidden rounded-lg bg-white/5">
+        {stretch.thumbnail ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={stretch.thumbnail} alt={stretch.gameName} className="h-full w-full object-cover" />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-gray-600">
+            <Gamepad2 size={22} />
+          </div>
+        )}
+      </div>
+
+      {/* Body */}
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <span className="truncate font-semibold text-white">{stretch.gameName}</span>
+          {stretch.isReturn && (
+            <span className="inline-flex items-center gap-1 rounded-full border border-teal-500/30 bg-teal-500/15 px-1.5 py-0.5 text-[10px] font-medium text-teal-300">
+              <RotateCcw size={10} /> came back
+            </span>
+          )}
+          {boughtThisMonth && (
+            <span className="inline-flex items-center gap-1 rounded-full border border-emerald-500/30 bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-300">
+              <ShoppingBag size={10} /> bought it
+            </span>
+          )}
+          {stretch.completedInStretch && (
+            <span className="inline-flex items-center gap-1 rounded-full border border-yellow-500/30 bg-yellow-500/15 px-1.5 py-0.5 text-[10px] font-medium text-yellow-300">
+              <CheckCircle2 size={10} /> finished
+            </span>
+          )}
+        </div>
+
+        {/* Stats line */}
+        <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-gray-400">
+          <span>{dateRangeLabel(stretch)}</span>
+          <span className="text-gray-600">·</span>
+          <span className="text-gray-300">{stretch.daysActive} day{stretch.daysActive !== 1 ? 's' : ''}</span>
+          <span className="text-gray-600">·</span>
+          <span className="text-gray-300">{fmtHours(stretch.totalHours)}</span>
+          <span
+            className={clsx(
+              'ml-1 rounded-full border px-1.5 py-0.5 text-[10px] font-medium',
+              CADENCE_STYLES[stretch.cadence]
+            )}
+          >
+            {stretch.cadenceLabel}
+          </span>
+        </div>
+
+        {/* Blurb */}
+        {blurb && <p className="mt-1.5 text-xs italic leading-snug text-gray-300/90">{blurb}</p>}
+      </div>
+    </div>
+  );
+}
+
+function PurchaseRow({ purchase }: { purchase: GameChroniclePurchase }) {
+  return (
+    <div className="flex items-center gap-3 rounded-xl border border-emerald-500/15 bg-emerald-500/[0.04] p-2.5">
+      <div className="h-10 w-10 shrink-0 overflow-hidden rounded-lg bg-white/5">
+        {purchase.thumbnail ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={purchase.thumbnail} alt={purchase.name} className="h-full w-full object-cover" />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-emerald-600/60">
+            <ShoppingBag size={16} />
+          </div>
+        )}
+      </div>
+      <div className="min-w-0 flex-1 text-sm">
+        <span className="font-medium text-white">{purchase.name}</span>
+        <span className="text-gray-400">
+          {' '}— bought {fmtDay(purchase.date)} for ${purchase.price}
+          {!purchase.played && <span className="text-amber-400/80"> · still untouched</span>}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/app/apps/game-analytics/components/TimelineView.tsx
+++ b/app/apps/game-analytics/components/TimelineView.tsx
@@ -23,6 +23,7 @@ import { FilmstripTimeline } from './FilmstripTimeline';
 import { GamingCalendar } from './GamingCalendar';
 import { CumulativeHoursCounter } from './CumulativeHoursCounter';
 import { StoryArcOverlay } from './StoryArcOverlay';
+import { StorySoFar } from './StorySoFar';
 import clsx from 'clsx';
 
 interface TimelineViewProps {
@@ -579,6 +580,9 @@ export function TimelineView({ games, gamesWithMetrics, updateGame, onLogTime, o
           initialPeriodKey={awardsHubConfig.periodKey}
         />
       )}
+
+      {/* Story So Far — scrollable chronicle of what you played and for how long */}
+      <StorySoFar games={games} />
 
       <WeekInReview data={weekInReviewData} allGames={games} weekOffset={weekOffset} maxWeeksBack={maxWeeksBack} onWeekChange={handleWeekChange} updateGame={updateGame} />
 

--- a/app/apps/game-analytics/lib/ai-game-service.ts
+++ b/app/apps/game-analytics/lib/ai-game-service.ts
@@ -540,6 +540,90 @@ If milestone data exists, write something specific and interesting about how fas
   }
 }
 
+// ─── Story So Far — chronicle stretch blurbs ─────────────────────────────────
+
+const CHRONICLE_BLURBS_CACHE = 'chronicle-blurbs-cache-v1';
+
+export interface ChronicleStretchInput {
+  key: string;       // stable id for this stretch
+  name: string;
+  genre?: string;
+  hours: number;
+  days: number;      // distinct days active
+  sessions: number;
+  cadenceLabel: string;
+  isReturn: boolean;
+  rating: number;
+  completed: boolean;
+  startLabel: string; // e.g. "May 3"
+}
+
+/**
+ * Generate one short, specific blurb per play stretch in a single batched AI
+ * call. Returns a map of stretch key → blurb. Cached per range key. Stretches
+ * not covered by the AI response simply won't appear in the map (caller falls
+ * back to the template blurb).
+ */
+export async function generateChronicleBlurbs(
+  rangeKey: string,
+  stretches: ChronicleStretchInput[]
+): Promise<Record<string, string>> {
+  const cacheAll = getCache<Record<string, Record<string, string>>>(CHRONICLE_BLURBS_CACHE) || {};
+  const cached = cacheAll[rangeKey];
+  if (cached && stretches.every(s => cached[s.key])) {
+    return cached;
+  }
+
+  if (stretches.length === 0) return {};
+
+  // Cap to keep the prompt sane; chronicle UI shows newest-relevant first anyway.
+  const capped = stretches.slice(0, 40);
+
+  const lines = capped.map((s, i) => {
+    const bits = [
+      `${s.hours % 1 === 0 ? s.hours : s.hours.toFixed(1)}h`,
+      `${s.days} day${s.days > 1 ? 's' : ''}`,
+      `${s.sessions} session${s.sessions > 1 ? 's' : ''}`,
+    ];
+    if (s.genre) bits.push(s.genre);
+    if (s.cadenceLabel) bits.push(s.cadenceLabel);
+    if (s.isReturn) bits.push('a comeback');
+    if (s.completed) bits.push('COMPLETED here');
+    bits.push(`rated ${s.rating}/10`);
+    return `${i + 1}. ${s.name} (started ${s.startLabel}): ${bits.join(', ')}`;
+  }).join('\n');
+
+  const prompt = `You are narrating a gamer's "story so far" — a chronological scroll of what they played and for how long. For EACH play stretch below, write ONE short blurb (max 14 words) that captures the feel of that chapter. Be specific with the numbers, warm, and a little cinematic. Don't start every line with "You". No quotes.
+
+${lines}
+
+Return exactly ${capped.length} lines, each in the format "N: blurb" (N is the number above). Nothing else.`;
+
+  try {
+    const model = getAIModel();
+    const result = await model.generateContent(prompt);
+    const text = result.response.text().trim();
+    const map: Record<string, string> = {};
+
+    text.split('\n').forEach(line => {
+      const match = line.match(/^\s*(\d+)[:.)]\s*(.+)$/);
+      if (match) {
+        const idx = parseInt(match[1], 10) - 1;
+        if (idx >= 0 && idx < capped.length) {
+          map[capped[idx].key] = match[2].trim().replace(/^["']|["']$/g, '');
+        }
+      }
+    });
+
+    cacheAll[rangeKey] = { ...(cacheAll[rangeKey] || {}), ...map };
+    setCache(CHRONICLE_BLURBS_CACHE, cacheAll);
+    return map;
+  } catch (error) {
+    console.error('AI chronicle blurbs error:', error);
+    return {};
+  }
+}
+
 /**
  * Clear all game AI caches
  */
@@ -551,6 +635,7 @@ export function clearGameAICache(): void {
   localStorage.removeItem(CHAPTER_TITLES_CACHE);
   localStorage.removeItem(MONTH_CHAPTER_TITLES_CACHE);
   localStorage.removeItem(WEEK_TITLES_CACHE);
+  localStorage.removeItem(CHRONICLE_BLURBS_CACHE);
 }
 
 // ─── Quarter blurbs ──────────────────────────────────────────────────────────

--- a/app/apps/game-analytics/lib/calculations.ts
+++ b/app/apps/game-analytics/lib/calculations.ts
@@ -13115,3 +13115,260 @@ export function getStoreUrl(gameName: string, platform?: string): { label: strin
 
   return stores;
 }
+
+// ============================================================
+// STORY SO FAR — Chronicle of play "stretches"
+// ============================================================
+//
+// The core idea: scroll through what you played, in order, and for how long.
+// A "stretch" is a span where a game had your attention — a run of play
+// sessions with no gap larger than `gapDays` (default 7). Stop playing for
+// more than a week and the next time you pick it up counts as a fresh stretch
+// (a "comeback").
+
+export type StoryRangeOption =
+  | 'this-month'
+  | 'this-quarter'
+  | 'last-3-months'
+  | 'year-so-far'
+  | 'last-year'
+  | 'this-year';
+
+export interface StoryRange {
+  option: StoryRangeOption;
+  label: string;       // e.g. "Year So Far"
+  start: Date;
+  end: Date;
+}
+
+/** Resolve a range option into concrete start/end dates. */
+export function resolveStoryRange(option: StoryRangeOption, now: Date = new Date()): StoryRange {
+  const y = now.getFullYear();
+  const m = now.getMonth();
+  const startOfDay = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0, 0);
+  const endOfDay = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59, 999);
+
+  switch (option) {
+    case 'this-month':
+      return { option, label: 'This Month', start: new Date(y, m, 1), end: endOfDay(now) };
+    case 'this-quarter': {
+      const qStartMonth = Math.floor(m / 3) * 3;
+      return { option, label: 'This Quarter', start: new Date(y, qStartMonth, 1), end: endOfDay(now) };
+    }
+    case 'last-3-months': {
+      const start = startOfDay(new Date(y, m, now.getDate()));
+      start.setMonth(start.getMonth() - 3);
+      return { option, label: 'Last 3 Months', start, end: endOfDay(now) };
+    }
+    case 'year-so-far':
+      return { option, label: 'Year So Far', start: new Date(y, 0, 1), end: endOfDay(now) };
+    case 'last-year':
+      return { option, label: 'Last Year', start: new Date(y - 1, 0, 1), end: new Date(y - 1, 11, 31, 23, 59, 59, 999) };
+    case 'this-year':
+      return { option, label: 'This Year', start: new Date(y, 0, 1), end: new Date(y, 11, 31, 23, 59, 59, 999) };
+  }
+}
+
+export type StretchCadence = 'binge' | 'steady' | 'one-off';
+
+export interface PlayStretch {
+  key: string;          // stable id: `${gameId}-${startDate}`
+  gameId: string;
+  gameName: string;
+  thumbnail?: string;
+  genre?: string;
+  rating: number;
+  startDate: string;    // YYYY-MM-DD, first session of the stretch
+  endDate: string;      // YYYY-MM-DD, last session of the stretch
+  monthKey: string;     // YYYY-MM of startDate (for grouping)
+  daysActive: number;   // distinct calendar days with a session
+  spanDays: number;     // inclusive days from first to last session
+  totalHours: number;
+  sessionCount: number;
+  avgGapDays: number;   // average gap (days) between sessions in this stretch
+  cadence: StretchCadence;
+  cadenceLabel: string; // human label, e.g. "every other day", "a binge", "one session"
+  isReturn: boolean;    // not the game's first stretch overall (a comeback)
+  returnOrdinal: number;// 1 = first stretch, 2 = second time around, ...
+  purchasedInRange: boolean; // game was bought during this stretch's window
+  completedInStretch: boolean; // game's completion date falls within the stretch
+}
+
+export interface GameChroniclePurchase {
+  gameId: string;
+  name: string;
+  thumbnail?: string;
+  date: string;
+  price: number;
+  played: boolean;      // did any session happen for this game in range?
+  monthKey: string;
+}
+
+export interface GameChronicle {
+  range: StoryRange;
+  stretches: PlayStretch[];          // sorted ascending by startDate
+  purchases: GameChroniclePurchase[];// purchases that fall inside the range
+  totalHours: number;
+  totalSessions: number;
+  uniqueGames: number;
+  monthKeys: string[];               // ascending list of month keys that have content
+}
+
+function describeCadence(spanDays: number, sessionCount: number, avgGapDays: number): { cadence: StretchCadence; label: string } {
+  if (sessionCount <= 1) return { cadence: 'one-off', label: 'a single session' };
+  // A "steady" drip: spread over time with a regular every-few-days rhythm.
+  if (spanDays >= 10 && sessionCount >= 4 && avgGapDays >= 2) {
+    if (avgGapDays <= 2.5) return { cadence: 'steady', label: 'almost every day' };
+    if (avgGapDays <= 4) return { cadence: 'steady', label: 'every other day' };
+    return { cadence: 'steady', label: 'a few times a week' };
+  }
+  // Concentrated play.
+  if (avgGapDays <= 1.5) return { cadence: 'binge', label: 'a daily binge' };
+  return { cadence: 'binge', label: 'a focused run' };
+}
+
+/**
+ * Split a single game's play logs into stretches (gap-split), across ALL time,
+ * so we can correctly mark comebacks. Returns stretches in chronological order.
+ */
+function buildGameStretches(game: Game, gapDays: number): PlayStretch[] {
+  const logs = (game.playLogs || [])
+    .filter(l => l.date)
+    .sort((a, b) => parseLocalDate(a.date).getTime() - parseLocalDate(b.date).getTime());
+  if (logs.length === 0) return [];
+
+  const DAY = 1000 * 60 * 60 * 24;
+  const groups: typeof logs[] = [];
+  let current: typeof logs = [logs[0]];
+
+  for (let i = 1; i < logs.length; i++) {
+    const prev = parseLocalDate(logs[i - 1].date).getTime();
+    const cur = parseLocalDate(logs[i].date).getTime();
+    const gap = (cur - prev) / DAY;
+    if (gap > gapDays) {
+      groups.push(current);
+      current = [logs[i]];
+    } else {
+      current.push(logs[i]);
+    }
+  }
+  groups.push(current);
+
+  const completionDate = game.status === 'Completed' ? game.endDate : undefined;
+
+  return groups.map((grp, idx) => {
+    const startDate = grp[0].date;
+    const endDate = grp[grp.length - 1].date;
+    const totalHours = grp.reduce((s, l) => s + l.hours, 0);
+    const distinctDays = new Set(grp.map(l => l.date)).size;
+    const spanDays = Math.round((parseLocalDate(endDate).getTime() - parseLocalDate(startDate).getTime()) / DAY) + 1;
+    const avgGapDays = grp.length > 1 ? (spanDays - 1) / (grp.length - 1) : 0;
+    const { cadence, label } = describeCadence(spanDays, grp.length, avgGapDays);
+
+    const completedInStretch = !!completionDate &&
+      parseLocalDate(completionDate) >= parseLocalDate(startDate) &&
+      parseLocalDate(completionDate) <= parseLocalDate(endDate);
+
+    return {
+      key: `${game.id}-${startDate}`,
+      gameId: game.id,
+      gameName: game.name,
+      thumbnail: game.thumbnail,
+      genre: game.genre,
+      rating: game.rating,
+      startDate,
+      endDate,
+      monthKey: startDate.substring(0, 7),
+      daysActive: distinctDays,
+      spanDays,
+      totalHours,
+      sessionCount: grp.length,
+      avgGapDays,
+      cadence,
+      cadenceLabel: label,
+      isReturn: idx > 0,
+      returnOrdinal: idx + 1,
+      purchasedInRange: false, // filled in by getGameChronicle
+      completedInStretch,
+    };
+  });
+}
+
+/**
+ * Build the "Story So Far" chronicle for a date range: an ordered list of play
+ * stretches (what you played and for how long), plus the purchases made in that
+ * window. Stretches are included when they overlap the range.
+ */
+export function getGameChronicle(games: Game[], range: StoryRange, gapDays: number = 7): GameChronicle {
+  const { start, end } = range;
+
+  const allStretches: PlayStretch[] = [];
+  games.forEach(game => {
+    const stretches = buildGameStretches(game, gapDays);
+    stretches.forEach(st => {
+      // Keep a stretch if it overlaps the range at all.
+      const sStart = parseLocalDate(st.startDate);
+      const sEnd = parseLocalDate(st.endDate);
+      if (sEnd >= start && sStart <= end) {
+        // Mark whether the game was bought during this stretch's window.
+        if (game.datePurchased) {
+          const p = parseLocalDate(game.datePurchased);
+          st.purchasedInRange = p >= sStart && p <= sEnd;
+        }
+        allStretches.push(st);
+      }
+    });
+  });
+
+  allStretches.sort((a, b) => parseLocalDate(a.startDate).getTime() - parseLocalDate(b.startDate).getTime());
+
+  // Purchases that fall inside the range.
+  const playedGameIds = new Set(allStretches.map(s => s.gameId));
+  const purchases: GameChroniclePurchase[] = games
+    .filter(g => g.datePurchased && g.status !== 'Wishlist')
+    .filter(g => {
+      const p = parseLocalDate(g.datePurchased!);
+      return p >= start && p <= end;
+    })
+    .map(g => ({
+      gameId: g.id,
+      name: g.name,
+      thumbnail: g.thumbnail,
+      date: g.datePurchased!,
+      price: g.price,
+      played: playedGameIds.has(g.id),
+      monthKey: g.datePurchased!.substring(0, 7),
+    }))
+    .sort((a, b) => parseLocalDate(a.date).getTime() - parseLocalDate(b.date).getTime());
+
+  const totalHours = allStretches.reduce((s, st) => s + st.totalHours, 0);
+  const totalSessions = allStretches.reduce((s, st) => s + st.sessionCount, 0);
+  const uniqueGames = new Set([...playedGameIds, ...purchases.map(p => p.gameId)]).size;
+
+  // Ascending list of month keys that have any stretch or purchase.
+  const monthKeySet = new Set<string>();
+  allStretches.forEach(s => monthKeySet.add(s.monthKey));
+  purchases.forEach(p => monthKeySet.add(p.monthKey));
+  const monthKeys = [...monthKeySet].sort();
+
+  return { range, stretches: allStretches, purchases, totalHours, totalSessions, uniqueGames, monthKeys };
+}
+
+/** Template (no-AI) blurb for a stretch — used as instant fallback before AI loads. */
+export function chronicleStretchBlurb(st: PlayStretch): string {
+  const h = st.totalHours;
+  const hrsText = h >= 1 ? `${h % 1 === 0 ? h : h.toFixed(1)} hours` : `${Math.round(h * 60)} min`;
+  if (st.completedInStretch) {
+    return `Saw it through to the end — ${hrsText} across ${st.daysActive} day${st.daysActive > 1 ? 's' : ''}.`;
+  }
+  if (st.cadence === 'steady') {
+    return `A steady habit — ${st.cadenceLabel} for ${hrsText}.`;
+  }
+  if (st.isReturn) {
+    return `Back for more — another ${hrsText} this time around.`;
+  }
+  if (st.sessionCount <= 1) {
+    return `A quick ${hrsText} taste, then onto the next thing.`;
+  }
+  return `${hrsText} over ${st.daysActive} days — ${st.cadenceLabel}.`;
+}


### PR DESCRIPTION
A scrollable, month-grouped chronicle of what you played and for how
long over a chosen range (this month, quarter, last 3 months, year so
far, last year, this year).

- buildStretches engine: groups a game's play logs into stretches
  (spans split on a 7+ day gap, so a return reads as a comeback), each
  carrying start/end, days active, hours, sessions, cadence (binge vs
  steady drip vs one-off), and completion/comeback/purchase flags.
- getGameChronicle / resolveStoryRange in calculations.ts.
- generateChronicleBlurbs: one batched AI call writes a short blurb per
  stretch, cached per range, with instant template fallbacks.
- StorySoFar.tsx: range-picker chips + scrollable list, rendered at the
  top of the Timeline tab.

https://claude.ai/code/session_01QZY6tVEUhxfdVB3cxBv6Wz