### PR TITLE
Improve buy queue: drag-prioritize, price tracking, AI gut-check, handoff

### DIFF
--- a/app/apps/game-analytics/components/AddToBuyQueueModal.tsx
+++ b/app/apps/game-analytics/components/AddToBuyQueueModal.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { useState, useEffect, useRef } from 'react';
-import { X, Search, Loader2, Star, Calendar, Check, ShoppingCart, AlertTriangle, Sparkles, Zap } from 'lucide-react';
+import { X, Search, Loader2, Star, Calendar, Check, ShoppingCart, AlertTriangle, Sparkles, Zap, RefreshCw, Library } from 'lucide-react';
 import { searchRAWGGames, RAWGGameData } from '../lib/rawg-api';
 import { PurchaseQueueEntry, Game } from '../lib/types';
 import { getImpulseCheckData, getSuggestedTargetPrice } from '../lib/calculations';
+import { fetchCheapestPrice } from '../lib/price-fetch';
 import clsx from 'clsx';
 
 const PLATFORMS = ['PS5', 'PS4', 'Xbox Series', 'Xbox One', 'Switch', 'PC', 'Other'];
@@ -15,6 +16,7 @@ interface Props {
   nextPriority: number;
   wishlistGames?: { name: string; platform?: string; genre?: string; thumbnail?: string }[];
   allGames?: Game[];
+  existingEntryNames?: string[];
 }
 
 function formatRelease(date: string | undefined): string {
@@ -31,12 +33,14 @@ function isUpcoming(date: string | undefined): boolean {
   return new Date(date) > new Date();
 }
 
-export function AddToBuyQueueModal({ onAdd, onClose, nextPriority, wishlistGames = [], allGames = [] }: Props) {
+export function AddToBuyQueueModal({ onAdd, onClose, nextPriority, wishlistGames = [], allGames = [], existingEntryNames = [] }: Props) {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<RAWGGameData[]>([]);
   const [searching, setSearching] = useState(false);
   const [selected, setSelected] = useState<RAWGGameData | null>(null);
   const [customName, setCustomName] = useState('');
+  const [fetchingPrice, setFetchingPrice] = useState(false);
+  const [fetchMsg, setFetchMsg] = useState<string | null>(null);
 
   // Form fields
   const [platform, setPlatform] = useState('PS5');
@@ -127,6 +131,34 @@ export function AddToBuyQueueModal({ onAdd, onClose, nextPriority, wishlistGames
   };
 
   const displayName = selected?.name || query.trim();
+
+  // Duplicate / already-owned guard (C3)
+  const checkName = (selected?.name || customName.trim() || query.trim()).toLowerCase();
+  const ownedDuplicate = checkName.length > 1
+    ? allGames.find(g => g.name.toLowerCase() === checkName && g.status !== 'Wishlist')
+    : undefined;
+  const queueDuplicate = checkName.length > 1 && existingEntryNames.some(n => n.toLowerCase() === checkName);
+
+  // Live price lookup (B3)
+  const handleFetchPrice = async () => {
+    const name = selected?.name || customName.trim() || query.trim();
+    if (!name) return;
+    setFetchingPrice(true);
+    setFetchMsg(null);
+    try {
+      const result = await fetchCheapestPrice(name);
+      if (result) {
+        setCurrentPrice(result.price.toString());
+        setFetchMsg(`${result.source}: $${result.price}`);
+      } else {
+        setFetchMsg('No price found — enter manually');
+      }
+    } catch {
+      setFetchMsg('Lookup failed — enter manually');
+    } finally {
+      setFetchingPrice(false);
+    }
+  };
 
   // Impulse check (Feature #8)
   const impulseCheck = isDayOneBuy && allGames.length > 0 ? getImpulseCheckData(allGames) : null;
@@ -361,6 +393,18 @@ export function AddToBuyQueueModal({ onAdd, onClose, nextPriority, wishlistGames
             </div>
           )}
 
+          {/* Duplicate / owned guard (C3) */}
+          {(ownedDuplicate || queueDuplicate) && (
+            <div className="flex items-center gap-2 p-3 rounded-xl border border-amber-500/20 bg-amber-500/[0.06] text-xs">
+              {ownedDuplicate ? <Library size={13} className="text-amber-400 flex-shrink-0" /> : <AlertTriangle size={13} className="text-amber-400 flex-shrink-0" />}
+              <span className="text-amber-400/90">
+                {ownedDuplicate
+                  ? `You already own "${ownedDuplicate.name}" in your library.`
+                  : 'This game is already in your buy queue.'}
+              </span>
+            </div>
+          )}
+
           {/* Prices */}
           <div className="grid grid-cols-3 gap-3">
             <div>
@@ -421,7 +465,22 @@ export function AddToBuyQueueModal({ onAdd, onClose, nextPriority, wishlistGames
             </button>
           )}
 
-          <p className="text-[11px] text-white/20 -mt-2">Prices are manual — check stores for current deals</p>
+          {/* Live price lookup (B3) */}
+          <div className="-mt-2 flex items-center gap-2">
+            <button
+              onClick={handleFetchPrice}
+              disabled={fetchingPrice || !displayName}
+              className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg bg-white/5 hover:bg-white/10 disabled:opacity-40 text-[11px] text-white/50 transition-all"
+            >
+              <RefreshCw size={11} className={clsx(fetchingPrice && 'animate-spin')} />
+              Check PC price
+            </button>
+            {fetchMsg ? (
+              <span className="text-[11px] text-white/40">{fetchMsg}</span>
+            ) : (
+              <span className="text-[11px] text-white/20">or enter prices manually</span>
+            )}
+          </div>
 
           {/* Notes */}
           <div>

--- a/app/apps/game-analytics/components/BuyQueueCard.tsx
+++ b/app/apps/game-analytics/components/BuyQueueCard.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import {
   ExternalLink, Check, Trash2, ChevronDown, ChevronUp, GripVertical,
   Calendar, Star, Zap, Target, TrendingDown, TrendingUp, Minus,
-  AlertCircle, Clock, Edit3, HelpCircle, ShoppingCart, Tag
+  Clock, Edit3, HelpCircle, ShoppingCart, Tag, RefreshCw, Moon, Sparkles
 } from 'lucide-react';
 import { PurchaseQueueEntry, PurchaseIntent } from '../lib/types';
 import { Game } from '../lib/types';
@@ -13,7 +13,11 @@ import {
   getPriceContext,
   getPredictedValue,
   getStoreUrl,
+  getPriceFreshness,
+  getCoolingOffData,
 } from '../lib/calculations';
+import { fetchCheapestPrice } from '../lib/price-fetch';
+import { PriceSparkline } from './PriceSparkline';
 import clsx from 'clsx';
 
 interface Props {
@@ -23,6 +27,8 @@ interface Props {
   onMarkPurchased: (id: string, price?: number) => Promise<void>;
   onDelete: (id: string) => void;
   onSetIntent?: (intent: PurchaseIntent) => void;
+  verdict?: string;
+  dragHandleProps?: React.HTMLAttributes<HTMLButtonElement>;
 }
 
 const INTENT_OPTIONS: { value: PurchaseIntent; label: string; icon: typeof ShoppingCart; active: string }[] = [
@@ -70,7 +76,7 @@ function getConfidenceColor(score: number): string {
   return 'text-red-400 bg-red-500/15';
 }
 
-export function BuyQueueCard({ entry, allGames, onUpdate, onMarkPurchased, onDelete, onSetIntent }: Props) {
+export function BuyQueueCard({ entry, allGames, onUpdate, onMarkPurchased, onDelete, onSetIntent, verdict, dragHandleProps }: Props) {
   const intent: PurchaseIntent = entry.intent ?? (entry.isMaybe ? 'maybe' : 'committed');
   const isMaybe = intent === 'maybe';
   const isDeferred = intent === 'deferred';
@@ -82,6 +88,8 @@ export function BuyQueueCard({ entry, allGames, onUpdate, onMarkPurchased, onDel
   const [releaseDateInput, setReleaseDateInput] = useState('');
   const [showPurchaseConfirm, setShowPurchaseConfirm] = useState(false);
   const [purchasePriceInput, setPurchasePriceInput] = useState('');
+  const [fetchingPrice, setFetchingPrice] = useState(false);
+  const [fetchMsg, setFetchMsg] = useState<string | null>(null);
 
   const upcoming = entry.releaseDate ? new Date(entry.releaseDate) > new Date() : false;
   const days = entry.releaseDate ? daysUntil(entry.releaseDate) : null;
@@ -127,6 +135,35 @@ export function BuyQueueCard({ entry, allGames, onUpdate, onMarkPurchased, onDel
       : null;
   const atLowest = lowestSeen != null && entry.currentPrice != null && entry.currentPrice <= lowestSeen;
 
+  // Stale-price nudge (B2) + cooling-off timer (C2)
+  const freshness = getPriceFreshness(entry);
+  const coolingOff = getCoolingOffData(entry);
+
+  // Live price lookup (B3) — best effort, manual fallback on failure
+  const handleFetchPrice = async () => {
+    setFetchingPrice(true);
+    setFetchMsg(null);
+    try {
+      const result = await fetchCheapestPrice(entry.gameName);
+      if (result) {
+        const today = new Date().toISOString().split('T')[0];
+        const history = entry.priceHistory ? [...entry.priceHistory] : [];
+        const last = history[history.length - 1];
+        if (last && last.date === today) history[history.length - 1] = { date: today, price: result.price };
+        else if (!last || last.price !== result.price) history.push({ date: today, price: result.price });
+        await onUpdate(entry.id, { currentPrice: result.price, priceHistory: history });
+        setFetchMsg(`${result.source}: $${result.price}`);
+      } else {
+        setFetchMsg('No price found — enter manually');
+      }
+    } catch {
+      setFetchMsg('Lookup failed — enter manually');
+    } finally {
+      setFetchingPrice(false);
+      setTimeout(() => setFetchMsg(null), 4000);
+    }
+  };
+
   const handleReleaseDateBlur = async () => {
     if (releaseDateInput) {
       await onUpdate(entry.id, { releaseDate: releaseDateInput });
@@ -153,8 +190,18 @@ export function BuyQueueCard({ entry, allGames, onUpdate, onMarkPurchased, onDel
   const countdown = getCountdownStyle();
 
   return (
+    <div className="flex items-stretch gap-1.5">
+      {dragHandleProps && (
+        <button
+          {...dragHandleProps}
+          className="flex-shrink-0 flex items-center justify-center w-6 rounded-lg text-white/15 hover:text-white/50 hover:bg-white/5 cursor-grab active:cursor-grabbing transition-colors touch-none"
+          aria-label="Drag to reorder"
+        >
+          <GripVertical size={14} />
+        </button>
+      )}
     <div className={clsx(
-      'rounded-xl overflow-hidden transition-all',
+      'flex-1 min-w-0 rounded-xl overflow-hidden transition-all',
       isMaybe
         ? 'border border-dashed border-amber-500/25 opacity-90'
         : isDeferred
@@ -272,6 +319,12 @@ export function BuyQueueCard({ entry, allGames, onUpdate, onMarkPurchased, onDel
               {entry.metacriticScore}
             </span>
           )}
+          {coolingOff && (
+            <span className="flex items-center gap-1" style={{ color: coolingOff.color }} title={coolingOff.message}>
+              <Moon size={9} />
+              {coolingOff.label} · {coolingOff.daysWaiting}d
+            </span>
+          )}
           {!upcoming && priceStatus && (
             <span className={clsx('flex items-center gap-1 ml-auto', priceStatus.color)}>
               <span className={clsx('w-1.5 h-1.5 rounded-full flex-shrink-0', priceStatus.dot)} />
@@ -345,6 +398,14 @@ export function BuyQueueCard({ entry, allGames, onUpdate, onMarkPurchased, onDel
                 {entry.currentPrice != null ? `$${entry.currentPrice}` : 'set'}
               </button>
             )}
+            <button
+              onClick={handleFetchPrice}
+              disabled={fetchingPrice}
+              title="Look up current PC price (CheapShark)"
+              className="text-white/20 hover:text-emerald-400 transition-colors"
+            >
+              <RefreshCw size={10} className={clsx(fetchingPrice && 'animate-spin')} />
+            </button>
           </div>
 
           {/* Target price — inline editable */}
@@ -379,18 +440,37 @@ export function BuyQueueCard({ entry, allGames, onUpdate, onMarkPurchased, onDel
           )}
         </div>
 
-        {/* Manual price history */}
+        {/* Stale-price nudge (B2) + live-fetch result */}
+        {!isMaybe && freshness.isStale && freshness.daysSinceCheck != null && entry.currentPrice != null && (
+          <button
+            onClick={handleFetchPrice}
+            disabled={fetchingPrice}
+            className="mt-1.5 flex items-center gap-1 text-[10px] text-amber-400/70 hover:text-amber-400 transition-colors"
+          >
+            <Clock size={9} />
+            Price last checked {freshness.daysSinceCheck}d ago — still ${entry.currentPrice}?
+            <RefreshCw size={9} className={clsx(fetchingPrice && 'animate-spin')} />
+          </button>
+        )}
+        {fetchMsg && (
+          <div className="mt-1 text-[10px] text-white/40">{fetchMsg}</div>
+        )}
+
+        {/* Manual price history + sparkline */}
         {lowestSeen != null && priceHistory.length >= 2 && (
-          <div className="mt-1.5 flex items-center gap-1.5 text-[10px] text-white/30">
-            {priceTrend === 'down' ? <TrendingDown size={9} className="text-emerald-400/60" /> :
-             priceTrend === 'up' ? <TrendingUp size={9} className="text-red-400/50" /> :
-             <Minus size={9} className="text-white/20" />}
-            <span>
-              Lowest seen <span className={clsx('font-medium', atLowest ? 'text-emerald-400' : 'text-white/50')}>${lowestSeen}</span>
-            </span>
-            <span className="text-white/15">·</span>
-            <span className="text-white/20">{priceHistory.length} prices tracked</span>
-            {atLowest && <span className="text-[9px] px-1 py-0.5 rounded bg-emerald-500/15 text-emerald-400">best yet</span>}
+          <div className="mt-1.5 flex items-center justify-between gap-2">
+            <div className="flex items-center gap-1.5 text-[10px] text-white/30 flex-wrap min-w-0">
+              {priceTrend === 'down' ? <TrendingDown size={9} className="text-emerald-400/60" /> :
+               priceTrend === 'up' ? <TrendingUp size={9} className="text-red-400/50" /> :
+               <Minus size={9} className="text-white/20" />}
+              <span>
+                Lowest <span className={clsx('font-medium', atLowest ? 'text-emerald-400' : 'text-white/50')}>${lowestSeen}</span>
+              </span>
+              <span className="text-white/15">·</span>
+              <span className="text-white/20">{priceHistory.length} tracked</span>
+              {atLowest && <span className="text-[9px] px-1 py-0.5 rounded bg-emerald-500/15 text-emerald-400">best yet</span>}
+            </div>
+            <PriceSparkline history={priceHistory} target={entry.targetPrice} />
           </div>
         )}
 
@@ -413,6 +493,14 @@ export function BuyQueueCard({ entry, allGames, onUpdate, onMarkPurchased, onDel
               predicted.predictedRating === 'Fair' ? 'text-yellow-400/50' : 'text-red-400/50'
             )} />
             <span className="italic">Predicted: {predicted.predictedRating} ({predicted.insight})</span>
+          </div>
+        )}
+
+        {/* AI verdict (C1) */}
+        {verdict && (
+          <div className="mt-1.5 flex items-start gap-1.5 text-[10px] text-purple-200/80 bg-purple-500/[0.07] border border-purple-500/10 rounded-lg px-2 py-1.5">
+            <Sparkles size={10} className="text-purple-400 flex-shrink-0 mt-0.5" />
+            <span className="italic leading-relaxed">{verdict}</span>
           </div>
         )}
 
@@ -547,6 +635,7 @@ export function BuyQueueCard({ entry, allGames, onUpdate, onMarkPurchased, onDel
           </div>
         </div>
       )}
+    </div>
     </div>
   );
 }

--- a/app/apps/game-analytics/components/BuyQueueTab.tsx
+++ b/app/apps/game-analytics/components/BuyQueueTab.tsx
@@ -3,9 +3,19 @@
 import { useState, useMemo } from 'react';
 import {
   Plus, ShoppingCart, Calendar, TrendingDown, Clock, PackageCheck,
-  ChevronDown, ChevronUp, AlertTriangle, Settings, Sparkles,
-  Tag, Gift, Target, Zap, BarChart2, Trophy, ArrowRight, HelpCircle
+  ChevronDown, ChevronUp, Settings, Sparkles,
+  Tag, Gift, Target, BarChart2, Trophy, ArrowRight, HelpCircle,
+  ArrowUpDown, Wand2, Loader2, ListOrdered, X
 } from 'lucide-react';
+import {
+  DndContext, closestCenter, KeyboardSensor, PointerSensor, TouchSensor,
+  useSensor, useSensors, DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  arrayMove, SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy,
+  useSortable,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import { Game, BudgetSettings, PurchaseQueueEntry } from '../lib/types';
 import { usePurchaseQueue } from '../hooks/usePurchaseQueue';
 import { AddToBuyQueueModal } from './AddToBuyQueueModal';
@@ -14,8 +24,27 @@ import {
   getQueueImpactSnapshot,
   getSaleSeasonIndicator,
   getPurchaseHistoryInsights,
+  getBuyConfidence,
+  getPredictedValue,
+  buildBuyQueueAIContext,
 } from '../lib/calculations';
+import { generateBuyQueueAdvice, BuyQueueAdvice } from '../lib/ai-buyqueue-service';
 import clsx from 'clsx';
+
+type SortMode = 'priority' | 'confidence' | 'price' | 'release' | 'value';
+
+const SORT_OPTIONS: { value: SortMode; label: string }[] = [
+  { value: 'priority', label: 'Manual' },
+  { value: 'confidence', label: 'Confidence' },
+  { value: 'price', label: 'Price' },
+  { value: 'release', label: 'Release' },
+  { value: 'value', label: 'Value' },
+];
+
+const priceOf = (e: PurchaseQueueEntry): number =>
+  e.targetPrice ?? e.currentPrice ?? e.msrpEstimate ?? 0;
+
+const VALUE_RANK: Record<string, number> = { Excellent: 4, Good: 3, Fair: 2, Poor: 1 };
 
 interface Props {
   userId: string | null;
@@ -24,21 +53,36 @@ interface Props {
   budgets: BudgetSettings[];
   yearSpent: number;
   onGoToBudget: () => void;
-  onAddGameToLibrary?: (data: { name: string; price: number; platform?: string; genre?: string; thumbnail?: string; datePurchased?: string; status: string }) => void;
+  onAddGameToLibrary?: (data: { name: string; price: number; platform?: string; genre?: string; thumbnail?: string; datePurchased?: string; status: string }) => Promise<string | undefined>;
+  onAddToPlayQueue?: (gameId: string) => Promise<void>;
+}
+
+/** Sortable wrapper so committed cards can be drag-reordered in Manual mode. */
+function SortableBuyCard({ entry, children }: { entry: PurchaseQueueEntry; children: (handleProps: React.HTMLAttributes<HTMLButtonElement>) => React.ReactNode }) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: entry.id });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+    zIndex: isDragging ? 10 : undefined,
+  };
+  return (
+    <div ref={setNodeRef} style={style}>
+      {children({ ...attributes, ...(listeners as React.HTMLAttributes<HTMLButtonElement>) })}
+    </div>
+  );
 }
 
 function formatMoney(n: number): string {
   return `$${n.toFixed(0)}`;
 }
 
-export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpent, onGoToBudget, onAddGameToLibrary }: Props) {
+export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpent, onGoToBudget, onAddGameToLibrary, onAddToPlayQueue }: Props) {
   const {
     entries,
     activeEntries,
     maybeEntries,
     deferredEntries,
-    upcomingEntries,
-    availableEntries,
     purchasedEntries,
     loading,
     plannedSpend,
@@ -50,12 +94,23 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
     deleteEntry,
     markPurchased,
     setIntent,
+    reorderEntries,
   } = usePurchaseQueue(userId);
 
   const [showAddModal, setShowAddModal] = useState(false);
   const [showPurchased, setShowPurchased] = useState(false);
   const [showStats, setShowStats] = useState(false);
   const [viewMode, setViewMode] = useState<'list' | 'timeline'>('list');
+  const [sortMode, setSortMode] = useState<SortMode>('priority');
+  const [aiAdvice, setAiAdvice] = useState<BuyQueueAdvice | null>(null);
+  const [aiLoading, setAiLoading] = useState(false);
+  const [justPurchased, setJustPurchased] = useState<{ name: string; gameId: string } | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 8 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
 
   const currentYear = new Date().getFullYear();
   const yearBudget = budgets.find(b => b.year === currentYear)?.yearlyBudget ?? null;
@@ -129,6 +184,54 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
     thumbnail: g.thumbnail,
   }));
 
+  // Display order respects the active sort; drag only rewires Manual priority.
+  const sortComparator = useMemo(() => {
+    return (a: PurchaseQueueEntry, b: PurchaseQueueEntry): number => {
+      switch (sortMode) {
+        case 'confidence': return getBuyConfidence(b, allGames).score - getBuyConfidence(a, allGames).score;
+        case 'price': return priceOf(a) - priceOf(b);
+        case 'release': {
+          const ra = a.releaseDate ? new Date(a.releaseDate).getTime() : Infinity;
+          const rb = b.releaseDate ? new Date(b.releaseDate).getTime() : Infinity;
+          return ra - rb;
+        }
+        case 'value': {
+          const va = VALUE_RANK[getPredictedValue(a, allGames)?.predictedRating ?? ''] ?? 0;
+          const vb = VALUE_RANK[getPredictedValue(b, allGames)?.predictedRating ?? ''] ?? 0;
+          return vb - va;
+        }
+        default: return a.priority - b.priority;
+      }
+    };
+  }, [sortMode, allGames]);
+
+  const sortedCommitted = useMemo(() => [...activeEntries].sort(sortComparator), [activeEntries, sortComparator]);
+  const sortedMaybe = useMemo(() => [...maybeEntries].sort(sortComparator), [maybeEntries, sortComparator]);
+  const sortedDeferred = useMemo(() => [...deferredEntries].sort(sortComparator), [deferredEntries, sortComparator]);
+
+  const dragEnabled = sortMode === 'priority';
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const ids = sortedCommitted.map(e => e.id);
+    const oldIndex = ids.indexOf(active.id as string);
+    const newIndex = ids.indexOf(over.id as string);
+    if (oldIndex < 0 || newIndex < 0) return;
+    reorderEntries(arrayMove(ids, oldIndex, newIndex));
+  };
+
+  const handleAskAI = async () => {
+    setAiLoading(true);
+    try {
+      const ctx = buildBuyQueueAIContext(activeEntries, maybeEntries, deferredEntries, allGames, yearBudget, yearSpent);
+      const advice = await generateBuyQueueAdvice(ctx);
+      setAiAdvice(advice);
+    } finally {
+      setAiLoading(false);
+    }
+  };
+
   const handleDelete = (id: string) => {
     if (window.confirm('Remove this game from your buy queue?')) {
       deleteEntry(id);
@@ -139,9 +242,9 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
     const entry = entries.find(e => e.id === id);
     await markPurchased(id, price);
 
-    // Auto-create in library (Feature #12)
+    // Auto-create in library (Feature #12), then offer the buy → play handoff (A3)
     if (entry && onAddGameToLibrary) {
-      onAddGameToLibrary({
+      const newGameId = await onAddGameToLibrary({
         name: entry.gameName,
         price: price ?? entry.currentPrice ?? entry.targetPrice ?? 0,
         platform: entry.platform,
@@ -150,8 +253,16 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
         datePurchased: new Date().toISOString().split('T')[0],
         status: 'Not Started',
       });
+      if (newGameId && onAddToPlayQueue) {
+        setJustPurchased({ name: entry.gameName, gameId: newGameId });
+      }
     }
   };
+
+  const existingEntryNames = useMemo(
+    () => [...activeEntries, ...maybeEntries, ...deferredEntries, ...purchasedEntries].map(e => e.gameName),
+    [activeEntries, maybeEntries, deferredEntries, purchasedEntries]
+  );
 
   // SVG budget ring helper
   const renderBudgetRing = () => {
@@ -332,6 +443,37 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
         </div>
 
         <div className="flex items-center gap-2">
+          {/* Sort control (A2) — list view only */}
+          {viewMode === 'list' && activeEntries.length > 1 && (
+            <div className="flex items-center gap-1.5 bg-white/5 rounded-lg pl-2 pr-1">
+              <ArrowUpDown size={12} className="text-white/30" />
+              <select
+                value={sortMode}
+                onChange={e => setSortMode(e.target.value as SortMode)}
+                className="bg-transparent text-xs text-white/60 py-1.5 pr-1 focus:outline-none cursor-pointer"
+              >
+                {SORT_OPTIONS.map(o => (
+                  <option key={o.value} value={o.value} className="bg-[#1a1a2e]">{o.label}</option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          {/* AI gut-check (C1) */}
+          {activeEntries.length > 0 && (
+            <button
+              onClick={handleAskAI}
+              disabled={aiLoading}
+              className={clsx(
+                'flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs transition-all',
+                aiAdvice ? 'bg-purple-500/15 text-purple-400' : 'bg-white/5 text-white/40 hover:text-white/60'
+              )}
+              title="Ask AI: should I buy these?"
+            >
+              {aiLoading ? <Loader2 size={13} className="animate-spin" /> : <Wand2 size={13} />}
+            </button>
+          )}
+
           {/* View toggle (Feature #14) */}
           <div className="flex items-center bg-white/5 rounded-lg overflow-hidden">
             <button
@@ -366,6 +508,47 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
           </button>
         </div>
       </div>
+
+      {/* AI gut-check banner (C1) */}
+      {aiAdvice && (
+        <div className="rounded-xl border border-purple-500/20 bg-purple-500/[0.06] p-3">
+          <div className="flex items-start gap-2">
+            <div className="w-7 h-7 rounded-full bg-purple-500/20 flex items-center justify-center flex-shrink-0">
+              <Wand2 size={14} className="text-purple-400" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="text-[11px] font-medium text-purple-400 uppercase tracking-wider mb-0.5">AI Gut Check</div>
+              <p className="text-xs text-white/60 leading-relaxed">{aiAdvice.gutCheck}</p>
+            </div>
+            <button onClick={() => setAiAdvice(null)} className="text-white/20 hover:text-white/50 transition-colors flex-shrink-0">
+              <X size={14} />
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Buy → Play handoff (A3) */}
+      {justPurchased && (
+        <div className="rounded-xl border border-emerald-500/25 bg-emerald-500/[0.07] p-3 flex items-center gap-2">
+          <PackageCheck size={15} className="text-emerald-400 flex-shrink-0" />
+          <span className="text-xs text-white/60 flex-1 min-w-0 truncate">
+            <span className="text-white/80 font-medium">{justPurchased.name}</span> added to your library. Queue it up to play?
+          </span>
+          <button
+            onClick={async () => {
+              if (onAddToPlayQueue) await onAddToPlayQueue(justPurchased.gameId);
+              setJustPurchased(null);
+            }}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-emerald-600 hover:bg-emerald-500 text-white text-xs font-medium transition-all flex-shrink-0"
+          >
+            <ListOrdered size={13} />
+            Up Next
+          </button>
+          <button onClick={() => setJustPurchased(null)} className="text-white/20 hover:text-white/50 transition-colors flex-shrink-0">
+            <X size={14} />
+          </button>
+        </div>
+      )}
 
       {/* Stats Dashboard (Feature #15) */}
       {showStats && activeEntries.length > 0 && (
@@ -415,6 +598,16 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
                 )}
                 <span className="text-white/40">{stats.impact.newLibrarySize} games</span>
               </div>
+              {/* Budget reaches only so far (D2) */}
+              {yearBudget != null && stats.impact.overflowItems.length > 0 && (
+                <div className="mt-2 flex items-start gap-1.5 text-[10px] text-amber-400/70">
+                  <Target size={10} className="flex-shrink-0 mt-0.5" />
+                  <span>
+                    Budget covers your top <span className="font-medium text-amber-400">{stats.impact.affordableCount}</span> pick{stats.impact.affordableCount !== 1 ? 's' : ''}.
+                    {' '}<span className="text-white/40">{stats.impact.overflowItems.slice(0, 3).join(', ')}{stats.impact.overflowItems.length > 3 ? '…' : ''}</span> spill over.
+                  </span>
+                </div>
+              )}
               {stats.impact.genreBreakdown.length > 0 && (
                 <div className="flex items-center gap-1.5 mt-2 flex-wrap">
                   {stats.impact.genreBreakdown.slice(0, 4).map(g => (
@@ -482,53 +675,56 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
       {/* List View */}
       {viewMode === 'list' && (
         <>
-          {/* Upcoming section */}
-          {upcomingEntries.length > 0 && (
-            <div className="space-y-2">
-              <div className="flex items-center gap-2">
-                <Calendar size={13} className="text-purple-400" />
-                <h3 className="text-xs font-medium text-white/50 uppercase tracking-wider">Upcoming</h3>
-                <span className="text-[11px] text-white/25">{upcomingEntries.length}</span>
-              </div>
-              <div className="space-y-2">
-                {upcomingEntries.map(entry => (
-                  <BuyQueueCard
-                    key={entry.id}
-                    entry={entry}
-                    allGames={allGames}
-                    onUpdate={updateEntry}
-                    onMarkPurchased={handleMarkPurchased}
-                    onDelete={handleDelete}
-                    onSetIntent={(intent) => setIntent(entry.id, intent)}
-                  />
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Released / Price Watch section */}
-          {availableEntries.length > 0 && (
+          {/* Watching section — committed, drag-to-prioritize in Manual mode (A1/A2) */}
+          {sortedCommitted.length > 0 && (
             <div className="space-y-2">
               <div className="flex items-center gap-2">
                 <Clock size={13} className="text-emerald-400" />
-                <h3 className="text-xs font-medium text-white/50 uppercase tracking-wider">
-                  {upcomingEntries.length > 0 ? 'Released — Price Watch' : 'Watching'}
-                </h3>
-                <span className="text-[11px] text-white/25">{availableEntries.length}</span>
+                <h3 className="text-xs font-medium text-white/50 uppercase tracking-wider">Watching</h3>
+                <span className="text-[11px] text-white/25">{sortedCommitted.length}</span>
+                {dragEnabled && sortedCommitted.length > 1 && (
+                  <span className="text-[10px] text-white/20 ml-auto">Drag to prioritize</span>
+                )}
               </div>
-              <div className="space-y-2">
-                {availableEntries.map(entry => (
-                  <BuyQueueCard
-                    key={entry.id}
-                    entry={entry}
-                    allGames={allGames}
-                    onUpdate={updateEntry}
-                    onMarkPurchased={handleMarkPurchased}
-                    onDelete={handleDelete}
-                    onSetIntent={(intent) => setIntent(entry.id, intent)}
-                  />
-                ))}
-              </div>
+              {dragEnabled ? (
+                <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+                  <SortableContext items={sortedCommitted.map(e => e.id)} strategy={verticalListSortingStrategy}>
+                    <div className="space-y-2">
+                      {sortedCommitted.map(entry => (
+                        <SortableBuyCard key={entry.id} entry={entry}>
+                          {(handleProps) => (
+                            <BuyQueueCard
+                              entry={entry}
+                              allGames={allGames}
+                              onUpdate={updateEntry}
+                              onMarkPurchased={handleMarkPurchased}
+                              onDelete={handleDelete}
+                              onSetIntent={(intent) => setIntent(entry.id, intent)}
+                              verdict={aiAdvice?.verdicts[entry.gameName]}
+                              dragHandleProps={handleProps}
+                            />
+                          )}
+                        </SortableBuyCard>
+                      ))}
+                    </div>
+                  </SortableContext>
+                </DndContext>
+              ) : (
+                <div className="space-y-2">
+                  {sortedCommitted.map(entry => (
+                    <BuyQueueCard
+                      key={entry.id}
+                      entry={entry}
+                      allGames={allGames}
+                      onUpdate={updateEntry}
+                      onMarkPurchased={handleMarkPurchased}
+                      onDelete={handleDelete}
+                      onSetIntent={(intent) => setIntent(entry.id, intent)}
+                      verdict={aiAdvice?.verdicts[entry.gameName]}
+                    />
+                  ))}
+                </div>
+              )}
             </div>
           )}
 
@@ -544,7 +740,7 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
                 )}
               </div>
               <div className="space-y-2">
-                {maybeEntries.map(entry => (
+                {sortedMaybe.map(entry => (
                   <BuyQueueCard
                     key={entry.id}
                     entry={entry}
@@ -553,6 +749,7 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
                     onMarkPurchased={handleMarkPurchased}
                     onDelete={handleDelete}
                     onSetIntent={(intent) => setIntent(entry.id, intent)}
+                    verdict={aiAdvice?.verdicts[entry.gameName]}
                   />
                 ))}
               </div>
@@ -571,7 +768,7 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
                 )}
               </div>
               <div className="space-y-2">
-                {deferredEntries.map(entry => (
+                {sortedDeferred.map(entry => (
                   <BuyQueueCard
                     key={entry.id}
                     entry={entry}
@@ -580,6 +777,7 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
                     onMarkPurchased={handleMarkPurchased}
                     onDelete={handleDelete}
                     onSetIntent={(intent) => setIntent(entry.id, intent)}
+                    verdict={aiAdvice?.verdicts[entry.gameName]}
                   />
                 ))}
               </div>
@@ -594,7 +792,12 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
           {monthlyPlan.length === 0 && activeEntries.length === 0 && (
             <p className="text-center text-white/25 text-sm py-8">No games to show in the timeline</p>
           )}
-          {monthlyPlan.map(month => (
+          {monthlyPlan.map(month => {
+            const monthlyBudget = yearBudget != null ? yearBudget / 12 : null;
+            const overMonth = monthlyBudget != null && month.totalCost > monthlyBudget;
+            const pacePct = monthlyBudget != null && monthlyBudget > 0
+              ? Math.min(100, (month.totalCost / monthlyBudget) * 100) : 0;
+            return (
             <div key={month.month} className="space-y-2">
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
@@ -603,9 +806,20 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
                   <span className="text-[11px] text-white/25">{month.entries.length} game{month.entries.length !== 1 ? 's' : ''}</span>
                 </div>
                 {month.totalCost > 0 && (
-                  <span className="text-xs text-white/30">{formatMoney(month.totalCost)}</span>
+                  <span className={clsx('text-xs', overMonth ? 'text-red-400' : 'text-white/30')}>
+                    {formatMoney(month.totalCost)}
+                    {monthlyBudget != null && <span className="text-white/20"> / {formatMoney(monthlyBudget)}</span>}
+                  </span>
                 )}
               </div>
+              {monthlyBudget != null && month.totalCost > 0 && (
+                <div className="h-1 rounded-full bg-white/5 overflow-hidden">
+                  <div
+                    className={clsx('h-full rounded-full transition-all', overMonth ? 'bg-red-500/70' : 'bg-emerald-500/60')}
+                    style={{ width: `${pacePct}%` }}
+                  />
+                </div>
+              )}
               {month.entries.length > 0 ? (
                 <div className="space-y-2">
                   {month.entries.map(entry => (
@@ -624,7 +838,8 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
                 <div className="text-center py-4 text-[11px] text-white/15">No planned purchases</div>
               )}
             </div>
-          ))}
+            );
+          })}
         </div>
       )}
 
@@ -728,6 +943,7 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
           nextPriority={activeEntries.length + 1}
           wishlistGames={wishlistForModal}
           allGames={allGames}
+          existingEntryNames={existingEntryNames}
         />
       )}
     </div>

--- a/app/apps/game-analytics/components/PriceSparkline.tsx
+++ b/app/apps/game-analytics/components/PriceSparkline.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { PriceObservation } from '../lib/types';
+
+interface Props {
+  history: PriceObservation[];
+  target?: number | null;
+  width?: number;
+  height?: number;
+}
+
+/**
+ * Tiny inline SVG sparkline of manually-tracked prices over time.
+ * Renders the trend line, a target threshold, and a marker on the latest point.
+ */
+export function PriceSparkline({ history, target, width = 120, height = 32 }: Props) {
+  if (!history || history.length < 2) return null;
+
+  const prices = history.map(h => h.price);
+  const min = Math.min(...prices, target ?? Infinity);
+  const max = Math.max(...prices, target ?? -Infinity);
+  const range = max - min || 1;
+  const pad = 3;
+
+  const x = (i: number) => pad + (i / (history.length - 1)) * (width - pad * 2);
+  const y = (price: number) => pad + (1 - (price - min) / range) * (height - pad * 2);
+
+  const points = history.map((h, i) => `${x(i).toFixed(1)},${y(h.price).toFixed(1)}`).join(' ');
+  const last = history[history.length - 1];
+  const first = history[0];
+  const trendDown = last.price < first.price;
+  const lineColor = trendDown ? '#34d399' : last.price > first.price ? '#f87171' : '#9ca3af';
+  const targetY = target != null ? y(target) : null;
+
+  return (
+    <svg width={width} height={height} className="overflow-visible">
+      {targetY != null && (
+        <line
+          x1={pad} y1={targetY} x2={width - pad} y2={targetY}
+          stroke="#34d399" strokeWidth={1} strokeDasharray="3 3" opacity={0.4}
+        />
+      )}
+      <polyline
+        points={points}
+        fill="none"
+        stroke={lineColor}
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle cx={x(history.length - 1)} cy={y(last.price)} r={2.5} fill={lineColor} />
+    </svg>
+  );
+}

--- a/app/apps/game-analytics/hooks/usePurchaseQueue.ts
+++ b/app/apps/game-analytics/hooks/usePurchaseQueue.ts
@@ -97,6 +97,22 @@ export function usePurchaseQueue(userId: string | null) {
     await updateEntry(id, { intent, isMaybe: intent === 'maybe' });
   }, [updateEntry]);
 
+  // Reassign `priority` to match a new manual order. Optimistic with rollback.
+  const reorderEntries = useCallback(async (orderedIds: string[]): Promise<void> => {
+    const snapshot = entriesRef.current;
+    const idToPriority = new Map(orderedIds.map((id, i) => [id, i + 1]));
+    setEntries(prev => sortEntries(prev.map(e =>
+      idToPriority.has(e.id) ? { ...e, priority: idToPriority.get(e.id)! } : e
+    )));
+    try {
+      await Promise.all(orderedIds.map((id, i) => purchaseQueueRepository.update(id, { priority: i + 1 })));
+    } catch (e) {
+      console.error('Failed to reorder purchase queue', e);
+      setEntries(snapshot);
+      throw e;
+    }
+  }, []);
+
   // ── Derived buckets ──────────────────────────────────────────────
   const today = new Date();
   today.setHours(0, 0, 0, 0);
@@ -147,6 +163,7 @@ export function usePurchaseQueue(userId: string | null) {
     deleteEntry,
     markPurchased,
     setIntent,
+    reorderEntries,
     refresh,
   };
 }

--- a/app/apps/game-analytics/lib/ai-buyqueue-service.ts
+++ b/app/apps/game-analytics/lib/ai-buyqueue-service.ts
@@ -1,0 +1,165 @@
+'use client';
+
+import { getAI, getGenerativeModel, GoogleAIBackend } from 'firebase/ai';
+import { initializeApp, getApps } from 'firebase/app';
+import { BuyQueueAIContext } from './calculations';
+
+const firebaseConfig = {
+  apiKey: "AIzaSyBS3IVvszDrm_zjjXu8TATgs1H-FlegHtM",
+  authDomain: "oneapp-943e3.firebaseapp.com",
+  projectId: "oneapp-943e3",
+  storageBucket: "oneapp-943e3.firebasestorage.app",
+  messagingSenderId: "1052736128978",
+  appId: "1:1052736128978:web:9d42b47c6a343eac35aa0b",
+};
+
+function getAIModel() {
+  const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+  const ai = getAI(app, { backend: new GoogleAIBackend() });
+  return getGenerativeModel(ai, { model: "gemini-2.5-flash" });
+}
+
+export interface BuyQueueAdvice {
+  gutCheck: string;
+  verdicts: Record<string, string>; // gameName -> one-line verdict
+}
+
+const CACHE_KEY = 'buyqueue-ai-cache';
+const CACHE_TTL = 1000 * 60 * 60 * 4; // 4 hours
+
+interface CachedAdvice extends BuyQueueAdvice {
+  timestamp: number;
+  hash: string;
+}
+
+function getHash(ctx: BuyQueueAIContext): string {
+  return [
+    ctx.yearBudget ?? 'nb',
+    Math.round(ctx.yearSpent),
+    Math.round(ctx.totalPlannedCost),
+    ...ctx.entries.map(e => `${e.name}:${e.intent}:${e.targetPrice ?? '-'}:${e.currentPrice ?? '-'}`),
+  ].join('|');
+}
+
+function readCache(): CachedAdvice | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    const cached: CachedAdvice = JSON.parse(raw);
+    if (Date.now() - cached.timestamp > CACHE_TTL) return null;
+    return cached;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(advice: BuyQueueAdvice, hash: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({ ...advice, hash, timestamp: Date.now() }));
+  } catch {
+    // ignore storage errors
+  }
+}
+
+export function clearBuyQueueAICache(): void {
+  if (typeof window === 'undefined') return;
+  try { localStorage.removeItem(CACHE_KEY); } catch { /* ignore */ }
+}
+
+function buildPrompt(ctx: BuyQueueAIContext): string {
+  const list = ctx.entries.map(e => {
+    const price = e.targetPrice ?? e.currentPrice ?? e.msrp ?? 0;
+    const tags = [e.isDayOneBuy ? 'day-one' : null, `${e.daysWaiting}d waiting`, `${e.confidence}% confidence`]
+      .filter(Boolean).join(', ');
+    return `- ${e.name} (${e.genre}, ${e.platform}) ~$${price} [${tags}]`;
+  }).join('\n');
+
+  return `You are a sharp, funny, financially-honest gaming buddy reviewing someone's game BUY queue (games they're considering purchasing — not playing).
+
+THEIR SITUATION:
+- Budget this year: ${ctx.yearBudget != null ? `$${ctx.yearBudget}` : 'not set'}
+- Already spent: $${ctx.yearSpent}
+- Planned spend in queue: $${ctx.totalPlannedCost}
+- Budget remaining after queue: ${ctx.budgetRemaining != null ? `$${ctx.budgetRemaining}` : 'unknown'}
+- Backlog (owned, barely/never played): ${ctx.backlogSize} games
+- Full-price games they barely touched: ${ctx.unplayedFullPriceCount}
+- Completion rate: ${ctx.completionRate}%
+- Favorite genres: ${ctx.topGenres.join(', ') || 'unknown'}
+- Sale season: ${ctx.saleSeason ?? 'none active'}
+
+THE BUY QUEUE (${ctx.committedCount} committed, ${ctx.maybeCount} maybe, ${ctx.deferredCount} deferred):
+${list || '(empty)'}
+
+Respond in EXACTLY this format, nothing else:
+GUTCHECK: <2-3 sentences. An honest, specific take on whether this spend makes sense given their backlog, budget, and habits. Reference real numbers. Be witty but useful — call out impulse risks or genuinely smart picks.>
+VERDICT: <exact game name> | <one short punchy sentence: buy now / wait for sale / skip it / no-brainer, with a quick reason>
+(one VERDICT line per committed game, using the exact game name)`;
+}
+
+function parseResponse(text: string, ctx: BuyQueueAIContext): BuyQueueAdvice {
+  const verdicts: Record<string, string> = {};
+  let gutCheck = '';
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    if (line.toUpperCase().startsWith('GUTCHECK:')) {
+      gutCheck = line.slice(line.indexOf(':') + 1).trim();
+    } else if (line.toUpperCase().startsWith('VERDICT:')) {
+      const body = line.slice(line.indexOf(':') + 1).trim();
+      const pipe = body.indexOf('|');
+      if (pipe > 0) {
+        const name = body.slice(0, pipe).trim();
+        const verdict = body.slice(pipe + 1).trim();
+        // Match against a real entry name (case-insensitive, tolerant of fuzz)
+        const match = ctx.entries.find(e =>
+          e.name.toLowerCase() === name.toLowerCase() ||
+          e.name.toLowerCase().includes(name.toLowerCase()) ||
+          name.toLowerCase().includes(e.name.toLowerCase())
+        );
+        if (match && verdict) verdicts[match.name] = verdict;
+      }
+    }
+  }
+  if (!gutCheck) gutCheck = text.trim().split('\n')[0] || 'Your queue is looking interesting.';
+  return { gutCheck, verdicts };
+}
+
+export async function generateBuyQueueAdvice(ctx: BuyQueueAIContext): Promise<BuyQueueAdvice> {
+  const hash = getHash(ctx);
+  const cached = readCache();
+  if (cached && cached.hash === hash) {
+    return { gutCheck: cached.gutCheck, verdicts: cached.verdicts };
+  }
+
+  try {
+    const model = getAIModel();
+    const result = await model.generateContent(buildPrompt(ctx));
+    const advice = parseResponse(result.response.text(), ctx);
+    writeCache(advice, hash);
+    return advice;
+  } catch (error) {
+    console.error('Buy queue AI advice error:', error);
+    return getFallbackAdvice(ctx);
+  }
+}
+
+function getFallbackAdvice(ctx: BuyQueueAIContext): BuyQueueAdvice {
+  const verdicts: Record<string, string> = {};
+  ctx.entries.forEach(e => {
+    if (e.confidence >= 75) verdicts[e.name] = 'Strong pick for your taste — grab it when the price is right.';
+    else if (e.isDayOneBuy && ctx.unplayedFullPriceCount > 3) verdicts[e.name] = 'Day-one buy, but your backlog says maybe wait for a sale.';
+    else verdicts[e.name] = 'Solid maybe — keep watching the price.';
+  });
+
+  let gutCheck: string;
+  if (ctx.budgetRemaining != null && ctx.budgetRemaining < 0) {
+    gutCheck = `This queue runs you $${Math.abs(ctx.budgetRemaining)} over budget. With ${ctx.backlogSize} games already waiting, maybe trim the list before you check out.`;
+  } else if (ctx.backlogSize > 5) {
+    gutCheck = `You've got ${ctx.backlogSize} unplayed games already. The queue isn't the problem — finding time to play is. Buy the sure things, defer the rest.`;
+  } else {
+    gutCheck = `$${ctx.totalPlannedCost} planned across ${ctx.committedCount} games. Reasonable — just let the prices come to you instead of paying full freight.`;
+  }
+  return { gutCheck, verdicts };
+}

--- a/app/apps/game-analytics/lib/calculations.ts
+++ b/app/apps/game-analytics/lib/calculations.ts
@@ -12694,6 +12694,8 @@ export function getQueueImpactSnapshot(
   overBudget: number | null;
   newLibrarySize: string;
   genreBreakdown: { genre: string; count: number }[];
+  affordableCount: number;
+  overflowItems: string[];
 } {
   const active = entries.filter(e => !e.purchased);
   const totalCost = active.reduce((s, e) => s + (e.targetPrice ?? e.currentPrice ?? e.msrpEstimate ?? 0), 0);
@@ -12703,7 +12705,21 @@ export function getQueueImpactSnapshot(
   active.forEach(e => { if (e.genre) genres[e.genre] = (genres[e.genre] || 0) + 1; });
   const genreBreakdown = Object.entries(genres).map(([genre, count]) => ({ genre, count })).sort((a, b) => b.count - a.count);
 
-  return { totalCost, overBudget, newLibrarySize: `+${active.length}`, genreBreakdown };
+  // Walk the queue in priority order and find where it busts the budget (D2)
+  let affordableCount = active.length;
+  const overflowItems: string[] = [];
+  if (yearBudget != null) {
+    const ordered = [...active].sort((a, b) => a.priority - b.priority);
+    let running = yearSpent;
+    affordableCount = 0;
+    for (const e of ordered) {
+      running += (e.targetPrice ?? e.currentPrice ?? e.msrpEstimate ?? 0);
+      if (running <= yearBudget) affordableCount++;
+      else overflowItems.push(e.gameName);
+    }
+  }
+
+  return { totalCost, overBudget, newLibrarySize: `+${active.length}`, genreBreakdown, affordableCount, overflowItems };
 }
 
 /**
@@ -12771,6 +12787,152 @@ export function getPurchaseHistoryInsights(entries: PurchaseQueueEntry[]): {
   const avgWaitDays = waits.length > 0 ? Math.round(waits.reduce((s, w) => s + w, 0) / waits.length) : 0;
 
   return { totalSaved, avgWaitDays, gamesFromQueue: purchased.length };
+}
+
+/**
+ * Price Freshness — how long since the "current price" was last touched.
+ * Manual prices go stale fast; this drives a "still $60?" nudge (B2).
+ */
+export function getPriceFreshness(entry: PurchaseQueueEntry): {
+  daysSinceCheck: number | null;
+  isStale: boolean;
+  lastChecked: string | null;
+} {
+  let lastDate: string | null = null;
+  if (entry.priceHistory && entry.priceHistory.length > 0) {
+    lastDate = entry.priceHistory[entry.priceHistory.length - 1].date;
+  } else if (entry.currentPrice != null && entry.updatedAt) {
+    lastDate = entry.updatedAt.split('T')[0];
+  }
+  if (!lastDate) return { daysSinceCheck: null, isStale: false, lastChecked: null };
+  const days = Math.floor((Date.now() - new Date(lastDate).getTime()) / 86400000);
+  return { daysSinceCheck: days, isStale: days >= 21, lastChecked: lastDate };
+}
+
+/**
+ * Impulse Cooling-Off Timer — restraint analog to the play queue's shame timer.
+ * Only nudges committed buys (maybe/deferred are already "waiting"). (C2)
+ */
+export type CoolingOffTier = 'sleep-on-it' | 'cooling' | 'considered' | 'seasoned';
+export function getCoolingOffData(entry: PurchaseQueueEntry): {
+  daysWaiting: number;
+  tier: CoolingOffTier;
+  label: string;
+  message: string;
+  color: string;
+} | null {
+  if (entry.purchased) return null;
+  const intent = entry.intent ?? (entry.isMaybe ? 'maybe' : 'committed');
+  if (intent !== 'committed') return null;
+  const start = entry.addedAt || entry.createdAt;
+  if (!start) return null;
+  const days = Math.floor((Date.now() - new Date(start).getTime()) / 86400000);
+
+  if (days <= 2) return {
+    daysWaiting: days, tier: 'sleep-on-it', label: 'Sleep on it', color: '#fbbf24',
+    message: days <= 0 ? 'Just added — give it a night before you commit.' : `${days}d in — still want it tomorrow?`,
+  };
+  if (days <= 7) return {
+    daysWaiting: days, tier: 'cooling', label: 'Cooling off', color: '#60a5fa',
+    message: `${days} days and still on your mind. The interest is real.`,
+  };
+  if (days <= 30) return {
+    daysWaiting: days, tier: 'considered', label: 'Well considered', color: '#34d399',
+    message: `${days} days of patience — this is a deliberate buy, not an impulse.`,
+  };
+  return {
+    daysWaiting: days, tier: 'seasoned', label: 'Long-considered', color: '#a78bfa',
+    message: `${days} days on your list. You clearly mean it — or it's time to let go.`,
+  };
+}
+
+/**
+ * Buy Queue AI Context — rich snapshot for the "Ask AI" gut-check (C1).
+ */
+export interface BuyQueueAIContext {
+  entries: {
+    name: string;
+    genre: string;
+    platform: string;
+    intent: string;
+    isDayOneBuy: boolean;
+    targetPrice: number | null;
+    currentPrice: number | null;
+    msrp: number | null;
+    daysWaiting: number;
+    confidence: number;
+  }[];
+  totalPlannedCost: number;
+  committedCount: number;
+  maybeCount: number;
+  deferredCount: number;
+  yearBudget: number | null;
+  yearSpent: number;
+  budgetRemaining: number | null;
+  backlogSize: number;
+  unplayedFullPriceCount: number;
+  completionRate: number;
+  topGenres: string[];
+  saleSeason: string | null;
+}
+
+export function buildBuyQueueAIContext(
+  committedEntries: PurchaseQueueEntry[],
+  maybeEntries: PurchaseQueueEntry[],
+  deferredEntries: PurchaseQueueEntry[],
+  allGames: Game[],
+  yearBudget: number | null,
+  yearSpent: number
+): BuyQueueAIContext {
+  const now = Date.now();
+  const entries = committedEntries.map(e => {
+    const start = e.addedAt || e.createdAt;
+    const daysWaiting = start ? Math.floor((now - new Date(start).getTime()) / 86400000) : 0;
+    return {
+      name: e.gameName,
+      genre: e.genre || 'Unknown',
+      platform: e.platform || 'Unknown',
+      intent: e.intent ?? 'committed',
+      isDayOneBuy: e.isDayOneBuy,
+      targetPrice: e.targetPrice ?? null,
+      currentPrice: e.currentPrice ?? null,
+      msrp: e.msrpEstimate ?? null,
+      daysWaiting,
+      confidence: getBuyConfidence(e, allGames).score,
+    };
+  });
+
+  const totalPlannedCost = committedEntries.reduce(
+    (s, e) => s + (e.targetPrice ?? e.currentPrice ?? e.msrpEstimate ?? 0), 0
+  );
+
+  const owned = allGames.filter(g => g.status !== 'Wishlist');
+  const completed = owned.filter(g => g.status === 'Completed').length;
+  const completionRate = owned.length > 0 ? Math.round((completed / owned.length) * 100) : 0;
+  const backlogSize = owned.filter(g => g.status === 'Not Started' || getTotalHours(g) < 1).length;
+  const unplayedFullPriceCount = owned.filter(g => g.price >= 50 && !g.acquiredFree && getTotalHours(g) < 2).length;
+
+  const genreCounts: Record<string, number> = {};
+  owned.forEach(g => { if (g.genre) genreCounts[g.genre] = (genreCounts[g.genre] || 0) + 1; });
+  const topGenres = Object.entries(genreCounts).sort((a, b) => b[1] - a[1]).slice(0, 3).map(([g]) => g);
+
+  const sale = getSaleSeasonIndicator();
+
+  return {
+    entries,
+    totalPlannedCost,
+    committedCount: committedEntries.length,
+    maybeCount: maybeEntries.length,
+    deferredCount: deferredEntries.length,
+    yearBudget,
+    yearSpent,
+    budgetRemaining: yearBudget != null ? yearBudget - yearSpent - totalPlannedCost : null,
+    backlogSize,
+    unplayedFullPriceCount,
+    completionRate,
+    topGenres,
+    saleSeason: sale?.inSeason ? sale.label : null,
+  };
 }
 
 // ── Game Card Deep Insights ──────────────────────────────────────────────────

--- a/app/apps/game-analytics/lib/price-fetch.ts
+++ b/app/apps/game-analytics/lib/price-fetch.ts
@@ -1,0 +1,54 @@
+'use client';
+
+/**
+ * Best-effort live price lookup via CheapShark (free, keyless, PC/Steam-centric).
+ * Runs client-side from the user's browser, so it works regardless of how the
+ * app is hosted. Console prices aren't covered — treat the result as a
+ * "lowest PC price" reference point, not gospel.
+ */
+
+export interface FetchedPrice {
+  price: number;       // rounded USD
+  title: string;       // matched store title
+  source: string;      // e.g. "CheapShark (PC)"
+}
+
+const CHEAPSHARK_GAMES = 'https://www.cheapshark.com/api/1.0/games';
+
+interface CheapSharkGame {
+  external: string;
+  cheapest: string;
+  cheapestDealID: string;
+}
+
+function bestMatch(name: string, results: CheapSharkGame[]): CheapSharkGame | null {
+  if (results.length === 0) return null;
+  const lower = name.trim().toLowerCase();
+  const exact = results.find(r => r.external?.toLowerCase() === lower);
+  if (exact) return exact;
+  const startsWith = results.find(r => r.external?.toLowerCase().startsWith(lower));
+  return startsWith ?? results[0];
+}
+
+export async function fetchCheapestPrice(name: string): Promise<FetchedPrice | null> {
+  if (!name || name.trim().length < 2) return null;
+  try {
+    const url = `${CHEAPSHARK_GAMES}?title=${encodeURIComponent(name.trim())}&limit=10`;
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    const data = (await res.json()) as CheapSharkGame[];
+    if (!Array.isArray(data)) return null;
+    const match = bestMatch(name, data);
+    if (!match) return null;
+    const cheapest = parseFloat(match.cheapest);
+    if (isNaN(cheapest) || cheapest <= 0) return null;
+    return {
+      price: Math.round(cheapest),
+      title: match.external,
+      source: 'CheapShark (PC)',
+    };
+  } catch {
+    // Network blocked, offline, or CORS — caller falls back to manual entry.
+    return null;
+  }
+}

--- a/app/apps/game-analytics/page.tsx
+++ b/app/apps/game-analytics/page.tsx
@@ -1336,8 +1336,9 @@ export default function GameAnalyticsPage() {
                       ...(data.thumbnail && { thumbnail: data.thumbnail }),
                     });
                     showToast(`${data.name} moved from wishlist to library`, 'success');
+                    return existingWishlistGame.id;
                   } else {
-                    await addGame({
+                    const newGame = await addGame({
                       name: data.name,
                       price: data.price,
                       hours: 0,
@@ -1350,10 +1351,16 @@ export default function GameAnalyticsPage() {
                       playLogs: [],
                     });
                     showToast(`${data.name} added to library`, 'success');
+                    return newGame?.id;
                   }
                 } catch {
                   // Silent fail — the game still got marked as purchased in the queue
+                  return undefined;
                 }
+              }}
+              onAddToPlayQueue={async (gameId) => {
+                await addToQueue(gameId);
+                showToast('Added to Up Next', 'success');
               }}
             />
           )}


### PR DESCRIPTION
Theme 1 — actionable
- A1: drag-to-prioritize committed games (dnd-kit) wired to a new
  reorderEntries() in usePurchaseQueue
- A2: sort control (Manual/Confidence/Price/Release/Value) over the list
- A3: buy → play handoff — "Bought It" now offers to add the new library
  game straight to the Up Next play queue

Theme 2 — price intelligence
- B1: inline price-history sparkline (PriceSparkline) with target line
- B2: stale-price nudge ("last checked 34d ago — still $60?")
- B3: best-effort live price lookup via CheapShark (keyless, client-side),
  in both the card refresh action and the add modal

Theme 3 — decision support
- C1: AI gut-check — one call returns a queue verdict + per-game buy
  advice (new ai-buyqueue-service.ts + buildBuyQueueAIContext)
- C2: impulse cooling-off timer badge on committed buys
- C3: duplicate / already-owned guard in the add modal

Theme 4 — budget & planning
- D1: per-month budget pacing bars in Plan view
- D2: "If You Bought Everything" now shows how far the budget reaches and
  which picks spill over

https://claude.ai/code/session_01AtyVrXpte7rVpbEntus4o4