### PR TITLE
Add Played &amp; Bought range glance panels to Stats

### DIFF
--- a/app/apps/game-analytics/components/RangeGlance.tsx
+++ b/app/apps/game-analytics/components/RangeGlance.tsx
@@ -1,0 +1,318 @@
+'use client';
+
+import { useMemo, useState, ReactNode } from 'react';
+import { ChevronDown, ChevronRight, Gamepad2, ShoppingBag, Clock, CalendarDays } from 'lucide-react';
+import clsx from 'clsx';
+import { Game } from '../lib/types';
+import {
+  parseLocalDate,
+  toDateKey,
+  getRangePlaySummary,
+  getRangePurchaseSummary,
+} from '../lib/calculations';
+import { RatingStars } from './RatingStars';
+
+// ── Shared helpers ───────────────────────────────────────────────────────────
+
+function startOfYearKey(): string {
+  return `${new Date().getFullYear()}-01-01`;
+}
+
+function todayKey(): string {
+  return toDateKey(new Date());
+}
+
+function fmtDay(dateStr: string): string {
+  return parseLocalDate(dateStr).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+function fmtHours(h: number): string {
+  if (h >= 1) return `${h % 1 === 0 ? h : h.toFixed(1)}h`;
+  return `${Math.round(h * 60)}m`;
+}
+
+function fmtMoney(n: number): string {
+  return `$${n % 1 === 0 ? n : n.toFixed(2)}`;
+}
+
+/** Collapsible block shell: title + icon + at-a-glance summary even when collapsed. */
+function CollapsibleBlock({
+  icon,
+  title,
+  summary,
+  defaultOpen = false,
+  children,
+}: {
+  icon: ReactNode;
+  title: string;
+  summary: ReactNode;
+  defaultOpen?: boolean;
+  children: ReactNode;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="bg-white/[0.02] border border-white/10 rounded-2xl overflow-hidden">
+      <button
+        onClick={() => setOpen(o => !o)}
+        className="w-full flex items-center gap-3 p-4 text-left hover:bg-white/[0.02] transition-colors"
+      >
+        <span className="text-purple-300 shrink-0">{icon}</span>
+        <span className="font-semibold text-white shrink-0">{title}</span>
+        <span className="text-xs text-gray-400 truncate flex-1">{summary}</span>
+        {open ? <ChevronDown size={18} className="text-gray-400 shrink-0" /> : <ChevronRight size={18} className="text-gray-400 shrink-0" />}
+      </button>
+      {open && <div className="px-4 pb-4">{children}</div>}
+    </div>
+  );
+}
+
+function DateRange({
+  start,
+  end,
+  onStart,
+  onEnd,
+}: {
+  start: string;
+  end: string;
+  onStart: (v: string) => void;
+  onEnd: (v: string) => void;
+}) {
+  return (
+    <div className="flex items-center gap-2 flex-wrap text-xs text-gray-400 mb-3">
+      <CalendarDays size={14} className="text-gray-500" />
+      <input
+        type="date"
+        value={start}
+        max={end}
+        onChange={e => onStart(e.target.value)}
+        className="bg-white/5 border border-white/10 rounded-lg px-2 py-1 text-gray-200 [color-scheme:dark]"
+      />
+      <span>→</span>
+      <input
+        type="date"
+        value={end}
+        min={start}
+        onChange={e => onEnd(e.target.value)}
+        className="bg-white/5 border border-white/10 rounded-lg px-2 py-1 text-gray-200 [color-scheme:dark]"
+      />
+    </div>
+  );
+}
+
+function SortButton<T extends string>({
+  options,
+  value,
+  onChange,
+}: {
+  options: { value: T; label: string }[];
+  value: T;
+  onChange: (v: T) => void;
+}) {
+  return (
+    <div className="flex items-center gap-1 flex-wrap">
+      <span className="text-[10px] uppercase tracking-wider text-gray-500 mr-1">Sort</span>
+      {options.map(o => (
+        <button
+          key={o.value}
+          onClick={() => onChange(o.value)}
+          className={clsx(
+            'rounded-full px-2 py-0.5 text-[11px] font-medium transition-colors',
+            value === o.value ? 'bg-purple-500/25 text-white' : 'bg-white/5 text-gray-400 hover:bg-white/10'
+          )}
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function Thumb({ src, alt, fallback }: { src?: string; alt: string; fallback: ReactNode }) {
+  return (
+    <div className="h-9 w-9 shrink-0 overflow-hidden rounded-md bg-white/5">
+      {src ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={src} alt={alt} className="h-full w-full object-cover" />
+      ) : (
+        <div className="flex h-full w-full items-center justify-center text-gray-600">{fallback}</div>
+      )}
+    </div>
+  );
+}
+
+// ── Played block ─────────────────────────────────────────────────────────────
+
+type PlayedSort = 'hours' | 'days' | 'rating' | 'name' | 'last';
+
+const PLAYED_SORTS: { value: PlayedSort; label: string }[] = [
+  { value: 'hours', label: 'Hours' },
+  { value: 'days', label: 'Days' },
+  { value: 'rating', label: 'Rating' },
+  { value: 'name', label: 'Name' },
+  { value: 'last', label: 'Last played' },
+];
+
+export function PlayedSummary({ games }: { games: Game[] }) {
+  const [start, setStart] = useState(startOfYearKey());
+  const [end, setEnd] = useState(todayKey());
+  const [sortBy, setSortBy] = useState<PlayedSort>('hours');
+
+  const summary = useMemo(
+    () => getRangePlaySummary(games, parseLocalDate(start), parseLocalDate(end)),
+    [games, start, end]
+  );
+
+  const sortedRows = useMemo(() => {
+    const rows = [...summary.rows];
+    switch (sortBy) {
+      case 'hours': rows.sort((a, b) => b.hours - a.hours); break;
+      case 'days': rows.sort((a, b) => b.daysPlayed - a.daysPlayed); break;
+      case 'rating': rows.sort((a, b) => b.rating - a.rating); break;
+      case 'name': rows.sort((a, b) => a.name.localeCompare(b.name)); break;
+      case 'last': rows.sort((a, b) => parseLocalDate(b.lastPlayed).getTime() - parseLocalDate(a.lastPlayed).getTime()); break;
+    }
+    return rows;
+  }, [summary.rows, sortBy]);
+
+  const maxHours = Math.max(1, ...summary.rows.map(r => r.hours));
+
+  const headerSummary = summary.totalGames > 0
+    ? `Played ${summary.totalDaysPlayed} / ${summary.totalDaysInRange} days · ${fmtHours(summary.totalHours)} · ${summary.totalGames} game${summary.totalGames !== 1 ? 's' : ''}`
+    : 'No play sessions in range';
+
+  return (
+    <CollapsibleBlock icon={<Gamepad2 size={18} />} title="Played" summary={headerSummary}>
+      <DateRange start={start} end={end} onStart={setStart} onEnd={setEnd} />
+
+      {summary.totalGames === 0 ? (
+        <p className="text-sm text-gray-500 py-4 text-center">No games played in this date range.</p>
+      ) : (
+        <>
+          <div className="flex items-center justify-between mb-2">
+            <span className="inline-flex items-center gap-1.5 text-xs text-gray-300">
+              <Clock size={13} className="text-purple-300" />
+              {summary.totalDaysPlayed} of {summary.totalDaysInRange} days active · {fmtHours(summary.totalHours)}
+            </span>
+            <SortButton options={PLAYED_SORTS} value={sortBy} onChange={setSortBy} />
+          </div>
+
+          <div className="space-y-1.5">
+            {sortedRows.map(row => (
+              <div key={row.gameId} className="flex items-center gap-3 rounded-lg bg-white/[0.02] px-2.5 py-2">
+                <Thumb src={row.thumbnail} alt={row.name} fallback={<Gamepad2 size={16} />} />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate text-sm font-medium text-white">{row.name}</span>
+                    <RatingStars rating={row.rating} size={11} />
+                  </div>
+                  {/* Mini hours bar */}
+                  <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-white/5">
+                    <div
+                      className="h-full rounded-full bg-gradient-to-r from-purple-500 to-fuchsia-400"
+                      style={{ width: `${(row.hours / maxHours) * 100}%` }}
+                    />
+                  </div>
+                </div>
+                <div className="shrink-0 text-right">
+                  <div className="text-sm font-semibold text-white">{fmtHours(row.hours)}</div>
+                  <div className="text-[11px] text-gray-400">{row.daysPlayed} day{row.daysPlayed !== 1 ? 's' : ''}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </CollapsibleBlock>
+  );
+}
+
+// ── Bought block ─────────────────────────────────────────────────────────────
+
+type BoughtSort = 'date' | 'price' | 'name';
+
+const BOUGHT_SORTS: { value: BoughtSort; label: string }[] = [
+  { value: 'date', label: 'Date' },
+  { value: 'price', label: 'Price' },
+  { value: 'name', label: 'Name' },
+];
+
+export function BoughtSummary({ games }: { games: Game[] }) {
+  const [start, setStart] = useState(startOfYearKey());
+  const [end, setEnd] = useState(todayKey());
+  const [sortBy, setSortBy] = useState<BoughtSort>('date');
+  const [excludeFree, setExcludeFree] = useState(true);
+
+  const summary = useMemo(
+    () => getRangePurchaseSummary(games, parseLocalDate(start), parseLocalDate(end), excludeFree),
+    [games, start, end, excludeFree]
+  );
+
+  const sortedRows = useMemo(() => {
+    const rows = [...summary.rows];
+    switch (sortBy) {
+      case 'date': rows.sort((a, b) => parseLocalDate(b.date).getTime() - parseLocalDate(a.date).getTime()); break;
+      case 'price': rows.sort((a, b) => b.price - a.price); break;
+      case 'name': rows.sort((a, b) => a.name.localeCompare(b.name)); break;
+    }
+    return rows;
+  }, [summary.rows, sortBy]);
+
+  const headerSummary = summary.totalCount > 0
+    ? `${fmtMoney(summary.totalSpent)} spent${summary.totalSaved > 0 ? ` · ${fmtMoney(summary.totalSaved)} saved` : ''} · ${summary.totalCount} game${summary.totalCount !== 1 ? 's' : ''}`
+    : 'No purchases in range';
+
+  return (
+    <CollapsibleBlock icon={<ShoppingBag size={18} />} title="Bought" summary={headerSummary}>
+      <DateRange start={start} end={end} onStart={setStart} onEnd={setEnd} />
+
+      <div className="flex items-center justify-between mb-2 flex-wrap gap-2">
+        <label className="inline-flex items-center gap-2 text-xs text-gray-300 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={excludeFree}
+            onChange={e => setExcludeFree(e.target.checked)}
+            className="accent-purple-500"
+          />
+          Exclude free / subscription games
+        </label>
+        <SortButton options={BOUGHT_SORTS} value={sortBy} onChange={setSortBy} />
+      </div>
+
+      {summary.totalCount === 0 ? (
+        <p className="text-sm text-gray-500 py-4 text-center">No games bought in this date range.</p>
+      ) : (
+        <>
+          <div className="mb-2 text-xs text-gray-300">
+            <span className="text-white font-semibold">{fmtMoney(summary.totalSpent)}</span> spent
+            {summary.totalSaved > 0 && (
+              <> · <span className="text-emerald-400 font-semibold">{fmtMoney(summary.totalSaved)}</span> saved in discounts</>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            {sortedRows.map(row => (
+              <div key={row.gameId} className="flex items-center gap-3 rounded-lg bg-white/[0.02] px-2.5 py-2">
+                <Thumb src={row.thumbnail} alt={row.name} fallback={<ShoppingBag size={15} />} />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate text-sm font-medium text-white">{row.name}</span>
+                    {row.freeLabel && (
+                      <span className="shrink-0 rounded-full border border-sky-500/30 bg-sky-500/15 px-1.5 py-0.5 text-[10px] font-medium text-sky-300">
+                        {row.freeLabel}
+                      </span>
+                    )}
+                  </div>
+                  <div className="text-[11px] text-gray-400">{fmtDay(row.date)}</div>
+                </div>
+                <div className="shrink-0 text-right">
+                  <div className="text-sm font-semibold text-white">{row.price === 0 ? 'Free' : fmtMoney(row.price)}</div>
+                  {row.saved > 0 && <div className="text-[11px] text-emerald-400">−{fmtMoney(row.saved)}</div>}
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </CollapsibleBlock>
+  );
+}

--- a/app/apps/game-analytics/components/StatsView.tsx
+++ b/app/apps/game-analytics/components/StatsView.tsx
@@ -64,6 +64,7 @@ import { TrophyRoomV2 } from './TrophyRoomV2';
 import { TrophyProgress, TrophyScoreSummary } from '../lib/trophy-calculations';
 import { DiscoverPanel } from './DiscoverPanel';
 import { WeeklyDigest } from './WeeklyDigest';
+import { PlayedSummary, BoughtSummary } from './RangeGlance';
 import clsx from 'clsx';
 
 interface StatsViewProps {
@@ -357,6 +358,12 @@ export function StatsView({ games, summary, budgets = [], onSetBudget, trophies,
 
   return (
     <div className="space-y-8">
+      {/* Played & Bought — at-a-glance summaries for a custom date range */}
+      <div className="space-y-3">
+        <PlayedSummary games={games} />
+        <BoughtSummary games={games} />
+      </div>
+
       {/* Library Health Dashboard */}
       <div className="p-5 bg-gradient-to-br from-white/[0.03] to-white/[0.01] border border-white/10 rounded-2xl">
         <div className="flex items-center gap-2 mb-4">

--- a/app/apps/game-analytics/lib/calculations.ts
+++ b/app/apps/game-analytics/lib/calculations.ts
@@ -13534,3 +13534,156 @@ export function chronicleStretchBlurb(st: PlayStretch): string {
   }
   return `${hrsText} over ${st.daysActive} days — ${st.cadenceLabel}.`;
 }
+
+// ============================================================
+// RANGE GLANCE — Played & Bought summaries for a custom date range
+// ============================================================
+//
+// Two simple, independent at-a-glance summaries for a free-form date range:
+// what you played (days + hours + rating) and what you bought (price +
+// discounts), each with its own totals. No periods, no grouping.
+
+export interface PlayedRangeRow {
+  gameId: string;
+  name: string;
+  thumbnail?: string;
+  genre?: string;
+  rating: number;
+  daysPlayed: number;  // distinct calendar days with a session in range
+  hours: number;       // session hours in range
+  sessions: number;
+  lastPlayed: string;  // YYYY-MM-DD, latest session in range
+}
+
+export interface PlayedRangeSummary {
+  rows: PlayedRangeRow[];
+  totalGames: number;
+  totalDaysPlayed: number;  // distinct active days across all games
+  totalDaysInRange: number; // calendar days spanned by the range (inclusive)
+  totalHours: number;
+  totalSessions: number;
+}
+
+/** Per-game play summary (days + hours + rating) for a custom date range. */
+export function getRangePlaySummary(games: Game[], start: Date, end: Date): PlayedRangeSummary {
+  const rows: PlayedRangeRow[] = [];
+  const allActiveDays = new Set<string>();
+
+  games.forEach(game => {
+    if (!game.playLogs || game.playLogs.length === 0) return;
+    const inRange = game.playLogs.filter(l => {
+      if (!l.date) return false;
+      const d = parseLocalDate(l.date);
+      return d >= start && d <= end;
+    });
+    if (inRange.length === 0) return;
+
+    const days = new Set(inRange.map(l => l.date));
+    days.forEach(d => allActiveDays.add(d));
+    const hours = inRange.reduce((s, l) => s + l.hours, 0);
+    const lastPlayed = inRange.reduce((a, b) =>
+      parseLocalDate(a.date) >= parseLocalDate(b.date) ? a : b
+    ).date;
+
+    rows.push({
+      gameId: game.id,
+      name: game.name,
+      thumbnail: game.thumbnail,
+      genre: game.genre,
+      rating: game.rating,
+      daysPlayed: days.size,
+      hours,
+      sessions: inRange.length,
+      lastPlayed,
+    });
+  });
+
+  rows.sort((a, b) => b.hours - a.hours);
+
+  const DAY = 1000 * 60 * 60 * 24;
+  const totalDaysInRange = Math.max(
+    1,
+    Math.round((parseLocalDate(toDateKey(end)).getTime() - parseLocalDate(toDateKey(start)).getTime()) / DAY) + 1
+  );
+
+  return {
+    rows,
+    totalGames: rows.length,
+    totalDaysPlayed: allActiveDays.size,
+    totalDaysInRange,
+    totalHours: rows.reduce((s, r) => s + r.hours, 0),
+    totalSessions: rows.reduce((s, r) => s + r.sessions, 0),
+  };
+}
+
+export interface BoughtRangeRow {
+  gameId: string;
+  name: string;
+  thumbnail?: string;
+  date: string;        // datePurchased (YYYY-MM-DD)
+  price: number;
+  originalPrice?: number;
+  saved: number;       // originalPrice - price when discounted, else 0
+  isFree: boolean;
+  freeLabel?: string;  // e.g. "PS Plus", "Free"
+}
+
+export interface BoughtRangeSummary {
+  rows: BoughtRangeRow[];
+  totalCount: number;
+  totalSpent: number;
+  totalSaved: number;  // discounts gotten
+}
+
+/** Is this game free / from a subscription (excluded when the toggle is on)? */
+export function isFreeOrSubscription(g: Game): boolean {
+  return !!g.acquiredFree || (g.price ?? 0) === 0 || !!g.subscriptionSource;
+}
+
+/** Per-game purchase summary (price + discounts) for a custom date range. */
+export function getRangePurchaseSummary(
+  games: Game[],
+  start: Date,
+  end: Date,
+  excludeFree: boolean
+): BoughtRangeSummary {
+  const rows: BoughtRangeRow[] = games
+    .filter(g => g.datePurchased && g.status !== 'Wishlist')
+    .filter(g => {
+      const d = parseLocalDate(g.datePurchased!);
+      return d >= start && d <= end;
+    })
+    .filter(g => !(excludeFree && isFreeOrSubscription(g)))
+    .map(g => {
+      const free = isFreeOrSubscription(g);
+      const saved = !free && g.originalPrice && g.originalPrice > g.price ? g.originalPrice - g.price : 0;
+      const freeLabel = free ? (g.subscriptionSource || 'Free') : undefined;
+      return {
+        gameId: g.id,
+        name: g.name,
+        thumbnail: g.thumbnail,
+        date: g.datePurchased!,
+        price: g.price,
+        originalPrice: g.originalPrice,
+        saved,
+        isFree: free,
+        freeLabel,
+      };
+    })
+    .sort((a, b) => parseLocalDate(b.date).getTime() - parseLocalDate(a.date).getTime());
+
+  return {
+    rows,
+    totalCount: rows.length,
+    totalSpent: rows.reduce((s, r) => s + r.price, 0),
+    totalSaved: rows.reduce((s, r) => s + r.saved, 0),
+  };
+}
+
+/** Format a Date as a local YYYY-MM-DD key (no UTC shift). */
+export function toDateKey(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}


### PR DESCRIPTION
## What

Two simple, independent **collapsible blocks** at the top of the **Stats** tab — a quick "what did I play / what did I buy" glance over any custom date range. No period chips, no grouping.

Each block has its **own free-form date range** (default: **This Year**) and shows an **at-a-glance summary in its header even when collapsed**.

### 🎮 Played
- Header summary: `Played 41 / 150 days · 187h · 12 games` — distinct days played **out of** total days in range.
- Per-game row: **rating** (reuses `RatingStars`), **days played**, **hours**, and a **mini hours bar** so heavy hitters pop.
- Sort: Hours · Days · Rating · Name · Last played.

### 🛍 Bought
- Header summary: `$214 spent · $89 saved · 8 games` — money spent + discounts gotten.
- Per-game row: purchase **date**, **price**, discount (`−$20`), and a tag for free/subscription games.
- **"Exclude free / subscription games" toggle — ON by default** (drops `acquiredFree` / `$0` / `subscriptionSource` games from the list **and** totals).
- Sort: Date · Price · Name.

## How
- **`calculations.ts`**: `getRangePlaySummary`, `getRangePurchaseSummary`, `isFreeOrSubscription`, `toDateKey`. Days played = distinct calendar days with a session in range; hours = session hours in range; both clamped to the dates. Saved = `originalPrice − price` where discounted.
- **`RangeGlance.tsx`**: the two collapsible components (`PlayedSummary`, `BoughtSummary`) with date inputs, sorts, and the exclude toggle.
- Rendered at the top of `StatsView`. No AI, fully self-contained.

## Verification
- `tsc --noEmit` — 0 errors
- `npm run build` — compiles successfully
- Lint — clean for new files (only pre-existing `<img>` warnings elsewhere)

https://claude.ai/code/session_01QZY6tVEUhxfdVB3cxBv6Wz

---
_Generated by [Claude Code](https://claude.ai/code/session_01QZY6tVEUhxfdVB3cxBv6Wz)_