### PR TITLE
Add budget-first Buy Queue: pricing scenarios, fit headline, Bought view

### DIFF
--- a/app/apps/game-analytics/components/BuyQueueCard.tsx
+++ b/app/apps/game-analytics/components/BuyQueueCard.tsx
@@ -21,6 +21,8 @@ interface Props {
   onDelete: (id: string) => void;
   onSetIntent?: (intent: PurchaseIntent) => void;
   verdict?: string;
+  /** Running budget remaining after this card; `ghost` projects a maybe without counting it. */
+  budgetLeft?: { remaining: number | null; isOver: boolean; ghost?: boolean } | null;
   dragHandleProps?: React.HTMLAttributes<HTMLButtonElement>;
 }
 
@@ -62,7 +64,7 @@ function getSavings(entry: PurchaseQueueEntry): string | null {
   return `${pct}% off`;
 }
 
-export function BuyQueueCard({ entry, onUpdate, onMarkPurchased, onDelete, onSetIntent, dragHandleProps }: Props) {
+export function BuyQueueCard({ entry, onUpdate, onMarkPurchased, onDelete, onSetIntent, budgetLeft, dragHandleProps }: Props) {
   const intent: PurchaseIntent = entry.intent ?? (entry.isMaybe ? 'maybe' : 'committed');
   const isMaybe = intent === 'maybe';
   const isDeferred = intent === 'deferred';
@@ -269,12 +271,26 @@ export function BuyQueueCard({ entry, onUpdate, onMarkPurchased, onDelete, onSet
                 : 'Set date'}
             </button>
           )}
-          {!upcoming && priceStatus && (
-            <span className={clsx('flex items-center gap-1 ml-auto', priceStatus.color)}>
-              <span className={clsx('w-1.5 h-1.5 rounded-full flex-shrink-0', priceStatus.dot)} />
-              {priceStatus.label}
-            </span>
-          )}
+          <div className="ml-auto flex items-center gap-2 flex-shrink-0">
+            {!upcoming && priceStatus && (
+              <span className={clsx('flex items-center gap-1', priceStatus.color)}>
+                <span className={clsx('w-1.5 h-1.5 rounded-full flex-shrink-0', priceStatus.dot)} />
+                {priceStatus.label}
+              </span>
+            )}
+            {budgetLeft && budgetLeft.remaining != null && (
+              <span className={clsx('px-1.5 py-0.5 rounded text-[10px] font-medium',
+                budgetLeft.ghost ? 'border border-dashed border-white/15 text-white/35'
+                  : budgetLeft.isOver ? 'bg-red-500/15 text-red-400'
+                    : 'bg-white/5 text-white/55')}>
+                {budgetLeft.ghost
+                  ? `would leave $${Math.round(budgetLeft.remaining)}`
+                  : budgetLeft.isOver
+                    ? `over $${Math.abs(Math.round(budgetLeft.remaining))}`
+                    : `$${Math.round(budgetLeft.remaining)} left`}
+              </span>
+            )}
+          </div>
         </div>
 
         {/* Price row */}

--- a/app/apps/game-analytics/components/BuyQueueCard.tsx
+++ b/app/apps/game-analytics/components/BuyQueueCard.tsx
@@ -3,19 +3,12 @@
 import { useState } from 'react';
 import {
   ExternalLink, Check, Trash2, ChevronDown, ChevronUp, GripVertical,
-  Calendar, Star, Zap, Target, TrendingDown, TrendingUp, Minus,
-  Clock, Edit3, HelpCircle, ShoppingCart, Tag, RefreshCw, Moon, Sparkles
+  Calendar, Zap, TrendingDown, TrendingUp, Minus,
+  Clock, HelpCircle, ShoppingCart, Tag, RefreshCw
 } from 'lucide-react';
 import { PurchaseQueueEntry, PurchaseIntent } from '../lib/types';
 import { Game } from '../lib/types';
-import {
-  getBuyConfidence,
-  getPriceContext,
-  getPredictedValue,
-  getStoreUrl,
-  getPriceFreshness,
-  getCoolingOffData,
-} from '../lib/calculations';
+import { getStoreUrl, getPriceFreshness } from '../lib/calculations';
 import { fetchCheapestPrice } from '../lib/price-fetch';
 import { PriceSparkline } from './PriceSparkline';
 import clsx from 'clsx';
@@ -69,14 +62,7 @@ function getSavings(entry: PurchaseQueueEntry): string | null {
   return `${pct}% off`;
 }
 
-function getConfidenceColor(score: number): string {
-  if (score >= 80) return 'text-emerald-400 bg-emerald-500/15';
-  if (score >= 60) return 'text-blue-400 bg-blue-500/15';
-  if (score >= 40) return 'text-yellow-400 bg-yellow-500/15';
-  return 'text-red-400 bg-red-500/15';
-}
-
-export function BuyQueueCard({ entry, allGames, onUpdate, onMarkPurchased, onDelete, onSetIntent, verdict, dragHandleProps }: Props) {
+export function BuyQueueCard({ entry, onUpdate, onMarkPurchased, onDelete, onSetIntent, dragHandleProps }: Props) {
   const intent: PurchaseIntent = entry.intent ?? (entry.isMaybe ? 'maybe' : 'committed');
   const isMaybe = intent === 'maybe';
   const isDeferred = intent === 'deferred';
@@ -97,10 +83,6 @@ export function BuyQueueCard({ entry, allGames, onUpdate, onMarkPurchased, onDel
   const savings = getSavings(entry);
   const isAtTarget = priceStatus?.glow ?? false;
 
-  // Intelligence (Features #5, #6, #7)
-  const confidence = getBuyConfidence(entry, allGames);
-  const priceContext = getPriceContext(entry, allGames);
-  const predicted = getPredictedValue(entry, allGames);
   const storeLinks = getStoreUrl(entry.gameName, entry.platform);
 
   const handlePriceBlur = async (field: 'currentPrice' | 'targetPrice') => {
@@ -125,7 +107,7 @@ export function BuyQueueCard({ entry, allGames, onUpdate, onMarkPurchased, onDel
     setPriceInput('');
   };
 
-  // Manual price history (Feature: price tracking)
+  // Manual price history
   const priceHistory = entry.priceHistory ?? [];
   const lowestSeen = priceHistory.length > 0 ? Math.min(...priceHistory.map(p => p.price)) : null;
   const firstSeen = priceHistory.length > 0 ? priceHistory[0].price : null;
@@ -135,11 +117,9 @@ export function BuyQueueCard({ entry, allGames, onUpdate, onMarkPurchased, onDel
       : null;
   const atLowest = lowestSeen != null && entry.currentPrice != null && entry.currentPrice <= lowestSeen;
 
-  // Stale-price nudge (B2) + cooling-off timer (C2)
+  // Stale-price nudge
   const freshness = getPriceFreshness(entry);
-  const coolingOff = getCoolingOffData(entry);
 
-  // Live price lookup (B3) — best effort, manual fallback on failure
   const handleFetchPrice = async () => {
     setFetchingPrice(true);
     setFetchMsg(null);
@@ -178,30 +158,53 @@ export function BuyQueueCard({ entry, allGames, onUpdate, onMarkPurchased, onDel
     setShowPurchaseConfirm(false);
   };
 
-  // Countdown urgency level (Feature #3)
+  // Countdown urgency
   const getCountdownStyle = () => {
     if (!upcoming || days === null) return null;
-    if (days <= 7) return { urgency: 'imminent', color: 'text-red-400', bg: 'bg-red-500/15', pulse: true };
-    if (days <= 30) return { urgency: 'soon', color: 'text-amber-400', bg: 'bg-amber-500/15', pulse: false };
-    if (days <= 90) return { urgency: 'approaching', color: 'text-purple-400', bg: 'bg-purple-500/15', pulse: false };
-    return { urgency: 'distant', color: 'text-white/40', bg: 'bg-white/5', pulse: false };
+    if (days <= 7) return { color: 'text-red-400', bg: 'bg-red-500/15', pulse: true };
+    if (days <= 30) return { color: 'text-amber-400', bg: 'bg-amber-500/15', pulse: false };
+    if (days <= 90) return { color: 'text-purple-400', bg: 'bg-purple-500/15', pulse: false };
+    return { color: 'text-white/40', bg: 'bg-white/5', pulse: false };
   };
-
   const countdown = getCountdownStyle();
+
+  // Day-1 / status badges (date-related identity only)
+  const renderBadges = (variant: 'overlay' | 'inline') => (
+    <>
+      {entry.isDayOneBuy && (
+        <span className={clsx('flex items-center gap-0.5 text-[9px] px-1 py-0.5 rounded flex-shrink-0',
+          variant === 'overlay' ? 'bg-amber-500/25 text-amber-300' : 'bg-amber-500/15 text-amber-400')}>
+          <Zap size={8} />Day 1
+        </span>
+      )}
+      {isMaybe && (
+        <span className={clsx('flex items-center gap-0.5 text-[9px] px-1 py-0.5 rounded flex-shrink-0',
+          variant === 'overlay' ? 'bg-amber-500/20 text-amber-300' : 'bg-amber-500/15 text-amber-400')}>
+          <HelpCircle size={8} />Maybe
+        </span>
+      )}
+      {isDeferred && (
+        <span className={clsx('flex items-center gap-0.5 text-[9px] px-1 py-0.5 rounded flex-shrink-0',
+          variant === 'overlay' ? 'bg-blue-500/20 text-blue-300' : 'bg-blue-500/15 text-blue-400')}>
+          <Tag size={8} />Deferred
+        </span>
+      )}
+    </>
+  );
 
   return (
     <div className="flex items-stretch gap-1.5">
       {dragHandleProps && (
         <button
           {...dragHandleProps}
-          className="flex-shrink-0 flex items-center justify-center w-6 rounded-lg text-white/15 hover:text-white/50 hover:bg-white/5 cursor-grab active:cursor-grabbing transition-colors touch-none"
+          className="flex-shrink-0 flex items-center justify-center w-5 rounded-lg text-white/15 hover:text-white/50 hover:bg-white/5 cursor-grab active:cursor-grabbing transition-colors touch-none"
           aria-label="Drag to reorder"
         >
-          <GripVertical size={14} />
+          <GripVertical size={13} />
         </button>
       )}
     <div className={clsx(
-      'flex-1 min-w-0 rounded-xl overflow-hidden transition-all',
+      'flex-1 min-w-0 rounded-lg overflow-hidden transition-all',
       isMaybe
         ? 'border border-dashed border-amber-500/25 opacity-90'
         : isDeferred
@@ -210,132 +213,42 @@ export function BuyQueueCard({ entry, allGames, onUpdate, onMarkPurchased, onDel
             ? 'border-2 border-emerald-500/40 buy-queue-price-glow'
             : 'border border-white/8 hover:border-white/12'
     )}>
-      {/* Poster Banner (Feature #2) */}
+      {/* Header — compact thumbnail or icon, name + date badges */}
       {entry.thumbnail ? (
-        <div className="relative h-24 overflow-hidden">
-          <img
-            src={entry.thumbnail}
-            alt={entry.gameName}
-            className="w-full h-full object-cover"
-          />
-          <div className="absolute inset-0 bg-gradient-to-t from-[#12121a] via-[#12121a]/50 to-transparent" />
-
-          {/* Countdown overlay (Feature #3) */}
+        <div className="relative h-14 overflow-hidden">
+          <img src={entry.thumbnail} alt={entry.gameName} className="w-full h-full object-cover" />
+          <div className="absolute inset-0 bg-gradient-to-t from-[#12121a] via-[#12121a]/60 to-transparent" />
           {upcoming && countdown && days !== null && (
             <div className={clsx(
-              'absolute top-2 right-2 px-2 py-1 rounded-lg text-xs font-bold flex items-center gap-1',
-              countdown.bg, countdown.color,
-              countdown.pulse && 'buy-queue-countdown-pulse'
+              'absolute top-1.5 right-1.5 px-1.5 py-0.5 rounded text-[10px] font-bold flex items-center gap-1',
+              countdown.bg, countdown.color, countdown.pulse && 'buy-queue-countdown-pulse'
             )}>
-              <Calendar size={11} />
-              {days <= 0 ? 'Today!' : days <= 7 ? `${days}d!` : `${days}d`}
+              <Calendar size={10} />
+              {days <= 0 ? 'Today!' : `${days}d`}
             </div>
           )}
-
-          {/* Confidence badge (Feature #5) */}
-          {allGames.length > 0 && (
-            <div className={clsx(
-              'absolute top-2 left-2 px-2 py-1 rounded-lg text-[11px] font-bold',
-              getConfidenceColor(confidence.score)
-            )}>
-              {confidence.score}%
-            </div>
-          )}
-
-          {/* Name + tags on image */}
-          <div className="absolute bottom-2 left-3 right-3">
-            <div className="flex items-center gap-1.5 flex-wrap">
-              <span className="text-sm font-semibold text-white truncate drop-shadow-lg">{entry.gameName}</span>
-              {entry.isDayOneBuy && (
-                <span className="flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded bg-amber-500/25 text-amber-300 flex-shrink-0 backdrop-blur-sm">
-                  <Zap size={9} />
-                  Day 1
-                </span>
-              )}
-              {isMaybe && (
-                <span className="flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded bg-amber-500/20 text-amber-300 flex-shrink-0 backdrop-blur-sm">
-                  <HelpCircle size={9} />
-                  Maybe
-                </span>
-              )}
-              {isDeferred && (
-                <span className="flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-300 flex-shrink-0 backdrop-blur-sm">
-                  <Tag size={9} />
-                  Deferred
-                </span>
-              )}
-            </div>
+          <div className="absolute bottom-1.5 left-2.5 right-2.5 flex items-center gap-1.5">
+            <span className="text-sm font-semibold text-white truncate drop-shadow-lg">{entry.gameName}</span>
+            {renderBadges('overlay')}
           </div>
         </div>
       ) : (
-        /* No thumbnail — compact header */
-        <div className="px-3 pt-3 pb-1">
-          <div className="flex items-center gap-2">
-            <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-purple-500/20 to-emerald-500/20 flex items-center justify-center flex-shrink-0">
-              <span className="text-lg">🎮</span>
-            </div>
-            <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-1.5 flex-wrap">
-                <span className="text-sm font-medium text-white/90 truncate">{entry.gameName}</span>
-                {entry.isDayOneBuy && (
-                  <span className="flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-400 flex-shrink-0">
-                    <Zap size={9} />
-                    Day 1
-                  </span>
-                )}
-                {isMaybe && (
-                  <span className="flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-400 flex-shrink-0">
-                    <HelpCircle size={9} />
-                    Maybe
-                  </span>
-                )}
-                {isDeferred && (
-                  <span className="flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded bg-blue-500/15 text-blue-400 flex-shrink-0">
-                    <Tag size={9} />
-                    Deferred
-                  </span>
-                )}
-              </div>
-            </div>
-            {/* Confidence badge inline */}
-            {allGames.length > 0 && (
-              <span className={clsx('text-[11px] font-bold px-2 py-0.5 rounded flex-shrink-0', getConfidenceColor(confidence.score))}>
-                {confidence.score}%
-              </span>
-            )}
+        <div className="px-2.5 pt-2 pb-1 flex items-center gap-2">
+          <div className="w-7 h-7 rounded-md bg-gradient-to-br from-purple-500/20 to-emerald-500/20 flex items-center justify-center flex-shrink-0">
+            <span className="text-sm">🎮</span>
+          </div>
+          <div className="flex items-center gap-1.5 flex-wrap min-w-0">
+            <span className="text-sm font-medium text-white/90 truncate">{entry.gameName}</span>
+            {renderBadges('inline')}
           </div>
         </div>
       )}
 
-      {/* Card body */}
-      <div className="bg-white/[0.03] px-3 pb-3 pt-2">
-        {/* Meta row */}
-        <div className="flex items-center gap-2 flex-wrap text-[11px]">
-          {entry.platform && <span className="text-white/40">{entry.platform}</span>}
-          {entry.genre && <span className="text-white/25">{entry.genre}</span>}
-          {entry.metacriticScore && (
-            <span className="flex items-center gap-0.5 text-white/30">
-              <Star size={9} />
-              {entry.metacriticScore}
-            </span>
-          )}
-          {coolingOff && (
-            <span className="flex items-center gap-1" style={{ color: coolingOff.color }} title={coolingOff.message}>
-              <Moon size={9} />
-              {coolingOff.label} · {coolingOff.daysWaiting}d
-            </span>
-          )}
-          {!upcoming && priceStatus && (
-            <span className={clsx('flex items-center gap-1 ml-auto', priceStatus.color)}>
-              <span className={clsx('w-1.5 h-1.5 rounded-full flex-shrink-0', priceStatus.dot)} />
-              {priceStatus.label}
-            </span>
-          )}
-        </div>
-
-        {/* Release date — editable (Manual release date feature) */}
-        <div className="mt-1.5 flex items-center gap-1 text-[11px]">
-          <Calendar size={9} className="text-white/20" />
+      {/* Compact body — dates + prices only */}
+      <div className="bg-white/[0.03] px-2.5 pb-2 pt-1.5 space-y-1.5">
+        {/* Date + price status */}
+        <div className="flex items-center gap-2 text-[11px]">
+          <Calendar size={10} className="text-white/20 flex-shrink-0" />
           {editingReleaseDate ? (
             <input
               autoFocus
@@ -349,35 +262,28 @@ export function BuyQueueCard({ entry, allGames, onUpdate, onMarkPurchased, onDel
           ) : (
             <button
               onClick={() => { setEditingReleaseDate(true); setReleaseDateInput(entry.releaseDate || ''); }}
-              className="text-white/25 hover:text-white/60 transition-colors underline decoration-dotted"
+              className="text-white/35 hover:text-white/60 transition-colors underline decoration-dotted"
             >
               {entry.releaseDate
                 ? (upcoming ? `Coming ${formatRelease(entry.releaseDate)}` : `Released ${formatRelease(entry.releaseDate)}`)
-                : 'Set release date'
-              }
+                : 'Set date'}
             </button>
           )}
-          {entry.releaseDate && (
-            <button
-              onClick={() => { setEditingReleaseDate(true); setReleaseDateInput(entry.releaseDate || ''); }}
-              className="text-white/15 hover:text-white/40 transition-colors ml-0.5"
-            >
-              <Edit3 size={9} />
-            </button>
+          {!upcoming && priceStatus && (
+            <span className={clsx('flex items-center gap-1 ml-auto', priceStatus.color)}>
+              <span className={clsx('w-1.5 h-1.5 rounded-full flex-shrink-0', priceStatus.dot)} />
+              {priceStatus.label}
+            </span>
           )}
         </div>
 
         {/* Price row */}
-        <div className="mt-2 flex items-center gap-3 flex-wrap">
+        <div className="flex items-center gap-2.5 flex-wrap text-[11px]">
           {entry.msrpEstimate && (
-            <div className="text-[11px] text-white/25">
-              MSRP <span className="text-white/40">${entry.msrpEstimate}</span>
-            </div>
+            <span className="text-white/25">MSRP <span className="text-white/40">${entry.msrpEstimate}</span></span>
           )}
-
-          {/* Current price — inline editable */}
           <div className="flex items-center gap-1">
-            <span className="text-[11px] text-white/30">Now:</span>
+            <span className="text-white/30">Now</span>
             {editingCurrentPrice ? (
               <input
                 autoFocus
@@ -386,14 +292,14 @@ export function BuyQueueCard({ entry, allGames, onUpdate, onMarkPurchased, onDel
                 onChange={e => setPriceInput(e.target.value)}
                 onBlur={() => handlePriceBlur('currentPrice')}
                 onKeyDown={e => { if (e.key === 'Enter') handlePriceBlur('currentPrice'); if (e.key === 'Escape') setEditingCurrentPrice(false); }}
-                className="w-16 bg-white/10 text-white text-xs px-1.5 py-0.5 rounded focus:outline-none"
+                className="w-14 bg-white/10 text-white text-xs px-1.5 py-0.5 rounded focus:outline-none"
                 placeholder="$0"
                 min="0"
               />
             ) : (
               <button
                 onClick={() => { setEditingCurrentPrice(true); setPriceInput(entry.currentPrice?.toString() || ''); }}
-                className="text-[11px] text-white/50 hover:text-white/80 transition-colors underline decoration-dotted"
+                className="text-white/50 hover:text-white/80 transition-colors underline decoration-dotted"
               >
                 {entry.currentPrice != null ? `$${entry.currentPrice}` : 'set'}
               </button>
@@ -407,10 +313,8 @@ export function BuyQueueCard({ entry, allGames, onUpdate, onMarkPurchased, onDel
               <RefreshCw size={10} className={clsx(fetchingPrice && 'animate-spin')} />
             </button>
           </div>
-
-          {/* Target price — inline editable */}
           <div className="flex items-center gap-1">
-            <span className="text-[11px] text-white/30">Buy at:</span>
+            <span className="text-white/30">Buy at</span>
             {editingTargetPrice ? (
               <input
                 autoFocus
@@ -419,220 +323,142 @@ export function BuyQueueCard({ entry, allGames, onUpdate, onMarkPurchased, onDel
                 onChange={e => setPriceInput(e.target.value)}
                 onBlur={() => handlePriceBlur('targetPrice')}
                 onKeyDown={e => { if (e.key === 'Enter') handlePriceBlur('targetPrice'); if (e.key === 'Escape') setEditingTargetPrice(false); }}
-                className="w-16 bg-white/10 text-white text-xs px-1.5 py-0.5 rounded focus:outline-none"
+                className="w-14 bg-white/10 text-white text-xs px-1.5 py-0.5 rounded focus:outline-none"
                 placeholder="$0"
                 min="0"
               />
             ) : (
               <button
                 onClick={() => { setEditingTargetPrice(true); setPriceInput(entry.targetPrice?.toString() || ''); }}
-                className="text-[11px] text-white/50 hover:text-white/80 transition-colors underline decoration-dotted"
+                className="text-white/50 hover:text-white/80 transition-colors underline decoration-dotted"
               >
                 {entry.targetPrice != null ? `$${entry.targetPrice}` : 'set'}
               </button>
             )}
           </div>
-
           {savings && (
-            <span className="text-[10px] px-1.5 py-0.5 rounded bg-emerald-500/15 text-emerald-400">
-              {savings}
-            </span>
+            <span className="text-[10px] px-1.5 py-0.5 rounded bg-emerald-500/15 text-emerald-400">{savings}</span>
           )}
         </div>
 
-        {/* Stale-price nudge (B2) + live-fetch result */}
-        {!isMaybe && freshness.isStale && freshness.daysSinceCheck != null && entry.currentPrice != null && (
+        {/* Stale-price nudge + live-fetch result */}
+        {freshness.isStale && freshness.daysSinceCheck != null && entry.currentPrice != null && (
           <button
             onClick={handleFetchPrice}
             disabled={fetchingPrice}
-            className="mt-1.5 flex items-center gap-1 text-[10px] text-amber-400/70 hover:text-amber-400 transition-colors"
+            className="flex items-center gap-1 text-[10px] text-amber-400/70 hover:text-amber-400 transition-colors"
           >
             <Clock size={9} />
-            Price last checked {freshness.daysSinceCheck}d ago — still ${entry.currentPrice}?
+            Checked {freshness.daysSinceCheck}d ago — still ${entry.currentPrice}?
             <RefreshCw size={9} className={clsx(fetchingPrice && 'animate-spin')} />
           </button>
         )}
-        {fetchMsg && (
-          <div className="mt-1 text-[10px] text-white/40">{fetchMsg}</div>
-        )}
+        {fetchMsg && <div className="text-[10px] text-white/40">{fetchMsg}</div>}
 
-        {/* Manual price history + sparkline */}
+        {/* Price history sparkline */}
         {lowestSeen != null && priceHistory.length >= 2 && (
-          <div className="mt-1.5 flex items-center justify-between gap-2">
-            <div className="flex items-center gap-1.5 text-[10px] text-white/30 flex-wrap min-w-0">
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-1.5 text-[10px] text-white/30 min-w-0">
               {priceTrend === 'down' ? <TrendingDown size={9} className="text-emerald-400/60" /> :
                priceTrend === 'up' ? <TrendingUp size={9} className="text-red-400/50" /> :
                <Minus size={9} className="text-white/20" />}
-              <span>
-                Lowest <span className={clsx('font-medium', atLowest ? 'text-emerald-400' : 'text-white/50')}>${lowestSeen}</span>
-              </span>
-              <span className="text-white/15">·</span>
-              <span className="text-white/20">{priceHistory.length} tracked</span>
-              {atLowest && <span className="text-[9px] px-1 py-0.5 rounded bg-emerald-500/15 text-emerald-400">best yet</span>}
+              <span>Low <span className={clsx('font-medium', atLowest ? 'text-emerald-400' : 'text-white/50')}>${lowestSeen}</span></span>
+              {atLowest && <span className="text-[9px] px-1 py-0.5 rounded bg-emerald-500/15 text-emerald-400">best</span>}
             </div>
             <PriceSparkline history={priceHistory} target={entry.targetPrice} />
           </div>
         )}
 
-        {/* Intelligence line — price context (Feature #6) */}
-        {allGames.length > 0 && priceContext.insight !== 'Not enough data yet' && (
-          <div className="mt-1.5 flex items-center gap-1 text-[10px] text-white/25">
-            {priceContext.comparison === 'below' ? <TrendingDown size={9} className="text-emerald-400/50" /> :
-             priceContext.comparison === 'above' ? <TrendingUp size={9} className="text-red-400/50" /> :
-             <Minus size={9} />}
-            <span className="italic">{priceContext.insight}</span>
-          </div>
-        )}
-
-        {/* Predicted value (Feature #7) */}
-        {predicted && (
-          <div className="mt-1 flex items-center gap-1 text-[10px] text-white/25">
-            <Target size={9} className={clsx(
-              predicted.predictedRating === 'Excellent' ? 'text-emerald-400/50' :
-              predicted.predictedRating === 'Good' ? 'text-blue-400/50' :
-              predicted.predictedRating === 'Fair' ? 'text-yellow-400/50' : 'text-red-400/50'
-            )} />
-            <span className="italic">Predicted: {predicted.predictedRating} ({predicted.insight})</span>
-          </div>
-        )}
-
-        {/* AI verdict (C1) */}
-        {verdict && (
-          <div className="mt-1.5 flex items-start gap-1.5 text-[10px] text-purple-200/80 bg-purple-500/[0.07] border border-purple-500/10 rounded-lg px-2 py-1.5">
-            <Sparkles size={10} className="text-purple-400 flex-shrink-0 mt-0.5" />
-            <span className="italic leading-relaxed">{verdict}</span>
-          </div>
-        )}
-
-        {/* Expand toggle */}
+        {/* Expand toggle — actions only */}
         <button
           onClick={() => setExpanded(!expanded)}
-          className="w-full flex items-center justify-center gap-1 mt-2 pt-2 border-t border-white/5 text-white/20 hover:text-white/40 transition-colors text-[11px]"
+          className="w-full flex items-center justify-center gap-1 pt-1.5 border-t border-white/5 text-white/20 hover:text-white/40 transition-colors text-[11px]"
         >
           {expanded ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
           {expanded ? 'Less' : 'More'}
         </button>
       </div>
 
-      {/* Expanded section */}
+      {/* Expanded section — actions only */}
       {expanded && (
-        <div className="px-3 pb-3 bg-white/[0.03] space-y-3">
-          {/* Confidence breakdown (Feature #5) */}
-          {confidence.factors.length > 0 && (
-            <div className="space-y-1.5">
-              <div className="text-[11px] text-white/30 font-medium">Buy Confidence: {confidence.score}%</div>
-              {confidence.factors.map((f, i) => (
-                <div key={i} className="flex items-center gap-2 text-[11px]">
-                  <div className="flex-1 min-w-0">
-                    <span className="text-white/40">{f.label}</span>
-                  </div>
-                  <div className="w-16 h-1.5 bg-white/5 rounded-full overflow-hidden flex-shrink-0">
-                    <div
-                      className={clsx(
-                        'h-full rounded-full transition-all',
-                        f.value >= 70 ? 'bg-emerald-500' : f.value >= 40 ? 'bg-yellow-500' : 'bg-red-500'
-                      )}
-                      style={{ width: `${Math.min(100, f.value)}%` }}
-                    />
-                  </div>
-                  <span className="text-white/25 text-[10px] w-8 text-right">{f.value.toFixed(0)}%</span>
-                </div>
-              ))}
-              {confidence.factors.length > 0 && (
-                <p className="text-[10px] text-white/20 italic">{confidence.factors[0].insight}</p>
-              )}
+        <div className="px-2.5 pb-2.5 bg-white/[0.03] flex items-center gap-2 flex-wrap">
+          {storeLinks.map((store, i) => (
+            <a
+              key={i}
+              href={store.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-blue-500/10 text-blue-400 hover:bg-blue-500/20 text-xs transition-all"
+            >
+              <ExternalLink size={12} />
+              {store.label}
+            </a>
+          ))}
+
+          {!showPurchaseConfirm ? (
+            <button
+              onClick={() => { setShowPurchaseConfirm(true); setPurchasePriceInput(entry.currentPrice?.toString() || ''); }}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-emerald-500/10 text-emerald-400 hover:bg-emerald-500/20 text-xs transition-all"
+            >
+              <Check size={12} />
+              Bought It
+            </button>
+          ) : (
+            <div className="flex items-center gap-2">
+              <div className="relative">
+                <span className="absolute left-2 top-1/2 -translate-y-1/2 text-white/30 text-xs">$</span>
+                <input
+                  type="number"
+                  autoFocus
+                  value={purchasePriceInput}
+                  onChange={e => setPurchasePriceInput(e.target.value)}
+                  placeholder="paid"
+                  className="w-20 bg-white/5 border border-white/10 rounded-lg pl-5 pr-2 py-1 text-xs text-white focus:outline-none focus:border-emerald-500/40"
+                />
+              </div>
+              <button
+                onClick={handleMarkPurchased}
+                className="px-3 py-1.5 rounded-lg bg-emerald-600 text-white text-xs hover:bg-emerald-500 transition-all"
+              >
+                Confirm
+              </button>
+              <button
+                onClick={() => setShowPurchaseConfirm(false)}
+                className="text-white/30 hover:text-white/60 text-xs transition-colors"
+              >
+                ×
+              </button>
             </div>
           )}
 
-          {/* Notes */}
-          {entry.notes && (
-            <p className="text-xs text-white/40 italic">&quot;{entry.notes}&quot;</p>
+          {onSetIntent && (
+            <div className="flex items-center rounded-lg bg-white/5 overflow-hidden">
+              {INTENT_OPTIONS.map(opt => {
+                const Icon = opt.icon;
+                const selected = intent === opt.value;
+                return (
+                  <button
+                    key={opt.value}
+                    onClick={() => onSetIntent(opt.value)}
+                    className={clsx(
+                      'flex items-center gap-1 px-2.5 py-1.5 text-[11px] transition-all',
+                      selected ? opt.active : 'text-white/30 hover:text-white/55'
+                    )}
+                  >
+                    <Icon size={11} />
+                    {opt.label}
+                  </button>
+                );
+              })}
+            </div>
           )}
 
-          {/* Actions row */}
-          <div className="flex items-center gap-2 flex-wrap">
-            {/* Store links (Feature #19) */}
-            {storeLinks.map((store, i) => (
-              <a
-                key={i}
-                href={store.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-blue-500/10 text-blue-400 hover:bg-blue-500/20 text-xs transition-all"
-              >
-                <ExternalLink size={12} />
-                {store.label}
-              </a>
-            ))}
-
-            {/* Bought It */}
-            {!showPurchaseConfirm ? (
-              <button
-                onClick={() => { setShowPurchaseConfirm(true); setPurchasePriceInput(entry.currentPrice?.toString() || ''); }}
-                className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-emerald-500/10 text-emerald-400 hover:bg-emerald-500/20 text-xs transition-all"
-              >
-                <Check size={12} />
-                Bought It
-              </button>
-            ) : (
-              <div className="flex items-center gap-2">
-                <div className="relative">
-                  <span className="absolute left-2 top-1/2 -translate-y-1/2 text-white/30 text-xs">$</span>
-                  <input
-                    type="number"
-                    autoFocus
-                    value={purchasePriceInput}
-                    onChange={e => setPurchasePriceInput(e.target.value)}
-                    placeholder="paid"
-                    className="w-20 bg-white/5 border border-white/10 rounded-lg pl-5 pr-2 py-1 text-xs text-white focus:outline-none focus:border-emerald-500/40"
-                  />
-                </div>
-                <button
-                  onClick={handleMarkPurchased}
-                  className="px-3 py-1.5 rounded-lg bg-emerald-600 text-white text-xs hover:bg-emerald-500 transition-all"
-                >
-                  Confirm
-                </button>
-                <button
-                  onClick={() => setShowPurchaseConfirm(false)}
-                  className="text-white/30 hover:text-white/60 text-xs transition-colors"
-                >
-                  ×
-                </button>
-              </div>
-            )}
-
-            {/* Intent control: Watching / Maybe / Deferred */}
-            {onSetIntent && (
-              <div className="flex items-center rounded-lg bg-white/5 overflow-hidden">
-                {INTENT_OPTIONS.map(opt => {
-                  const Icon = opt.icon;
-                  const selected = intent === opt.value;
-                  return (
-                    <button
-                      key={opt.value}
-                      onClick={() => onSetIntent(opt.value)}
-                      className={clsx(
-                        'flex items-center gap-1 px-2.5 py-1.5 text-[11px] transition-all',
-                        selected ? opt.active : 'text-white/30 hover:text-white/55'
-                      )}
-                    >
-                      <Icon size={11} />
-                      {opt.label}
-                    </button>
-                  );
-                })}
-              </div>
-            )}
-
-            {/* Delete */}
-            <button
-              onClick={() => onDelete(entry.id)}
-              className="ml-auto flex items-center gap-1 px-2 py-1.5 rounded-lg text-red-400/50 hover:text-red-400 hover:bg-red-500/10 text-xs transition-all"
-            >
-              <Trash2 size={12} />
-            </button>
-          </div>
+          <button
+            onClick={() => onDelete(entry.id)}
+            className="ml-auto flex items-center gap-1 px-2 py-1.5 rounded-lg text-red-400/50 hover:text-red-400 hover:bg-red-500/10 text-xs transition-all"
+          >
+            <Trash2 size={12} />
+          </button>
         </div>
       )}
     </div>

--- a/app/apps/game-analytics/components/BuyQueueTab.tsx
+++ b/app/apps/game-analytics/components/BuyQueueTab.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import {
   Plus, ShoppingCart, Calendar, TrendingDown, Clock, PackageCheck,
-  ChevronDown, ChevronUp, Settings, Sparkles,
+  Settings, Sparkles,
   Tag, Gift, Target, BarChart2, Trophy, ArrowRight, HelpCircle,
-  ArrowUpDown, Wand2, Loader2, ListOrdered, X
+  ArrowUpDown, Wand2, Loader2, ListOrdered, X, Wallet
 } from 'lucide-react';
 import {
   DndContext, closestCenter, KeyboardSensor, PointerSensor, TouchSensor,
@@ -22,6 +22,7 @@ import { AddToBuyQueueModal } from './AddToBuyQueueModal';
 import { BuyQueueCard } from './BuyQueueCard';
 import {
   getQueueImpactSnapshot,
+  getBudgetFitScenarios,
   getSaleSeasonIndicator,
   getPurchaseHistoryInsights,
   getBuyConfidence,
@@ -86,6 +87,7 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
     purchasedEntries,
     loading,
     plannedSpend,
+    fullPriceSpend,
     maybeSpend,
     deferredSpend,
     releasingSoon,
@@ -98,8 +100,30 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
   } = usePurchaseQueue(userId);
 
   const [showAddModal, setShowAddModal] = useState(false);
-  const [showPurchased, setShowPurchased] = useState(false);
   const [showStats, setShowStats] = useState(false);
+  // 'deal' = assume target/sale prices (default), 'full' = assume full MSRP now.
+  const [pricingMode, setPricingMode] = useState<'deal' | 'full'>('deal');
+  // Top-level view: the live queue ('watching') or already-bought history ('bought').
+  const [mainView, setMainView] = useState<'watching' | 'bought'>('watching');
+
+  // Restore the saved pricing preference once on mount.
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem('buy-queue-pricing-mode');
+      if (saved === 'full' || saved === 'deal') setPricingMode(saved);
+    } catch {
+      // ignore — non-persistent is fine
+    }
+  }, []);
+
+  const handlePricingMode = (mode: 'deal' | 'full') => {
+    setPricingMode(mode);
+    try {
+      localStorage.setItem('buy-queue-pricing-mode', mode);
+    } catch {
+      // ignore
+    }
+  };
   const [viewMode, setViewMode] = useState<'list' | 'timeline'>('list');
   const [sortMode, setSortMode] = useState<SortMode>('priority');
   const [aiAdvice, setAiAdvice] = useState<BuyQueueAdvice | null>(null);
@@ -115,9 +139,9 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
   const currentYear = new Date().getFullYear();
   const yearBudget = budgets.find(b => b.year === currentYear)?.yearlyBudget ?? null;
 
-  // Budget ring math
+  // Budget ring math — "planned" follows the selected pricing scenario.
   const budgetUsed = yearSpent;
-  const budgetPlanned = plannedSpend;
+  const budgetPlanned = pricingMode === 'full' ? fullPriceSpend : plannedSpend;
   const budgetTotal = yearBudget ?? 0;
   const budgetRemaining = yearBudget != null ? yearBudget - budgetUsed - budgetPlanned : null;
   const isOverBudget = yearBudget != null && (budgetUsed + budgetPlanned) > yearBudget;
@@ -126,6 +150,12 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
   // Ring percentages
   const spentPct = budgetTotal > 0 ? Math.min(100, (budgetUsed / budgetTotal) * 100) : 0;
   const plannedPct = budgetTotal > 0 ? Math.min(100 - spentPct, (budgetPlanned / budgetTotal) * 100) : 0;
+
+  // Budget fit — how many committed picks fit at full price vs deal price.
+  const budgetFit = useMemo(
+    () => getBudgetFitScenarios(activeEntries, yearBudget, yearSpent),
+    [activeEntries, yearBudget, yearSpent]
+  );
 
   // Sale season
   const saleSeason = useMemo(() => getSaleSeasonIndicator(), []);
@@ -352,7 +382,7 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
   return (
     <div className="space-y-5">
       {/* Deal Alert Banner (Feature #11) */}
-      {dealsAtTarget.length > 0 && (
+      {mainView === 'watching' && dealsAtTarget.length > 0 && (
         <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/[0.08] p-3 buy-queue-deal-alert">
           <div className="flex items-center gap-2">
             <div className="w-8 h-8 rounded-full bg-emerald-500/20 flex items-center justify-center flex-shrink-0">
@@ -372,7 +402,7 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
       )}
 
       {/* Sale Season Badge (Feature #20) */}
-      {saleSeason && (
+      {mainView === 'watching' && saleSeason && (
         <div className={clsx(
           'flex items-center gap-2 px-3 py-2 rounded-lg text-xs',
           saleSeason.inSeason
@@ -393,7 +423,72 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
         isOverBudget ? 'bg-red-500/5 border-red-500/20' : 'bg-white/[0.02] border-white/5'
       )}>
         {yearBudget != null ? (
-          renderBudgetRing()
+          <>
+            {renderBudgetRing()}
+            {activeEntries.length > 0 && (
+              <div className="mt-3 pt-3 border-t border-white/5 space-y-2.5">
+                {/* Pricing scenario toggle */}
+                <div className="flex items-center justify-between">
+                  <span className="text-[11px] text-white/30">Price assumption</span>
+                  <div className="flex items-center bg-white/5 rounded-lg overflow-hidden">
+                    <button
+                      onClick={() => handlePricingMode('deal')}
+                      className={clsx('px-2.5 py-1 text-[11px] transition-all',
+                        pricingMode === 'deal' ? 'bg-emerald-500/15 text-emerald-400 font-medium' : 'text-white/30 hover:text-white/50')}
+                    >
+                      Deal price
+                    </button>
+                    <button
+                      onClick={() => handlePricingMode('full')}
+                      className={clsx('px-2.5 py-1 text-[11px] transition-all',
+                        pricingMode === 'full' ? 'bg-white/10 text-white/70 font-medium' : 'text-white/30 hover:text-white/50')}
+                    >
+                      Full price
+                    </button>
+                  </div>
+                </div>
+                {/* "How many fit" headline */}
+                <div className="flex items-start gap-2">
+                  <Wallet size={14} className="text-emerald-400 mt-0.5 flex-shrink-0" />
+                  <p className="text-xs text-white/60 leading-relaxed">
+                    {(() => {
+                      const fit = pricingMode === 'full' ? budgetFit.fullPrice : budgetFit.deal;
+                      const allFit = fit.affordableCount >= budgetFit.total;
+                      const label = pricingMode === 'full' ? 'full price' : 'deal prices';
+                      return (
+                        <>
+                          {allFit ? (
+                            <>All <span className="font-medium text-white/90">{budgetFit.total}</span> picks fit at {label}.</>
+                          ) : (
+                            <>Budget fits your top <span className="font-medium text-emerald-400">{fit.affordableCount}</span> of {budgetFit.total} at {label}.</>
+                          )}{' '}
+                          {pricingMode === 'full' && budgetFit.extraFromDeals > 0 && (
+                            <span className="text-white/40">Wait for deals → <span className="text-amber-400 font-medium">{budgetFit.extraFromDeals} more</span> fit.</span>
+                          )}
+                          {pricingMode === 'deal' && budgetFit.potentialSavings > 0 && (
+                            <span className="text-white/40">Waiting saves ~<span className="text-emerald-400 font-medium">{formatMoney(budgetFit.potentialSavings)}</span> vs full price.</span>
+                          )}
+                        </>
+                      );
+                    })()}
+                  </p>
+                </div>
+                {/* Spillover games at the current assumption */}
+                {(() => {
+                  const fit = pricingMode === 'full' ? budgetFit.fullPrice : budgetFit.deal;
+                  if (fit.overflowItems.length === 0) return null;
+                  return (
+                    <div className="flex items-start gap-1.5 text-[10px] text-amber-400/70">
+                      <Target size={10} className="flex-shrink-0 mt-0.5" />
+                      <span>
+                        Spills over: <span className="text-white/40">{fit.overflowItems.slice(0, 3).join(', ')}{fit.overflowItems.length > 3 ? `, +${fit.overflowItems.length - 3} more` : ''}</span>
+                      </span>
+                    </div>
+                  );
+                })()}
+              </div>
+            )}
+          </>
         ) : (
           <div className="flex items-center justify-between">
             <div>
@@ -413,6 +508,34 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
         )}
       </div>
 
+      {/* Watching | Bought switch */}
+      <div className="flex items-center bg-white/5 rounded-lg overflow-hidden w-fit">
+        <button
+          onClick={() => setMainView('watching')}
+          className={clsx('flex items-center gap-1.5 px-3 py-1.5 text-xs transition-all',
+            mainView === 'watching' ? 'bg-white/10 text-white/80 font-medium' : 'text-white/40 hover:text-white/60')}
+        >
+          <ShoppingCart size={13} />
+          Watching
+          {activeEntries.length + maybeEntries.length + deferredEntries.length > 0 && (
+            <span className="text-white/30">{activeEntries.length + maybeEntries.length + deferredEntries.length}</span>
+          )}
+        </button>
+        <button
+          onClick={() => setMainView('bought')}
+          className={clsx('flex items-center gap-1.5 px-3 py-1.5 text-xs transition-all',
+            mainView === 'bought' ? 'bg-white/10 text-white/80 font-medium' : 'text-white/40 hover:text-white/60')}
+        >
+          <PackageCheck size={13} />
+          Bought
+          {purchasedEntries.length > 0 && (
+            <span className="text-white/30">{purchasedEntries.length}</span>
+          )}
+        </button>
+      </div>
+
+      {mainView === 'watching' && (
+      <>
       {/* Header bar */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3 flex-wrap">
@@ -842,23 +965,20 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
           })}
         </div>
       )}
+      </>
+      )}
 
-      {/* Purchased history (Feature #17 - Enhanced) */}
-      {purchasedEntries.length > 0 && (
-        <div className="space-y-2">
-          <button
-            onClick={() => setShowPurchased(!showPurchased)}
-            className="flex items-center gap-2 text-xs text-white/30 hover:text-white/50 transition-colors w-full"
-          >
-            {showPurchased ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
-            <PackageCheck size={12} className="text-white/25" />
-            <span>{purchasedEntries.length} purchased</span>
-            {stats.purchaseInsights.totalSaved > 0 && (
-              <span className="text-emerald-400/50 ml-auto">Saved {formatMoney(stats.purchaseInsights.totalSaved)}</span>
-            )}
-          </button>
-          {showPurchased && (
+      {/* Bought view — purchased history */}
+      {mainView === 'bought' && (
+        purchasedEntries.length > 0 ? (
             <div className="space-y-3">
+              <div className="flex items-center gap-2 text-xs text-white/40">
+                <PackageCheck size={13} className="text-white/30" />
+                <span><span className="text-white/70 font-medium">{purchasedEntries.length}</span> purchased</span>
+                {stats.purchaseInsights.totalSaved > 0 && (
+                  <span className="text-emerald-400/60 ml-auto">Saved {formatMoney(stats.purchaseInsights.totalSaved)} vs MSRP</span>
+                )}
+              </div>
               {/* Purchase insights summary */}
               {purchasedEntries.length >= 2 && (
                 <div className="flex items-center gap-4 flex-wrap px-3 py-2 bg-white/[0.02] rounded-lg text-[11px]">
@@ -908,12 +1028,23 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
                 ))}
               </div>
             </div>
-          )}
-        </div>
+        ) : (
+          <div className="text-center py-16 space-y-3">
+            <div className="w-16 h-16 rounded-2xl bg-white/[0.03] flex items-center justify-center mx-auto">
+              <PackageCheck size={28} className="text-white/10" />
+            </div>
+            <div>
+              <p className="text-white/40 text-sm font-medium">Nothing bought yet</p>
+              <p className="text-white/20 text-xs mt-1.5 max-w-xs mx-auto leading-relaxed">
+                When you mark a queued game as purchased, it lands here with how much you saved versus full price.
+              </p>
+            </div>
+          </div>
+        )
       )}
 
       {/* Wishlist nudge (Feature #13) */}
-      {wishlistGames.length > 0 && (activeEntries.length > 0 || maybeEntries.length > 0 || deferredEntries.length > 0) && (
+      {mainView === 'watching' && wishlistGames.length > 0 && (activeEntries.length > 0 || maybeEntries.length > 0 || deferredEntries.length > 0) && (
         (() => {
           const queuedNames = new Set([...activeEntries, ...maybeEntries, ...deferredEntries].map(e => e.gameName.toLowerCase()));
           const untracked = wishlistGames.filter(g => !queuedNames.has(g.name.toLowerCase()));

--- a/app/apps/game-analytics/components/BuyQueueTab.tsx
+++ b/app/apps/game-analytics/components/BuyQueueTab.tsx
@@ -2,10 +2,10 @@
 
 import { useState, useMemo, useEffect } from 'react';
 import {
-  Plus, ShoppingCart, Calendar, TrendingDown, Clock, PackageCheck,
-  Settings, Sparkles,
-  Tag, Gift, Target, BarChart2, Trophy, ArrowRight, HelpCircle,
-  ArrowUpDown, Wand2, Loader2, ListOrdered, X, Wallet
+  Plus, ShoppingCart, Calendar, PackageCheck,
+  Settings, Sparkles, Percent, ChevronDown, ChevronUp,
+  Tag, Gift, Target, BarChart2, ArrowRight, HelpCircle,
+  Wand2, Loader2, ListOrdered, X, Wallet
 } from 'lucide-react';
 import {
   DndContext, closestCenter, KeyboardSensor, PointerSensor, TouchSensor,
@@ -22,30 +22,16 @@ import { AddToBuyQueueModal } from './AddToBuyQueueModal';
 import { BuyQueueCard } from './BuyQueueCard';
 import {
   getQueueImpactSnapshot,
-  getBudgetFitScenarios,
+  getQueueRunningTally,
+  QueuePriceMode,
   getSaleSeasonIndicator,
   getPurchaseHistoryInsights,
-  getBuyConfidence,
-  getPredictedValue,
   buildBuyQueueAIContext,
 } from '../lib/calculations';
 import { generateBuyQueueAdvice, BuyQueueAdvice } from '../lib/ai-buyqueue-service';
 import clsx from 'clsx';
 
-type SortMode = 'priority' | 'confidence' | 'price' | 'release' | 'value';
-
-const SORT_OPTIONS: { value: SortMode; label: string }[] = [
-  { value: 'priority', label: 'Manual' },
-  { value: 'confidence', label: 'Confidence' },
-  { value: 'price', label: 'Price' },
-  { value: 'release', label: 'Release' },
-  { value: 'value', label: 'Value' },
-];
-
-const priceOf = (e: PurchaseQueueEntry): number =>
-  e.targetPrice ?? e.currentPrice ?? e.msrpEstimate ?? 0;
-
-const VALUE_RANK: Record<string, number> = { Excellent: 4, Good: 3, Fair: 2, Poor: 1 };
+type PriceMode = 'full' | 'deal' | 'model';
 
 interface Props {
   userId: string | null;
@@ -58,7 +44,7 @@ interface Props {
   onAddToPlayQueue?: (gameId: string) => Promise<void>;
 }
 
-/** Sortable wrapper so committed cards can be drag-reordered in Manual mode. */
+/** Sortable wrapper so no-date committed cards can be drag-reordered. */
 function SortableBuyCard({ entry, children }: { entry: PurchaseQueueEntry; children: (handleProps: React.HTMLAttributes<HTMLButtonElement>) => React.ReactNode }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: entry.id });
   const style = {
@@ -87,9 +73,7 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
     purchasedEntries,
     loading,
     plannedSpend,
-    fullPriceSpend,
     maybeSpend,
-    deferredSpend,
     releasingSoon,
     addEntry,
     updateEntry,
@@ -101,34 +85,38 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
 
   const [showAddModal, setShowAddModal] = useState(false);
   const [showStats, setShowStats] = useState(false);
-  // 'deal' = assume target/sale prices (default), 'full' = assume full MSRP now.
-  const [pricingMode, setPricingMode] = useState<'deal' | 'full'>('deal');
-  // Top-level view: the live queue ('watching') or already-bought history ('bought').
-  const [mainView, setMainView] = useState<'watching' | 'bought'>('watching');
-
-  // Restore the saved pricing preference once on mount.
-  useEffect(() => {
-    try {
-      const saved = localStorage.getItem('buy-queue-pricing-mode');
-      if (saved === 'full' || saved === 'deal') setPricingMode(saved);
-    } catch {
-      // ignore — non-persistent is fine
-    }
-  }, []);
-
-  const handlePricingMode = (mode: 'deal' | 'full') => {
-    setPricingMode(mode);
-    try {
-      localStorage.setItem('buy-queue-pricing-mode', mode);
-    } catch {
-      // ignore
-    }
-  };
-  const [viewMode, setViewMode] = useState<'list' | 'timeline'>('list');
-  const [sortMode, setSortMode] = useState<SortMode>('priority');
+  const [showLater, setShowLater] = useState(false);
+  const [showBought, setShowBought] = useState(false);
   const [aiAdvice, setAiAdvice] = useState<BuyQueueAdvice | null>(null);
   const [aiLoading, setAiLoading] = useState(false);
   const [justPurchased, setJustPurchased] = useState<{ name: string; gameId: string } | null>(null);
+
+  // Pricing scenario: your target deals (default), full MSRP, or a modeled % off.
+  const [priceMode, setPriceMode] = useState<PriceMode>('deal');
+  const [modelDiscount, setModelDiscount] = useState(0.33);
+
+  useEffect(() => {
+    try {
+      const m = localStorage.getItem('buy-queue-price-mode');
+      if (m === 'full' || m === 'deal' || m === 'model') setPriceMode(m);
+      const d = localStorage.getItem('buy-queue-model-discount');
+      if (d) { const n = parseFloat(d); if (!isNaN(n)) setModelDiscount(Math.min(0.8, Math.max(0, n))); }
+    } catch { /* non-persistent is fine */ }
+  }, []);
+
+  const handlePriceMode = (m: PriceMode) => {
+    setPriceMode(m);
+    try { localStorage.setItem('buy-queue-price-mode', m); } catch { /* ignore */ }
+  };
+  const handleModelDiscount = (d: number) => {
+    setModelDiscount(d);
+    try { localStorage.setItem('buy-queue-model-discount', String(d)); } catch { /* ignore */ }
+  };
+
+  const mode = useMemo<QueuePriceMode>(
+    () => priceMode === 'model' ? { kind: 'model', discount: modelDiscount } : { kind: priceMode },
+    [priceMode, modelDiscount]
+  );
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
@@ -139,23 +127,63 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
   const currentYear = new Date().getFullYear();
   const yearBudget = budgets.find(b => b.year === currentYear)?.yearlyBudget ?? null;
 
-  // Budget ring math — "planned" follows the selected pricing scenario.
+  const entryById = useMemo(() => {
+    const m = new Map<string, PurchaseQueueEntry>();
+    entries.forEach(e => m.set(e.id, e));
+    return m;
+  }, [entries]);
+
+  // ── Timeline grouping: Dated (available now → upcoming) · No date · Later ──
+  const { datedCommitted, undatedCommitted, orderedCommitted, laterEntries } = useMemo(() => {
+    const todayMid = new Date(); todayMid.setHours(0, 0, 0, 0);
+    const dated = activeEntries.filter(e => e.releaseDate);
+    const available = dated
+      .filter(e => new Date(e.releaseDate!) <= todayMid)
+      .sort((a, b) => a.priority - b.priority);
+    const upcoming = dated
+      .filter(e => new Date(e.releaseDate!) > todayMid)
+      .sort((a, b) => new Date(a.releaseDate!).getTime() - new Date(b.releaseDate!).getTime());
+    const datedCommitted = [...available, ...upcoming];
+    const undatedCommitted = activeEntries.filter(e => !e.releaseDate).sort((a, b) => a.priority - b.priority);
+    return {
+      datedCommitted,
+      undatedCommitted,
+      orderedCommitted: [...datedCommitted, ...undatedCommitted],
+      laterEntries: [...maybeEntries, ...deferredEntries],
+    };
+  }, [activeEntries, maybeEntries, deferredEntries]);
+
+  // ── Running budget tally (current mode) + full/deal for comparison ──
+  const tally = useMemo(() => getQueueRunningTally(orderedCommitted, yearBudget, yearSpent, mode), [orderedCommitted, yearBudget, yearSpent, mode]);
+  const committedTotal = tally.rows.length ? tally.rows[tally.rows.length - 1].cumulative : 0;
+  const ghost = useMemo(() => getQueueRunningTally(laterEntries, yearBudget, yearSpent, mode, committedTotal), [laterEntries, yearBudget, yearSpent, mode, committedTotal]);
+  const fullTally = useMemo(() => getQueueRunningTally(orderedCommitted, yearBudget, yearSpent, { kind: 'full' }), [orderedCommitted, yearBudget, yearSpent]);
+  const dealTally = useMemo(() => getQueueRunningTally(orderedCommitted, yearBudget, yearSpent, { kind: 'deal' }), [orderedCommitted, yearBudget, yearSpent]);
+
+  const tallyMap = useMemo(() => new Map(tally.rows.map(r => [r.id, r])), [tally]);
+  const ghostMap = useMemo(() => new Map(ghost.rows.map(r => [r.id, r])), [ghost]);
+
+  const total = orderedCommitted.length;
+  const fitNow = tally.rows.filter(r => !r.isOver).length;
+  const fitFull = fullTally.rows.filter(r => !r.isOver).length;
+  const fitDeal = dealTally.rows.filter(r => !r.isOver).length;
+  const fullSum = fullTally.rows.length ? fullTally.rows[fullTally.rows.length - 1].cumulative : 0;
+  const dealSum = dealTally.rows.length ? dealTally.rows[dealTally.rows.length - 1].cumulative : 0;
+  const potentialSavings = Math.max(0, fullSum - dealSum);
+  const overflowNames = tally.rows.filter(r => r.isOver).map(r => entryById.get(r.id)?.gameName).filter(Boolean) as string[];
+
+  // Budget ring math — "planned" is the committed total under the current mode.
   const budgetUsed = yearSpent;
-  const budgetPlanned = pricingMode === 'full' ? fullPriceSpend : plannedSpend;
+  const budgetPlanned = committedTotal;
   const budgetTotal = yearBudget ?? 0;
   const budgetRemaining = yearBudget != null ? yearBudget - budgetUsed - budgetPlanned : null;
   const isOverBudget = yearBudget != null && (budgetUsed + budgetPlanned) > yearBudget;
   const overBy = yearBudget != null ? Math.max(0, budgetUsed + budgetPlanned - yearBudget) : 0;
-
-  // Ring percentages
   const spentPct = budgetTotal > 0 ? Math.min(100, (budgetUsed / budgetTotal) * 100) : 0;
   const plannedPct = budgetTotal > 0 ? Math.min(100 - spentPct, (budgetPlanned / budgetTotal) * 100) : 0;
 
-  // Budget fit — how many committed picks fit at full price vs deal price.
-  const budgetFit = useMemo(
-    () => getBudgetFitScenarios(activeEntries, yearBudget, yearSpent),
-    [activeEntries, yearBudget, yearSpent]
-  );
+  // Bought / spent summary (free games never have a purchase price)
+  const boughtSpent = useMemo(() => purchasedEntries.reduce((s, e) => s + (e.purchasePrice ?? 0), 0), [purchasedEntries]);
 
   // Sale season
   const saleSeason = useMemo(() => getSaleSeasonIndicator(), []);
@@ -177,35 +205,10 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
       if (e.platform) acc[e.platform] = (acc[e.platform] || 0) + 1;
       return acc;
     }, {});
-    const genreBreakdown = activeEntries.reduce<Record<string, number>>((acc, e) => {
-      if (e.genre) acc[e.genre] = (acc[e.genre] || 0) + 1;
-      return acc;
-    }, {});
     const purchaseInsights = getPurchaseHistoryInsights(entries);
     const impact = getQueueImpactSnapshot(activeEntries, yearBudget, yearSpent);
-    return { dayOneBuys, totalSavingsPotential, platformBreakdown, genreBreakdown, purchaseInsights, impact };
+    return { dayOneBuys, totalSavingsPotential, platformBreakdown, purchaseInsights, impact };
   }, [activeEntries, entries, yearBudget, yearSpent]);
-
-  // Monthly timeline view data
-  const monthlyPlan = useMemo(() => {
-    if (viewMode !== 'timeline') return [];
-    const months: { month: string; entries: PurchaseQueueEntry[]; totalCost: number }[] = [];
-    const now = new Date();
-    for (let i = 0; i < 6; i++) {
-      const d = new Date(now.getFullYear(), now.getMonth() + i, 1);
-      const monthStr = d.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
-      const monthEntries = activeEntries.filter(e => {
-        if (!e.releaseDate) return i === 0; // no release date → show in current month
-        const rel = new Date(e.releaseDate);
-        return rel.getMonth() === d.getMonth() && rel.getFullYear() === d.getFullYear();
-      });
-      if (monthEntries.length > 0 || i === 0) {
-        const totalCost = monthEntries.reduce((s, e) => s + (e.targetPrice ?? e.currentPrice ?? e.msrpEstimate ?? 0), 0);
-        months.push({ month: monthStr, entries: monthEntries, totalCost });
-      }
-    }
-    return months;
-  }, [activeEntries, viewMode]);
 
   const wishlistForModal = wishlistGames.map(g => ({
     name: g.name,
@@ -214,37 +217,10 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
     thumbnail: g.thumbnail,
   }));
 
-  // Display order respects the active sort; drag only rewires Manual priority.
-  const sortComparator = useMemo(() => {
-    return (a: PurchaseQueueEntry, b: PurchaseQueueEntry): number => {
-      switch (sortMode) {
-        case 'confidence': return getBuyConfidence(b, allGames).score - getBuyConfidence(a, allGames).score;
-        case 'price': return priceOf(a) - priceOf(b);
-        case 'release': {
-          const ra = a.releaseDate ? new Date(a.releaseDate).getTime() : Infinity;
-          const rb = b.releaseDate ? new Date(b.releaseDate).getTime() : Infinity;
-          return ra - rb;
-        }
-        case 'value': {
-          const va = VALUE_RANK[getPredictedValue(a, allGames)?.predictedRating ?? ''] ?? 0;
-          const vb = VALUE_RANK[getPredictedValue(b, allGames)?.predictedRating ?? ''] ?? 0;
-          return vb - va;
-        }
-        default: return a.priority - b.priority;
-      }
-    };
-  }, [sortMode, allGames]);
-
-  const sortedCommitted = useMemo(() => [...activeEntries].sort(sortComparator), [activeEntries, sortComparator]);
-  const sortedMaybe = useMemo(() => [...maybeEntries].sort(sortComparator), [maybeEntries, sortComparator]);
-  const sortedDeferred = useMemo(() => [...deferredEntries].sort(sortComparator), [deferredEntries, sortComparator]);
-
-  const dragEnabled = sortMode === 'priority';
-
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
     if (!over || active.id === over.id) return;
-    const ids = sortedCommitted.map(e => e.id);
+    const ids = undatedCommitted.map(e => e.id);
     const oldIndex = ids.indexOf(active.id as string);
     const newIndex = ids.indexOf(over.id as string);
     if (oldIndex < 0 || newIndex < 0) return;
@@ -271,8 +247,6 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
   const handleMarkPurchased = async (id: string, price?: number) => {
     const entry = entries.find(e => e.id === id);
     await markPurchased(id, price);
-
-    // Auto-create in library (Feature #12), then offer the buy → play handoff (A3)
     if (entry && onAddGameToLibrary) {
       const newGameId = await onAddGameToLibrary({
         name: entry.gameName,
@@ -294,6 +268,32 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
     [activeEntries, maybeEntries, deferredEntries, purchasedEntries]
   );
 
+  // Renders a committed card with its budget-left chip + the cutoff divider.
+  const renderCommittedCard = (entry: PurchaseQueueEntry, dragHandleProps?: React.HTMLAttributes<HTMLButtonElement>) => {
+    const row = tallyMap.get(entry.id);
+    return (
+      <div key={entry.id} className="space-y-2">
+        {yearBudget != null && tally.cutoffId === entry.id && (
+          <div className="flex items-center gap-2 py-0.5">
+            <div className="flex-1 h-px bg-red-500/20" />
+            <span className="text-[10px] text-red-400/70 uppercase tracking-wider">Budget runs out</span>
+            <div className="flex-1 h-px bg-red-500/20" />
+          </div>
+        )}
+        <BuyQueueCard
+          entry={entry}
+          allGames={allGames}
+          onUpdate={updateEntry}
+          onMarkPurchased={handleMarkPurchased}
+          onDelete={handleDelete}
+          onSetIntent={(intent) => setIntent(entry.id, intent)}
+          budgetLeft={row ? { remaining: row.remaining, isOver: row.isOver } : null}
+          dragHandleProps={dragHandleProps}
+        />
+      </div>
+    );
+  };
+
   // SVG budget ring helper
   const renderBudgetRing = () => {
     if (yearBudget == null) return null;
@@ -303,23 +303,18 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
     const circumference = 2 * Math.PI * radius;
     const spentDash = (spentPct / 100) * circumference;
     const plannedDash = (plannedPct / 100) * circumference;
-    const spentOffset = 0;
-    const plannedOffset = circumference - spentDash;
 
     return (
       <div className="flex items-center gap-5">
         <div className="relative flex-shrink-0" style={{ width: size, height: size }}>
           <svg width={size} height={size} className="transform -rotate-90">
-            {/* Background track */}
             <circle cx={size/2} cy={size/2} r={radius} fill="none" stroke="rgba(255,255,255,0.05)" strokeWidth={strokeWidth} />
-            {/* Spent arc */}
             <circle cx={size/2} cy={size/2} r={radius} fill="none"
               stroke="#10b981" strokeWidth={strokeWidth} strokeLinecap="round"
               strokeDasharray={`${spentDash} ${circumference - spentDash}`}
-              strokeDashoffset={spentOffset}
+              strokeDashoffset={0}
               className="transition-all duration-700"
             />
-            {/* Planned arc */}
             {plannedPct > 0 && (
               <circle cx={size/2} cy={size/2} r={radius} fill="none"
                 stroke={isOverBudget ? '#ef4444' : '#f59e0b'} strokeWidth={strokeWidth} strokeLinecap="round"
@@ -329,7 +324,6 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
               />
             )}
           </svg>
-          {/* Center text */}
           <div className="absolute inset-0 flex flex-col items-center justify-center">
             {isOverBudget ? (
               <>
@@ -379,10 +373,13 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
     );
   }
 
+  const modeLabel = priceMode === 'full' ? 'full price' : priceMode === 'model' ? `${Math.round(modelDiscount * 100)}% off` : 'your deal prices';
+  const isEmpty = orderedCommitted.length === 0 && laterEntries.length === 0;
+
   return (
     <div className="space-y-5">
-      {/* Deal Alert Banner (Feature #11) */}
-      {mainView === 'watching' && dealsAtTarget.length > 0 && (
+      {/* Deal Alert Banner */}
+      {dealsAtTarget.length > 0 && (
         <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/[0.08] p-3 buy-queue-deal-alert">
           <div className="flex items-center gap-2">
             <div className="w-8 h-8 rounded-full bg-emerald-500/20 flex items-center justify-center flex-shrink-0">
@@ -401,8 +398,8 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
         </div>
       )}
 
-      {/* Sale Season Badge (Feature #20) */}
-      {mainView === 'watching' && saleSeason && (
+      {/* Sale Season Badge */}
+      {saleSeason && (
         <div className={clsx(
           'flex items-center gap-2 px-3 py-2 rounded-lg text-xs',
           saleSeason.inSeason
@@ -417,7 +414,7 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
         </div>
       )}
 
-      {/* Budget Ring (Feature #1) */}
+      {/* Budget card — ring + pricing model + how-many-fit headline */}
       <div className={clsx(
         'rounded-xl border p-4',
         isOverBudget ? 'bg-red-500/5 border-red-500/20' : 'bg-white/[0.02] border-white/5'
@@ -425,67 +422,69 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
         {yearBudget != null ? (
           <>
             {renderBudgetRing()}
-            {activeEntries.length > 0 && (
+            {total > 0 && (
               <div className="mt-3 pt-3 border-t border-white/5 space-y-2.5">
-                {/* Pricing scenario toggle */}
-                <div className="flex items-center justify-between">
+                {/* Pricing scenario control */}
+                <div className="flex items-center justify-between gap-2">
                   <span className="text-[11px] text-white/30">Price assumption</span>
                   <div className="flex items-center bg-white/5 rounded-lg overflow-hidden">
-                    <button
-                      onClick={() => handlePricingMode('deal')}
-                      className={clsx('px-2.5 py-1 text-[11px] transition-all',
-                        pricingMode === 'deal' ? 'bg-emerald-500/15 text-emerald-400 font-medium' : 'text-white/30 hover:text-white/50')}
-                    >
-                      Deal price
-                    </button>
-                    <button
-                      onClick={() => handlePricingMode('full')}
-                      className={clsx('px-2.5 py-1 text-[11px] transition-all',
-                        pricingMode === 'full' ? 'bg-white/10 text-white/70 font-medium' : 'text-white/30 hover:text-white/50')}
-                    >
-                      Full price
-                    </button>
+                    {(['deal', 'full', 'model'] as PriceMode[]).map(m => (
+                      <button
+                        key={m}
+                        onClick={() => handlePriceMode(m)}
+                        className={clsx('px-2.5 py-1 text-[11px] transition-all',
+                          priceMode === m
+                            ? (m === 'deal' ? 'bg-emerald-500/15 text-emerald-400 font-medium' : 'bg-white/10 text-white/70 font-medium')
+                            : 'text-white/30 hover:text-white/50')}
+                      >
+                        {m === 'deal' ? 'My deals' : m === 'full' ? 'Full price' : 'Model %'}
+                      </button>
+                    ))}
                   </div>
                 </div>
+
+                {/* Discount slider (model mode) */}
+                {priceMode === 'model' && (
+                  <div className="flex items-center gap-2">
+                    <Percent size={12} className="text-emerald-400/70 flex-shrink-0" />
+                    <input
+                      type="range" min={0} max={80} step={5}
+                      value={Math.round(modelDiscount * 100)}
+                      onChange={e => handleModelDiscount(parseInt(e.target.value) / 100)}
+                      className="flex-1 accent-emerald-500"
+                    />
+                    <span className="text-xs text-white/60 font-medium w-12 text-right">{Math.round(modelDiscount * 100)}% off</span>
+                  </div>
+                )}
+
                 {/* "How many fit" headline */}
                 <div className="flex items-start gap-2">
                   <Wallet size={14} className="text-emerald-400 mt-0.5 flex-shrink-0" />
                   <p className="text-xs text-white/60 leading-relaxed">
-                    {(() => {
-                      const fit = pricingMode === 'full' ? budgetFit.fullPrice : budgetFit.deal;
-                      const allFit = fit.affordableCount >= budgetFit.total;
-                      const label = pricingMode === 'full' ? 'full price' : 'deal prices';
-                      return (
-                        <>
-                          {allFit ? (
-                            <>All <span className="font-medium text-white/90">{budgetFit.total}</span> picks fit at {label}.</>
-                          ) : (
-                            <>Budget fits your top <span className="font-medium text-emerald-400">{fit.affordableCount}</span> of {budgetFit.total} at {label}.</>
-                          )}{' '}
-                          {pricingMode === 'full' && budgetFit.extraFromDeals > 0 && (
-                            <span className="text-white/40">Wait for deals → <span className="text-amber-400 font-medium">{budgetFit.extraFromDeals} more</span> fit.</span>
-                          )}
-                          {pricingMode === 'deal' && budgetFit.potentialSavings > 0 && (
-                            <span className="text-white/40">Waiting saves ~<span className="text-emerald-400 font-medium">{formatMoney(budgetFit.potentialSavings)}</span> vs full price.</span>
-                          )}
-                        </>
-                      );
-                    })()}
+                    {fitNow >= total ? (
+                      <>All <span className="font-medium text-white/90">{total}</span> picks fit at {modeLabel}.</>
+                    ) : (
+                      <>Budget fits your top <span className="font-medium text-emerald-400">{fitNow}</span> of {total} at {modeLabel}.</>
+                    )}{' '}
+                    {priceMode === 'full' && fitDeal > fitFull && (
+                      <span className="text-white/40">Wait for deals → <span className="text-amber-400 font-medium">{fitDeal - fitFull} more</span> fit.</span>
+                    )}
+                    {priceMode === 'deal' && potentialSavings > 0 && (
+                      <span className="text-white/40">Waiting saves ~<span className="text-emerald-400 font-medium">{formatMoney(potentialSavings)}</span> vs full price.</span>
+                    )}
+                    {priceMode === 'model' && (
+                      <span className="text-white/40">That&apos;s <span className="text-emerald-400 font-medium">{fitNow}</span> games for <span className="text-white/60 font-medium">{formatMoney(committedTotal)}</span>.</span>
+                    )}
                   </p>
                 </div>
-                {/* Spillover games at the current assumption */}
-                {(() => {
-                  const fit = pricingMode === 'full' ? budgetFit.fullPrice : budgetFit.deal;
-                  if (fit.overflowItems.length === 0) return null;
-                  return (
-                    <div className="flex items-start gap-1.5 text-[10px] text-amber-400/70">
-                      <Target size={10} className="flex-shrink-0 mt-0.5" />
-                      <span>
-                        Spills over: <span className="text-white/40">{fit.overflowItems.slice(0, 3).join(', ')}{fit.overflowItems.length > 3 ? `, +${fit.overflowItems.length - 3} more` : ''}</span>
-                      </span>
-                    </div>
-                  );
-                })()}
+
+                {/* Spillover */}
+                {overflowNames.length > 0 && (
+                  <div className="flex items-start gap-1.5 text-[10px] text-amber-400/70">
+                    <Target size={10} className="flex-shrink-0 mt-0.5" />
+                    <span>Spills over: <span className="text-white/40">{overflowNames.slice(0, 3).join(', ')}{overflowNames.length > 3 ? `, +${overflowNames.length - 3} more` : ''}</span></span>
+                  </div>
+                )}
               </div>
             )}
           </>
@@ -493,9 +492,7 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
           <div className="flex items-center justify-between">
             <div>
               <span className="text-xs font-medium text-white/50 uppercase tracking-wider">{currentYear} Budget</span>
-              <p className="text-[11px] text-white/25 mt-1">
-                Set a budget in Stats to track spend vs plan here
-              </p>
+              <p className="text-[11px] text-white/25 mt-1">Set a budget in Stats to track spend vs plan here</p>
             </div>
             <button
               onClick={onGoToBudget}
@@ -508,53 +505,19 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
         )}
       </div>
 
-      {/* Watching | Bought switch */}
-      <div className="flex items-center bg-white/5 rounded-lg overflow-hidden w-fit">
-        <button
-          onClick={() => setMainView('watching')}
-          className={clsx('flex items-center gap-1.5 px-3 py-1.5 text-xs transition-all',
-            mainView === 'watching' ? 'bg-white/10 text-white/80 font-medium' : 'text-white/40 hover:text-white/60')}
-        >
-          <ShoppingCart size={13} />
-          Watching
-          {activeEntries.length + maybeEntries.length + deferredEntries.length > 0 && (
-            <span className="text-white/30">{activeEntries.length + maybeEntries.length + deferredEntries.length}</span>
-          )}
-        </button>
-        <button
-          onClick={() => setMainView('bought')}
-          className={clsx('flex items-center gap-1.5 px-3 py-1.5 text-xs transition-all',
-            mainView === 'bought' ? 'bg-white/10 text-white/80 font-medium' : 'text-white/40 hover:text-white/60')}
-        >
-          <PackageCheck size={13} />
-          Bought
-          {purchasedEntries.length > 0 && (
-            <span className="text-white/30">{purchasedEntries.length}</span>
-          )}
-        </button>
-      </div>
-
-      {mainView === 'watching' && (
-      <>
       {/* Header bar */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3 flex-wrap">
           <div className="flex items-center gap-2">
             <ShoppingCart size={16} className="text-emerald-400" />
             <span className="text-white/70 text-sm">
-              <span className="text-white font-medium">{activeEntries.length}</span> watching
+              <span className="text-white font-medium">{activeEntries.length}</span> to buy
             </span>
           </div>
-          {maybeEntries.length > 0 && (
+          {laterEntries.length > 0 && (
             <div className="flex items-center gap-1.5 text-xs text-amber-400/70">
               <HelpCircle size={12} />
-              <span>{maybeEntries.length} maybe</span>
-            </div>
-          )}
-          {deferredEntries.length > 0 && (
-            <div className="flex items-center gap-1.5 text-xs text-blue-400/70">
-              <Tag size={12} />
-              <span>{deferredEntries.length} deferred</span>
+              <span>{laterEntries.length} later</span>
             </div>
           )}
           {releasingSoon > 0 && (
@@ -566,59 +529,21 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
         </div>
 
         <div className="flex items-center gap-2">
-          {/* Sort control (A2) — list view only */}
-          {viewMode === 'list' && activeEntries.length > 1 && (
-            <div className="flex items-center gap-1.5 bg-white/5 rounded-lg pl-2 pr-1">
-              <ArrowUpDown size={12} className="text-white/30" />
-              <select
-                value={sortMode}
-                onChange={e => setSortMode(e.target.value as SortMode)}
-                className="bg-transparent text-xs text-white/60 py-1.5 pr-1 focus:outline-none cursor-pointer"
-              >
-                {SORT_OPTIONS.map(o => (
-                  <option key={o.value} value={o.value} className="bg-[#1a1a2e]">{o.label}</option>
-                ))}
-              </select>
-            </div>
-          )}
-
-          {/* AI gut-check (C1) */}
           {activeEntries.length > 0 && (
             <button
               onClick={handleAskAI}
               disabled={aiLoading}
-              className={clsx(
-                'flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs transition-all',
-                aiAdvice ? 'bg-purple-500/15 text-purple-400' : 'bg-white/5 text-white/40 hover:text-white/60'
-              )}
+              className={clsx('flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs transition-all',
+                aiAdvice ? 'bg-purple-500/15 text-purple-400' : 'bg-white/5 text-white/40 hover:text-white/60')}
               title="Ask AI: should I buy these?"
             >
               {aiLoading ? <Loader2 size={13} className="animate-spin" /> : <Wand2 size={13} />}
             </button>
           )}
-
-          {/* View toggle (Feature #14) */}
-          <div className="flex items-center bg-white/5 rounded-lg overflow-hidden">
-            <button
-              onClick={() => setViewMode('list')}
-              className={clsx('px-2.5 py-1.5 text-xs transition-all', viewMode === 'list' ? 'bg-white/10 text-white/80' : 'text-white/30')}
-            >
-              List
-            </button>
-            <button
-              onClick={() => setViewMode('timeline')}
-              className={clsx('px-2.5 py-1.5 text-xs transition-all', viewMode === 'timeline' ? 'bg-white/10 text-white/80' : 'text-white/30')}
-            >
-              Plan
-            </button>
-          </div>
-
           <button
             onClick={() => setShowStats(!showStats)}
-            className={clsx(
-              'flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs transition-all',
-              showStats ? 'bg-emerald-500/15 text-emerald-400' : 'bg-white/5 text-white/40 hover:text-white/60'
-            )}
+            className={clsx('flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs transition-all',
+              showStats ? 'bg-emerald-500/15 text-emerald-400' : 'bg-white/5 text-white/40 hover:text-white/60')}
           >
             <BarChart2 size={13} />
           </button>
@@ -632,7 +557,7 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
         </div>
       </div>
 
-      {/* AI gut-check banner (C1) */}
+      {/* AI gut-check banner */}
       {aiAdvice && (
         <div className="rounded-xl border border-purple-500/20 bg-purple-500/[0.06] p-3">
           <div className="flex items-start gap-2">
@@ -650,7 +575,7 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
         </div>
       )}
 
-      {/* Buy → Play handoff (A3) */}
+      {/* Buy → Play handoff */}
       {justPurchased && (
         <div className="rounded-xl border border-emerald-500/25 bg-emerald-500/[0.07] p-3 flex items-center gap-2">
           <PackageCheck size={15} className="text-emerald-400 flex-shrink-0" />
@@ -673,16 +598,14 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
         </div>
       )}
 
-      {/* Stats Dashboard (Feature #15) */}
+      {/* Stats Dashboard */}
       {showStats && activeEntries.length > 0 && (
         <div className="bg-white/[0.02] border border-white/5 rounded-xl p-4 space-y-4">
           <h3 className="text-xs font-medium text-white/50 uppercase tracking-wider">Queue Intelligence</h3>
-
-          {/* Quick stats row */}
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
             <div className="p-3 rounded-lg bg-white/[0.02]">
               <div className="text-lg font-semibold text-white/90">{activeEntries.length}</div>
-              <div className="text-[11px] text-white/30">Watching</div>
+              <div className="text-[11px] text-white/30">To buy</div>
             </div>
             <div className="p-3 rounded-lg bg-white/[0.02]">
               <div className="text-lg font-semibold text-amber-400">{stats.dayOneBuys}</div>
@@ -692,78 +615,31 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
               <div className="text-lg font-semibold text-white/90">{formatMoney(plannedSpend)}</div>
               <div className="text-[11px] text-white/30">Planned</div>
             </div>
-            {maybeEntries.length > 0 ? (
-              <div className="p-3 rounded-lg bg-amber-500/[0.05] border border-amber-500/10">
-                <div className="text-lg font-semibold text-amber-400/80">{maybeEntries.length}</div>
-                <div className="text-[11px] text-white/30">
-                  Maybe{maybeSpend > 0 ? ` · ${formatMoney(maybeSpend)}` : ''}
-                </div>
-              </div>
-            ) : stats.totalSavingsPotential > 0 ? (
+            {stats.totalSavingsPotential > 0 && (
               <div className="p-3 rounded-lg bg-white/[0.02]">
                 <div className="text-lg font-semibold text-emerald-400">{formatMoney(stats.totalSavingsPotential)}</div>
                 <div className="text-[11px] text-white/30">Potential Savings</div>
               </div>
-            ) : null}
+            )}
           </div>
-
-          {/* "If You Bought Everything" Snapshot (Feature #16) */}
-          {stats.impact.totalCost > 0 && (
-            <div className="p-3 rounded-lg bg-white/[0.03] border border-white/5">
-              <div className="flex items-center gap-2 mb-2">
-                <Sparkles size={12} className="text-purple-400" />
-                <span className="text-xs font-medium text-white/50">If You Bought Everything</span>
-              </div>
-              <div className="flex items-center gap-4 flex-wrap text-[11px]">
-                <span className="text-white/70 font-medium">{formatMoney(stats.impact.totalCost)} total</span>
-                {stats.impact.overBudget != null && stats.impact.overBudget > 0 && (
-                  <span className="text-red-400">{formatMoney(stats.impact.overBudget)} over budget</span>
-                )}
-                <span className="text-white/40">{stats.impact.newLibrarySize} games</span>
-              </div>
-              {/* Budget reaches only so far (D2) */}
-              {yearBudget != null && stats.impact.overflowItems.length > 0 && (
-                <div className="mt-2 flex items-start gap-1.5 text-[10px] text-amber-400/70">
-                  <Target size={10} className="flex-shrink-0 mt-0.5" />
-                  <span>
-                    Budget covers your top <span className="font-medium text-amber-400">{stats.impact.affordableCount}</span> pick{stats.impact.affordableCount !== 1 ? 's' : ''}.
-                    {' '}<span className="text-white/40">{stats.impact.overflowItems.slice(0, 3).join(', ')}{stats.impact.overflowItems.length > 3 ? '…' : ''}</span> spill over.
-                  </span>
-                </div>
-              )}
-              {stats.impact.genreBreakdown.length > 0 && (
-                <div className="flex items-center gap-1.5 mt-2 flex-wrap">
-                  {stats.impact.genreBreakdown.slice(0, 4).map(g => (
-                    <span key={g.genre} className="text-[10px] px-1.5 py-0.5 rounded bg-white/5 text-white/40">
-                      {g.genre} ({g.count})
-                    </span>
-                  ))}
-                </div>
-              )}
-            </div>
-          )}
-
-          {/* Platform breakdown */}
           {Object.keys(stats.platformBreakdown).length > 0 && (
             <div>
               <div className="text-[11px] text-white/30 mb-2">By Platform</div>
               <div className="flex items-center gap-2 flex-wrap">
-                {Object.entries(stats.platformBreakdown)
-                  .sort((a, b) => b[1] - a[1])
-                  .map(([plat, count]) => (
-                    <div key={plat} className="flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-white/5 text-xs">
-                      <span className="text-white/60">{plat}</span>
-                      <span className="text-white/30">{count}</span>
-                    </div>
-                  ))}
+                {Object.entries(stats.platformBreakdown).sort((a, b) => b[1] - a[1]).map(([plat, count]) => (
+                  <div key={plat} className="flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-white/5 text-xs">
+                    <span className="text-white/60">{plat}</span>
+                    <span className="text-white/30">{count}</span>
+                  </div>
+                ))}
               </div>
             </div>
           )}
         </div>
       )}
 
-      {/* Empty state (Feature #18) */}
-      {activeEntries.length === 0 && maybeEntries.length === 0 && deferredEntries.length === 0 && (
+      {/* Empty state */}
+      {isEmpty && (
         <div className="text-center py-16 space-y-4">
           <div className="w-16 h-16 rounded-2xl bg-white/[0.03] flex items-center justify-center mx-auto">
             <ShoppingCart size={28} className="text-white/10" />
@@ -795,256 +671,127 @@ export function BuyQueueTab({ userId, wishlistGames, allGames, budgets, yearSpen
         </div>
       )}
 
-      {/* List View */}
-      {viewMode === 'list' && (
-        <>
-          {/* Watching section — committed, drag-to-prioritize in Manual mode (A1/A2) */}
-          {sortedCommitted.length > 0 && (
-            <div className="space-y-2">
-              <div className="flex items-center gap-2">
-                <Clock size={13} className="text-emerald-400" />
-                <h3 className="text-xs font-medium text-white/50 uppercase tracking-wider">Watching</h3>
-                <span className="text-[11px] text-white/25">{sortedCommitted.length}</span>
-                {dragEnabled && sortedCommitted.length > 1 && (
-                  <span className="text-[10px] text-white/20 ml-auto">Drag to prioritize</span>
-                )}
-              </div>
-              {dragEnabled ? (
-                <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-                  <SortableContext items={sortedCommitted.map(e => e.id)} strategy={verticalListSortingStrategy}>
-                    <div className="space-y-2">
-                      {sortedCommitted.map(entry => (
-                        <SortableBuyCard key={entry.id} entry={entry}>
-                          {(handleProps) => (
-                            <BuyQueueCard
-                              entry={entry}
-                              allGames={allGames}
-                              onUpdate={updateEntry}
-                              onMarkPurchased={handleMarkPurchased}
-                              onDelete={handleDelete}
-                              onSetIntent={(intent) => setIntent(entry.id, intent)}
-                              verdict={aiAdvice?.verdicts[entry.gameName]}
-                              dragHandleProps={handleProps}
-                            />
-                          )}
-                        </SortableBuyCard>
-                      ))}
-                    </div>
-                  </SortableContext>
-                </DndContext>
-              ) : (
-                <div className="space-y-2">
-                  {sortedCommitted.map(entry => (
-                    <BuyQueueCard
-                      key={entry.id}
-                      entry={entry}
-                      allGames={allGames}
-                      onUpdate={updateEntry}
-                      onMarkPurchased={handleMarkPurchased}
-                      onDelete={handleDelete}
-                      onSetIntent={(intent) => setIntent(entry.id, intent)}
-                      verdict={aiAdvice?.verdicts[entry.gameName]}
-                    />
-                  ))}
-                </div>
-              )}
-            </div>
-          )}
-
-          {/* Maybe section */}
-          {maybeEntries.length > 0 && (
-            <div className="space-y-2">
-              <div className="flex items-center gap-2">
-                <HelpCircle size={13} className="text-amber-400/70" />
-                <h3 className="text-xs font-medium text-white/50 uppercase tracking-wider">Maybe</h3>
-                <span className="text-[11px] text-white/25">{maybeEntries.length}</span>
-                {maybeSpend > 0 && (
-                  <span className="text-[11px] text-amber-400/40 ml-auto">{formatMoney(maybeSpend)} possible</span>
-                )}
-              </div>
-              <div className="space-y-2">
-                {sortedMaybe.map(entry => (
-                  <BuyQueueCard
-                    key={entry.id}
-                    entry={entry}
-                    allGames={allGames}
-                    onUpdate={updateEntry}
-                    onMarkPurchased={handleMarkPurchased}
-                    onDelete={handleDelete}
-                    onSetIntent={(intent) => setIntent(entry.id, intent)}
-                    verdict={aiAdvice?.verdicts[entry.gameName]}
-                  />
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Deferred section — waiting for a deal */}
-          {deferredEntries.length > 0 && (
-            <div className="space-y-2">
-              <div className="flex items-center gap-2">
-                <Tag size={13} className="text-blue-400/70" />
-                <h3 className="text-xs font-medium text-white/50 uppercase tracking-wider">Deferred — Waiting for a Deal</h3>
-                <span className="text-[11px] text-white/25">{deferredEntries.length}</span>
-                {deferredSpend > 0 && (
-                  <span className="text-[11px] text-blue-400/40 ml-auto">{formatMoney(deferredSpend)} at full price</span>
-                )}
-              </div>
-              <div className="space-y-2">
-                {sortedDeferred.map(entry => (
-                  <BuyQueueCard
-                    key={entry.id}
-                    entry={entry}
-                    allGames={allGames}
-                    onUpdate={updateEntry}
-                    onMarkPurchased={handleMarkPurchased}
-                    onDelete={handleDelete}
-                    onSetIntent={(intent) => setIntent(entry.id, intent)}
-                    verdict={aiAdvice?.verdicts[entry.gameName]}
-                  />
-                ))}
-              </div>
-            </div>
-          )}
-        </>
-      )}
-
-      {/* Timeline/Plan View (Feature #14) */}
-      {viewMode === 'timeline' && (
-        <div className="space-y-4">
-          {monthlyPlan.length === 0 && activeEntries.length === 0 && (
-            <p className="text-center text-white/25 text-sm py-8">No games to show in the timeline</p>
-          )}
-          {monthlyPlan.map(month => {
-            const monthlyBudget = yearBudget != null ? yearBudget / 12 : null;
-            const overMonth = monthlyBudget != null && month.totalCost > monthlyBudget;
-            const pacePct = monthlyBudget != null && monthlyBudget > 0
-              ? Math.min(100, (month.totalCost / monthlyBudget) * 100) : 0;
-            return (
-            <div key={month.month} className="space-y-2">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <Calendar size={13} className="text-purple-400" />
-                  <h3 className="text-xs font-medium text-white/50 uppercase tracking-wider">{month.month}</h3>
-                  <span className="text-[11px] text-white/25">{month.entries.length} game{month.entries.length !== 1 ? 's' : ''}</span>
-                </div>
-                {month.totalCost > 0 && (
-                  <span className={clsx('text-xs', overMonth ? 'text-red-400' : 'text-white/30')}>
-                    {formatMoney(month.totalCost)}
-                    {monthlyBudget != null && <span className="text-white/20"> / {formatMoney(monthlyBudget)}</span>}
-                  </span>
-                )}
-              </div>
-              {monthlyBudget != null && month.totalCost > 0 && (
-                <div className="h-1 rounded-full bg-white/5 overflow-hidden">
-                  <div
-                    className={clsx('h-full rounded-full transition-all', overMonth ? 'bg-red-500/70' : 'bg-emerald-500/60')}
-                    style={{ width: `${pacePct}%` }}
-                  />
-                </div>
-              )}
-              {month.entries.length > 0 ? (
-                <div className="space-y-2">
-                  {month.entries.map(entry => (
-                    <BuyQueueCard
-                      key={entry.id}
-                      entry={entry}
-                      allGames={allGames}
-                      onUpdate={updateEntry}
-                      onMarkPurchased={handleMarkPurchased}
-                      onDelete={handleDelete}
-                      onSetIntent={(intent) => setIntent(entry.id, intent)}
-                    />
-                  ))}
-                </div>
-              ) : (
-                <div className="text-center py-4 text-[11px] text-white/15">No planned purchases</div>
-              )}
-            </div>
-            );
-          })}
+      {/* Dated group — release date order (available now → upcoming) */}
+      {datedCommitted.length > 0 && (
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Calendar size={13} className="text-emerald-400" />
+            <h3 className="text-xs font-medium text-white/50 uppercase tracking-wider">Dated</h3>
+            <span className="text-[11px] text-white/25">{datedCommitted.length}</span>
+          </div>
+          <div className="space-y-2">
+            {datedCommitted.map(entry => renderCommittedCard(entry))}
+          </div>
         </div>
       )}
-      </>
-      )}
 
-      {/* Bought view — purchased history */}
-      {mainView === 'bought' && (
-        purchasedEntries.length > 0 ? (
-            <div className="space-y-3">
-              <div className="flex items-center gap-2 text-xs text-white/40">
-                <PackageCheck size={13} className="text-white/30" />
-                <span><span className="text-white/70 font-medium">{purchasedEntries.length}</span> purchased</span>
-                {stats.purchaseInsights.totalSaved > 0 && (
-                  <span className="text-emerald-400/60 ml-auto">Saved {formatMoney(stats.purchaseInsights.totalSaved)} vs MSRP</span>
-                )}
-              </div>
-              {/* Purchase insights summary */}
-              {purchasedEntries.length >= 2 && (
-                <div className="flex items-center gap-4 flex-wrap px-3 py-2 bg-white/[0.02] rounded-lg text-[11px]">
-                  <div className="flex items-center gap-1.5">
-                    <Trophy size={10} className="text-amber-400" />
-                    <span className="text-white/40">Queue purchases:</span>
-                    <span className="text-white/60 font-medium">{stats.purchaseInsights.gamesFromQueue}</span>
-                  </div>
-                  {stats.purchaseInsights.totalSaved > 0 && (
-                    <div className="flex items-center gap-1.5">
-                      <TrendingDown size={10} className="text-emerald-400" />
-                      <span className="text-white/40">Saved vs MSRP:</span>
-                      <span className="text-emerald-400 font-medium">{formatMoney(stats.purchaseInsights.totalSaved)}</span>
-                    </div>
-                  )}
-                  {stats.purchaseInsights.avgWaitDays > 0 && (
-                    <div className="flex items-center gap-1.5">
-                      <Clock size={10} className="text-white/30" />
-                      <span className="text-white/40">Avg wait:</span>
-                      <span className="text-white/60 font-medium">{stats.purchaseInsights.avgWaitDays}d</span>
-                    </div>
-                  )}
-                </div>
-              )}
-
-              <div className="space-y-2 opacity-60">
-                {purchasedEntries.map(entry => (
-                  <div key={entry.id} className="flex items-center gap-3 p-3 bg-white/[0.02] border border-white/5 rounded-xl">
-                    {entry.thumbnail ? (
-                      <img src={entry.thumbnail} alt="" className="w-10 h-7 rounded object-cover flex-shrink-0 grayscale" />
-                    ) : (
-                      <div className="w-10 h-7 rounded bg-white/5 flex-shrink-0" />
-                    )}
-                    <div className="flex-1 min-w-0">
-                      <div className="text-sm text-white/50 truncate">{entry.gameName}</div>
-                      <div className="flex items-center gap-2 text-[11px] text-white/25">
-                        {entry.purchasePrice != null && <span>Paid ${entry.purchasePrice}</span>}
-                        {entry.msrpEstimate && entry.purchasePrice != null && entry.msrpEstimate > entry.purchasePrice && (
-                          <span className="text-emerald-400/60">Saved ${(entry.msrpEstimate - entry.purchasePrice).toFixed(0)}</span>
-                        )}
-                      </div>
-                    </div>
-                    <div className="flex items-center gap-1 text-emerald-400/60 text-[11px]">
-                      <PackageCheck size={11} />
-                    </div>
-                  </div>
+      {/* No-date group — priority order, drag to reorder */}
+      {undatedCommitted.length > 0 && (
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <HelpCircle size={13} className="text-white/40" />
+            <h3 className="text-xs font-medium text-white/50 uppercase tracking-wider">No date</h3>
+            <span className="text-[11px] text-white/25">{undatedCommitted.length}</span>
+            {undatedCommitted.length > 1 && (
+              <span className="text-[10px] text-white/20 ml-auto">Drag to prioritize</span>
+            )}
+          </div>
+          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+            <SortableContext items={undatedCommitted.map(e => e.id)} strategy={verticalListSortingStrategy}>
+              <div className="space-y-2">
+                {undatedCommitted.map(entry => (
+                  <SortableBuyCard key={entry.id} entry={entry}>
+                    {(handleProps) => renderCommittedCard(entry, handleProps)}
+                  </SortableBuyCard>
                 ))}
               </div>
-            </div>
-        ) : (
-          <div className="text-center py-16 space-y-3">
-            <div className="w-16 h-16 rounded-2xl bg-white/[0.03] flex items-center justify-center mx-auto">
-              <PackageCheck size={28} className="text-white/10" />
-            </div>
-            <div>
-              <p className="text-white/40 text-sm font-medium">Nothing bought yet</p>
-              <p className="text-white/20 text-xs mt-1.5 max-w-xs mx-auto leading-relaxed">
-                When you mark a queued game as purchased, it lands here with how much you saved versus full price.
-              </p>
-            </div>
-          </div>
-        )
+            </SortableContext>
+          </DndContext>
+        </div>
       )}
 
-      {/* Wishlist nudge (Feature #13) */}
-      {mainView === 'watching' && wishlistGames.length > 0 && (activeEntries.length > 0 || maybeEntries.length > 0 || deferredEntries.length > 0) && (
+      {/* Later / Maybe group — ghosted projection, collapsible */}
+      {laterEntries.length > 0 && (
+        <div className="space-y-2">
+          <button
+            onClick={() => setShowLater(!showLater)}
+            className="flex items-center gap-2 w-full text-left"
+          >
+            {showLater ? <ChevronUp size={13} className="text-white/30" /> : <ChevronDown size={13} className="text-white/30" />}
+            <Tag size={13} className="text-amber-400/70" />
+            <h3 className="text-xs font-medium text-white/50 uppercase tracking-wider">Later / Maybe</h3>
+            <span className="text-[11px] text-white/25">{laterEntries.length}</span>
+            {maybeSpend > 0 && (
+              <span className="text-[11px] text-amber-400/40 ml-auto">{formatMoney(laterEntries.reduce((s, e) => s + (e.targetPrice ?? e.currentPrice ?? e.msrpEstimate ?? 0), 0))} if added</span>
+            )}
+          </button>
+          {showLater && (
+            <div className="space-y-2">
+              {laterEntries.map(entry => {
+                const g = ghostMap.get(entry.id);
+                return (
+                  <BuyQueueCard
+                    key={entry.id}
+                    entry={entry}
+                    allGames={allGames}
+                    onUpdate={updateEntry}
+                    onMarkPurchased={handleMarkPurchased}
+                    onDelete={handleDelete}
+                    onSetIntent={(intent) => setIntent(entry.id, intent)}
+                    budgetLeft={g ? { remaining: g.remaining, isOver: g.isOver, ghost: true } : null}
+                  />
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Bought / spent — collapsible, bottom of the view */}
+      {purchasedEntries.length > 0 && (
+        <div className="space-y-2 pt-1">
+          <button
+            onClick={() => setShowBought(!showBought)}
+            className="flex items-center gap-2 w-full text-left"
+          >
+            {showBought ? <ChevronUp size={13} className="text-white/30" /> : <ChevronDown size={13} className="text-white/30" />}
+            <PackageCheck size={13} className="text-white/30" />
+            <h3 className="text-xs font-medium text-white/50 uppercase tracking-wider">Bought</h3>
+            <span className="text-[11px] text-white/25">{purchasedEntries.length}</span>
+            <span className="text-[11px] text-white/40 ml-auto">
+              Spent <span className="text-white/70 font-medium">{formatMoney(boughtSpent)}</span>
+              {yearBudget != null && <span className="text-white/25"> of {formatMoney(yearBudget)}</span>}
+              {stats.purchaseInsights.totalSaved > 0 && <span className="text-emerald-400/60"> · saved {formatMoney(stats.purchaseInsights.totalSaved)}</span>}
+            </span>
+          </button>
+          {showBought && (
+            <div className="space-y-2 opacity-70">
+              {purchasedEntries.map(entry => (
+                <div key={entry.id} className="flex items-center gap-3 p-3 bg-white/[0.02] border border-white/5 rounded-xl">
+                  {entry.thumbnail ? (
+                    <img src={entry.thumbnail} alt="" className="w-10 h-7 rounded object-cover flex-shrink-0 grayscale" />
+                  ) : (
+                    <div className="w-10 h-7 rounded bg-white/5 flex-shrink-0" />
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm text-white/50 truncate">{entry.gameName}</div>
+                    <div className="flex items-center gap-2 text-[11px] text-white/25">
+                      {entry.purchasePrice != null && <span>Paid ${entry.purchasePrice}</span>}
+                      {entry.msrpEstimate && entry.purchasePrice != null && entry.msrpEstimate > entry.purchasePrice && (
+                        <span className="text-emerald-400/60">Saved ${(entry.msrpEstimate - entry.purchasePrice).toFixed(0)}</span>
+                      )}
+                    </div>
+                  </div>
+                  <PackageCheck size={11} className="text-emerald-400/60 flex-shrink-0" />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Wishlist nudge */}
+      {wishlistGames.length > 0 && !isEmpty && (
         (() => {
           const queuedNames = new Set([...activeEntries, ...maybeEntries, ...deferredEntries].map(e => e.gameName.toLowerCase()));
           const untracked = wishlistGames.filter(g => !queuedNames.has(g.name.toLowerCase()));

--- a/app/apps/game-analytics/data/baseline-buy-queue.ts
+++ b/app/apps/game-analytics/data/baseline-buy-queue.ts
@@ -1,0 +1,165 @@
+import { PurchaseQueueEntry } from '../lib/types';
+
+type SeedEntry = Omit<PurchaseQueueEntry, 'id' | 'userId' | 'createdAt' | 'updatedAt'>;
+
+const today = new Date();
+const iso = (d: Date) => d.toISOString();
+const daysFromNow = (n: number) => {
+  const d = new Date(today);
+  d.setDate(d.getDate() + n);
+  return d.toISOString().split('T')[0];
+};
+
+/**
+ * Sample Buy Queue entries for testing the budget tools.
+ *
+ * Designed to exercise every scenario in the redesigned Buy Queue tab:
+ *  - Full price vs. deal price gap (msrpEstimate > targetPrice)
+ *  - "How many fit" overflow once committed picks exceed the budget
+ *  - Maybe / Deferred buckets (excluded from the budget plan)
+ *  - A deal already at target price (triggers the deal alert)
+ *  - A purchased item so the "Bought" view has savings to show
+ */
+export const BASELINE_BUY_QUEUE: SeedEntry[] = [
+  // ── Watching (committed) — these count toward the budget plan ──
+  {
+    gameName: 'Grand Theft Auto VI',
+    platform: 'PlayStation',
+    genre: 'Action',
+    releaseDate: daysFromNow(110),
+    isDayOneBuy: true,
+    msrpEstimate: 70,
+    targetPrice: 70,
+    currentPrice: 70,
+    notes: 'Day-one, no waiting on this one.',
+    priority: 1,
+    purchased: false,
+    intent: 'committed',
+    addedAt: iso(today),
+  },
+  {
+    gameName: 'Monster Hunter Wilds',
+    platform: 'PlayStation',
+    genre: 'RPG',
+    releaseDate: daysFromNow(-90),
+    isDayOneBuy: false,
+    msrpEstimate: 70,
+    targetPrice: 50,
+    currentPrice: 60,
+    priority: 2,
+    purchased: false,
+    intent: 'committed',
+    addedAt: iso(today),
+  },
+  {
+    gameName: 'Civilization VII',
+    platform: 'Steam',
+    genre: 'Strategy',
+    releaseDate: daysFromNow(-120),
+    isDayOneBuy: false,
+    msrpEstimate: 70,
+    targetPrice: 40,
+    currentPrice: 55,
+    notes: 'Wait for the first proper sale.',
+    priority: 3,
+    purchased: false,
+    intent: 'committed',
+    addedAt: iso(today),
+  },
+  {
+    gameName: 'Hollow Knight: Silksong',
+    platform: 'Nintendo',
+    genre: 'Metroidvania',
+    releaseDate: daysFromNow(-30),
+    isDayOneBuy: false,
+    msrpEstimate: 30,
+    targetPrice: 20,
+    currentPrice: 30,
+    priority: 4,
+    purchased: false,
+    intent: 'committed',
+    addedAt: iso(today),
+  },
+
+  // ── Maybe — soft interest, excluded from the budget plan ──
+  {
+    gameName: 'Death Stranding 2: On the Beach',
+    platform: 'PlayStation',
+    genre: 'Action',
+    releaseDate: daysFromNow(40),
+    isDayOneBuy: false,
+    msrpEstimate: 70,
+    targetPrice: 50,
+    priority: 5,
+    purchased: false,
+    intent: 'maybe',
+    addedAt: iso(today),
+  },
+  {
+    gameName: 'Elden Ring: Nightreign',
+    platform: 'Steam',
+    genre: 'RPG',
+    releaseDate: daysFromNow(-10),
+    isDayOneBuy: false,
+    msrpEstimate: 40,
+    targetPrice: 30,
+    currentPrice: 40,
+    priority: 6,
+    purchased: false,
+    intent: 'maybe',
+    addedAt: iso(today),
+  },
+
+  // ── Deferred — waiting for a discount (home of deal alerts) ──
+  {
+    gameName: 'Metaphor: ReFantazio',
+    platform: 'Xbox',
+    genre: 'RPG',
+    releaseDate: daysFromNow(-200),
+    isDayOneBuy: false,
+    msrpEstimate: 70,
+    targetPrice: 35,
+    currentPrice: 35, // at target → fires the deal alert
+    priceHistory: [
+      { date: daysFromNow(-30), price: 50 },
+      { date: daysFromNow(-7), price: 42 },
+      { date: daysFromNow(0), price: 35 },
+    ],
+    priority: 7,
+    purchased: false,
+    intent: 'deferred',
+    addedAt: iso(today),
+  },
+  {
+    gameName: 'Star Wars Outlaws',
+    platform: 'PlayStation',
+    genre: 'Action',
+    releaseDate: daysFromNow(-260),
+    isDayOneBuy: false,
+    msrpEstimate: 70,
+    targetPrice: 25,
+    currentPrice: 30,
+    priority: 8,
+    purchased: false,
+    intent: 'deferred',
+    addedAt: iso(today),
+  },
+
+  // ── Already bought from the queue — populates the "Bought" view ──
+  {
+    gameName: 'Astro Bot',
+    platform: 'PlayStation',
+    genre: 'Platformer',
+    releaseDate: daysFromNow(-150),
+    isDayOneBuy: false,
+    msrpEstimate: 60,
+    targetPrice: 40,
+    currentPrice: 40,
+    priority: 9,
+    purchased: true,
+    purchasedAt: daysFromNow(-45),
+    purchasePrice: 40,
+    intent: 'committed',
+    addedAt: daysFromNow(-80),
+  },
+];

--- a/app/apps/game-analytics/data/baseline-buy-queue.ts
+++ b/app/apps/game-analytics/data/baseline-buy-queue.ts
@@ -4,33 +4,34 @@ type SeedEntry = Omit<PurchaseQueueEntry, 'id' | 'userId' | 'createdAt' | 'updat
 
 const today = new Date();
 const iso = (d: Date) => d.toISOString();
-const daysFromNow = (n: number) => {
+const day = (n: number) => {
   const d = new Date(today);
   d.setDate(d.getDate() + n);
   return d.toISOString().split('T')[0];
 };
 
 /**
- * Sample Buy Queue entries for testing the budget tools.
+ * Sample Buy Queue entries for testing the budget + pricing tools.
  *
- * Designed to exercise every scenario in the redesigned Buy Queue tab:
- *  - Full price vs. deal price gap (msrpEstimate > targetPrice)
- *  - "How many fit" overflow once committed picks exceed the budget
+ * Deliberately spread across every dimension the redesigned tab cares about:
+ *  - Dates: upcoming (various distances), released/available-now, and TBA (no date)
+ *  - Price gap: MSRP well above target so the Full vs Deal price toggle moves
+ *  - Price history: multi-point drops so the sparkline + "best yet" render
+ *  - A deal already at target (fires the deal alert)
  *  - Maybe / Deferred buckets (excluded from the budget plan)
- *  - A deal already at target price (triggers the deal alert)
- *  - A purchased item so the "Bought" view has savings to show
+ *  - Bought items with real savings so the Bought view has a spend story
  */
 export const BASELINE_BUY_QUEUE: SeedEntry[] = [
-  // ── Watching (committed) — these count toward the budget plan ──
+  // ── Committed, DATED, upcoming ──────────────────────────────
   {
     gameName: 'Grand Theft Auto VI',
     platform: 'PlayStation',
     genre: 'Action',
-    releaseDate: daysFromNow(110),
+    releaseDate: day(112),
     isDayOneBuy: true,
-    msrpEstimate: 70,
-    targetPrice: 70,
-    currentPrice: 70,
+    msrpEstimate: 80,
+    targetPrice: 80,
+    currentPrice: 80,
     notes: 'Day-one, no waiting on this one.',
     priority: 1,
     purchased: false,
@@ -38,15 +39,36 @@ export const BASELINE_BUY_QUEUE: SeedEntry[] = [
     addedAt: iso(today),
   },
   {
+    gameName: 'Death Stranding 2: On the Beach',
+    platform: 'PlayStation',
+    genre: 'Action',
+    releaseDate: day(34),
+    isDayOneBuy: false,
+    msrpEstimate: 70,
+    targetPrice: 50,
+    currentPrice: 70,
+    priority: 2,
+    purchased: false,
+    intent: 'committed',
+    addedAt: iso(today),
+  },
+
+  // ── Committed, DATED, released / available now (with price history) ──
+  {
     gameName: 'Monster Hunter Wilds',
     platform: 'PlayStation',
     genre: 'RPG',
-    releaseDate: daysFromNow(-90),
+    releaseDate: day(-92),
     isDayOneBuy: false,
     msrpEstimate: 70,
     targetPrice: 50,
     currentPrice: 60,
-    priority: 2,
+    priceHistory: [
+      { date: day(-60), price: 70 },
+      { date: day(-25), price: 65 },
+      { date: day(-3), price: 60 },
+    ],
+    priority: 3,
     purchased: false,
     intent: 'committed',
     addedAt: iso(today),
@@ -55,56 +77,62 @@ export const BASELINE_BUY_QUEUE: SeedEntry[] = [
     gameName: 'Civilization VII',
     platform: 'Steam',
     genre: 'Strategy',
-    releaseDate: daysFromNow(-120),
+    releaseDate: day(-124),
     isDayOneBuy: false,
     msrpEstimate: 70,
     targetPrice: 40,
-    currentPrice: 55,
-    notes: 'Wait for the first proper sale.',
-    priority: 3,
-    purchased: false,
-    intent: 'committed',
-    addedAt: iso(today),
-  },
-  {
-    gameName: 'Hollow Knight: Silksong',
-    platform: 'Nintendo',
-    genre: 'Metroidvania',
-    releaseDate: daysFromNow(-30),
-    isDayOneBuy: false,
-    msrpEstimate: 30,
-    targetPrice: 20,
-    currentPrice: 30,
+    currentPrice: 50,
+    priceHistory: [
+      { date: day(-90), price: 70 },
+      { date: day(-40), price: 60 },
+      { date: day(-10), price: 50 },
+    ],
+    notes: 'Wait for the first real sale.',
     priority: 4,
     purchased: false,
     intent: 'committed',
     addedAt: iso(today),
   },
 
-  // ── Maybe — soft interest, excluded from the budget plan ──
+  // ── Committed, NO DATE (TBA) ────────────────────────────────
   {
-    gameName: 'Death Stranding 2: On the Beach',
-    platform: 'PlayStation',
-    genre: 'Action',
-    releaseDate: daysFromNow(40),
+    gameName: 'Hades II',
+    platform: 'Steam',
+    genre: 'Roguelike',
     isDayOneBuy: false,
-    msrpEstimate: 70,
-    targetPrice: 50,
+    msrpEstimate: 30,
+    targetPrice: 25,
+    currentPrice: 30,
     priority: 5,
     purchased: false,
-    intent: 'maybe',
+    intent: 'committed',
     addedAt: iso(today),
   },
+
+  // ── Maybe — soft interest, excluded from the budget plan ────
   {
     gameName: 'Elden Ring: Nightreign',
     platform: 'Steam',
     genre: 'RPG',
-    releaseDate: daysFromNow(-10),
+    releaseDate: day(-12),
     isDayOneBuy: false,
     msrpEstimate: 40,
     targetPrice: 30,
     currentPrice: 40,
     priority: 6,
+    purchased: false,
+    intent: 'maybe',
+    addedAt: iso(today),
+  },
+  {
+    gameName: 'Ghost of Yotei',
+    platform: 'PlayStation',
+    genre: 'Action',
+    releaseDate: day(78),
+    isDayOneBuy: false,
+    msrpEstimate: 70,
+    targetPrice: 45,
+    priority: 7,
     purchased: false,
     intent: 'maybe',
     addedAt: iso(today),
@@ -115,17 +143,18 @@ export const BASELINE_BUY_QUEUE: SeedEntry[] = [
     gameName: 'Metaphor: ReFantazio',
     platform: 'Xbox',
     genre: 'RPG',
-    releaseDate: daysFromNow(-200),
+    releaseDate: day(-205),
     isDayOneBuy: false,
     msrpEstimate: 70,
     targetPrice: 35,
     currentPrice: 35, // at target → fires the deal alert
     priceHistory: [
-      { date: daysFromNow(-30), price: 50 },
-      { date: daysFromNow(-7), price: 42 },
-      { date: daysFromNow(0), price: 35 },
+      { date: day(-60), price: 55 },
+      { date: day(-30), price: 50 },
+      { date: day(-7), price: 42 },
+      { date: day(0), price: 35 },
     ],
-    priority: 7,
+    priority: 8,
     purchased: false,
     intent: 'deferred',
     addedAt: iso(today),
@@ -134,32 +163,53 @@ export const BASELINE_BUY_QUEUE: SeedEntry[] = [
     gameName: 'Star Wars Outlaws',
     platform: 'PlayStation',
     genre: 'Action',
-    releaseDate: daysFromNow(-260),
+    releaseDate: day(-265),
     isDayOneBuy: false,
     msrpEstimate: 70,
     targetPrice: 25,
     currentPrice: 30,
-    priority: 8,
+    priceHistory: [
+      { date: day(-120), price: 70 },
+      { date: day(-60), price: 45 },
+      { date: day(-5), price: 30 },
+    ],
+    priority: 9,
     purchased: false,
     intent: 'deferred',
     addedAt: iso(today),
   },
 
-  // ── Already bought from the queue — populates the "Bought" view ──
+  // ── Already bought from the queue — populates the Bought view ──
   {
     gameName: 'Astro Bot',
     platform: 'PlayStation',
     genre: 'Platformer',
-    releaseDate: daysFromNow(-150),
+    releaseDate: day(-150),
     isDayOneBuy: false,
     msrpEstimate: 60,
     targetPrice: 40,
     currentPrice: 40,
-    priority: 9,
+    priority: 10,
     purchased: true,
-    purchasedAt: daysFromNow(-45),
+    purchasedAt: day(-45),
     purchasePrice: 40,
     intent: 'committed',
-    addedAt: daysFromNow(-80),
+    addedAt: day(-80),
+  },
+  {
+    gameName: "Baldur's Gate 3",
+    platform: 'Steam',
+    genre: 'RPG',
+    releaseDate: day(-300),
+    isDayOneBuy: false,
+    msrpEstimate: 60,
+    targetPrice: 50,
+    currentPrice: 50,
+    priority: 11,
+    purchased: true,
+    purchasedAt: day(-120),
+    purchasePrice: 48,
+    intent: 'committed',
+    addedAt: day(-160),
   },
 ];

--- a/app/apps/game-analytics/hooks/usePurchaseQueue.ts
+++ b/app/apps/game-analytics/hooks/usePurchaseQueue.ts
@@ -138,6 +138,12 @@ export function usePurchaseQueue(userId: string | null) {
   const maybeSpend = maybeEntries.reduce((sum, e) => sum + priceOf(e), 0);
   const deferredSpend = deferredEntries.reduce((sum, e) => sum + priceOf(e), 0);
 
+  // Full-price (MSRP) total for committed games — the "buy now, no waiting" scenario.
+  const fullPriceSpend = activeEntries.reduce(
+    (sum, e) => sum + (e.msrpEstimate ?? e.currentPrice ?? e.targetPrice ?? 70),
+    0
+  );
+
   // releasingSoon is informational — includes every non-purchased intent.
   const releasingSoon = notPurchased.filter(e => {
     if (!e.releaseDate) return false;
@@ -155,6 +161,7 @@ export function usePurchaseQueue(userId: string | null) {
     purchasedEntries,
     loading,
     plannedSpend,
+    fullPriceSpend,
     maybeSpend,
     deferredSpend,
     releasingSoon,

--- a/app/apps/game-analytics/lib/calculations.ts
+++ b/app/apps/game-analytics/lib/calculations.ts
@@ -12683,6 +12683,83 @@ export function getSuggestedTargetPrice(
 }
 
 /**
+ * Budget Fit Scenarios
+ *
+ * Answers "how many games can I fit before I have to wait for a discount?".
+ * Walks the queue in manual priority order and fills the remaining budget
+ * twice: once at full price (MSRP) and once at deal/target price. Returns how
+ * many picks fit in each scenario plus the games that spill over, so the UI can
+ * say e.g. "fits your top 3 at full price, all 6 if you wait for deals".
+ */
+const DEFAULT_FULL_PRICE = 70;
+
+const fullPriceOf = (e: PurchaseQueueEntry): number =>
+  e.msrpEstimate ?? e.currentPrice ?? e.targetPrice ?? DEFAULT_FULL_PRICE;
+
+const dealPriceOf = (e: PurchaseQueueEntry): number =>
+  e.targetPrice ?? e.currentPrice ?? e.msrpEstimate ?? DEFAULT_FULL_PRICE;
+
+interface BudgetFitResult {
+  affordableCount: number;
+  overflowItems: string[];
+  totalCost: number;
+}
+
+function fillBudget(
+  ordered: PurchaseQueueEntry[],
+  priceOf: (e: PurchaseQueueEntry) => number,
+  yearBudget: number | null,
+  yearSpent: number
+): BudgetFitResult {
+  const totalCost = ordered.reduce((s, e) => s + priceOf(e), 0);
+  if (yearBudget == null) {
+    return { affordableCount: ordered.length, overflowItems: [], totalCost };
+  }
+  let running = yearSpent;
+  let affordableCount = 0;
+  const overflowItems: string[] = [];
+  for (const e of ordered) {
+    running += priceOf(e);
+    if (running <= yearBudget) affordableCount++;
+    else overflowItems.push(e.gameName);
+  }
+  return { affordableCount, overflowItems, totalCost };
+}
+
+export function getBudgetFitScenarios(
+  entries: PurchaseQueueEntry[],
+  yearBudget: number | null,
+  yearSpent: number
+): {
+  total: number;
+  remaining: number | null;
+  fullPrice: BudgetFitResult;
+  deal: BudgetFitResult;
+  /** Extra games unlocked by waiting for deals instead of buying at full price. */
+  extraFromDeals: number;
+  /** Estimated savings if every pick is bought at deal price vs full price. */
+  potentialSavings: number;
+} {
+  const active = entries
+    .filter(e => !e.purchased)
+    .sort((a, b) => a.priority - b.priority);
+
+  const fullPrice = fillBudget(active, fullPriceOf, yearBudget, yearSpent);
+  const deal = fillBudget(active, dealPriceOf, yearBudget, yearSpent);
+  const remaining = yearBudget != null ? yearBudget - yearSpent : null;
+  const potentialSavings = Math.max(0, fullPrice.totalCost - deal.totalCost);
+
+  return {
+    total: active.length,
+    remaining,
+    fullPrice,
+    deal,
+    extraFromDeals: Math.max(0, deal.affordableCount - fullPrice.affordableCount),
+    potentialSavings,
+  };
+}
+
+/**
  * Queue Impact Snapshot (Feature #16)
  */
 export function getQueueImpactSnapshot(

--- a/app/apps/game-analytics/lib/calculations.ts
+++ b/app/apps/game-analytics/lib/calculations.ts
@@ -12699,6 +12699,22 @@ const fullPriceOf = (e: PurchaseQueueEntry): number =>
 const dealPriceOf = (e: PurchaseQueueEntry): number =>
   e.targetPrice ?? e.currentPrice ?? e.msrpEstimate ?? DEFAULT_FULL_PRICE;
 
+/** Pricing scenario for budget projections: full MSRP, your target deals, or a modeled % off. */
+export type QueuePriceMode =
+  | { kind: 'full' }
+  | { kind: 'deal' }
+  | { kind: 'model'; discount: number }; // discount in 0..1 off MSRP
+
+/** Resolve the price for a single queue entry under a pricing scenario. */
+export function resolveQueuePrice(e: PurchaseQueueEntry, mode: QueuePriceMode): number {
+  if (mode.kind === 'full') return fullPriceOf(e);
+  if (mode.kind === 'model') {
+    const d = Math.min(0.95, Math.max(0, mode.discount));
+    return Math.round(fullPriceOf(e) * (1 - d));
+  }
+  return dealPriceOf(e);
+}
+
 interface BudgetFitResult {
   affordableCount: number;
   overflowItems: string[];
@@ -12757,6 +12773,43 @@ export function getBudgetFitScenarios(
     extraFromDeals: Math.max(0, deal.affordableCount - fullPrice.affordableCount),
     potentialSavings,
   };
+}
+
+/** A single row in the running budget tally. */
+export interface QueueTallyRow {
+  id: string;
+  price: number;
+  cumulative: number;        // running committed spend including this entry
+  remaining: number | null;  // budget − yearSpent − cumulative (null if no budget)
+  isOver: boolean;
+}
+
+/**
+ * Walk a list of entries in display order, accruing spend against the budget.
+ * Returns the per-entry remaining budget plus the id of the first entry that
+ * busts the budget (so the UI can draw a "runs out here" divider before it).
+ *
+ * `startCumulative` lets a second pass (e.g. the ghost tally for maybes)
+ * continue from where the committed total left off.
+ */
+export function getQueueRunningTally(
+  ordered: PurchaseQueueEntry[],
+  yearBudget: number | null,
+  yearSpent: number,
+  mode: QueuePriceMode,
+  startCumulative = 0
+): { rows: QueueTallyRow[]; cutoffId: string | null } {
+  let cumulative = startCumulative;
+  let cutoffId: string | null = null;
+  const rows = ordered.map((e): QueueTallyRow => {
+    const price = resolveQueuePrice(e, mode);
+    cumulative += price;
+    const remaining = yearBudget != null ? yearBudget - yearSpent - cumulative : null;
+    const isOver = remaining != null && remaining < 0;
+    if (isOver && cutoffId === null) cutoffId = e.id;
+    return { id: e.id, price, cumulative, remaining, isOver };
+  });
+  return { rows, cutoffId };
 }
 
 /**

--- a/app/apps/game-analytics/page.tsx
+++ b/app/apps/game-analytics/page.tsx
@@ -256,7 +256,8 @@ export default function GameAnalyticsPage() {
   // This year's spending (for buy queue budget bar)
   const currentYearSpent = useMemo(() => {
     const year = new Date().getFullYear();
-    const byMonth = getSpendingByMonth(games);
+    // Free / subscription games don't cost money — exclude them from spend.
+    const byMonth = getSpendingByMonth(games.filter(g => !g.acquiredFree));
     return Object.entries(byMonth)
       .filter(([key]) => key.startsWith(String(year)))
       .reduce((sum, [, val]) => sum + val, 0);

--- a/app/apps/game-analytics/page.tsx
+++ b/app/apps/game-analytics/page.tsx
@@ -21,6 +21,8 @@ import { gameRepository } from './lib/storage';
 import { useRankings } from './hooks/useRankings';
 import { rankingRepository } from './lib/ranking-storage';
 import { BASELINE_GAMES_2025 } from './data/baseline-games';
+import { BASELINE_BUY_QUEUE } from './data/baseline-buy-queue';
+import { purchaseQueueRepository } from './lib/purchase-queue-storage';
 import { useAuthContext } from '@/lib/AuthContext';
 import { useToast } from '@/components/Toast';
 import { getROIRating, getWeekStatsForOffset, getGamesPlayedInTimeRange, getCompletionProbability, getGameHealthDot, getRelativeTime, getDaysContext, getSessionMomentum, getValueTrajectory, getGameSmartOneLiner, getFranchiseInfo, getProgressPercent, getShelfLife, parseLocalDate, getCardRarity, getRelationshipStatus, getGameStreak, getHeroNumber, getCardFreshness, getGameSections, getCardBackData, getContextualWhisper, getLibraryRank, getCardMoodPulse, getProgressRingData, getStatPopoverData, getWeekRecapData, getSmartNudges, getGamingCreditScore, getRotationStats, getSpendingForecast, getSpendingByMonth, getShelfLifeExpiry, formatRating, getRatingRank } from './lib/calculations';
@@ -396,7 +398,21 @@ export default function GameAnalyticsPage() {
       for (const gameData of BASELINE_GAMES_2025) {
         await gameRepository.create(gameData);
       }
-      showToast('Sample games loaded', 'success');
+
+      // Seed sample Buy Queue entries so the budget tools have data to test against.
+      purchaseQueueRepository.setUserId(user?.uid || 'local-user');
+      for (const entry of BASELINE_BUY_QUEUE) {
+        await purchaseQueueRepository.create(entry);
+      }
+
+      // Give the current year a budget if one isn't set, so the "how many fit"
+      // headline and budget ring are populated out of the box.
+      const seedYear = new Date().getFullYear();
+      if (!budgets.some(b => b.year === seedYear)) {
+        await setBudget(seedYear, 300);
+      }
+
+      showToast('Sample games + buy queue loaded', 'success');
       await refresh();
     } catch (e) {
       showToast(`Failed to seed data: ${(e as Error).message}`, 'error');


### PR DESCRIPTION
- New getBudgetFitScenarios() computes how many committed picks fit the
  budget at full price vs. deal price, in manual priority order
- Full Price / Deal Price toggle on the budget card (persisted), drives the
  budget ring and a plain-language 'how many fit' headline + spillover list
- Promote purchased history into a first-class Watching | Bought view switch
- Seed sample Buy Queue entries (and a default budget) via Load Samples so
  the budget tools are testable out of the box