### PR TITLE
Add What-If Simulator to Stats tab with 4 alternate reality scenarios

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -5,6 +5,15 @@ entry below is one run. Newest entries first.
 
 ---
 
+## 2026-06-01 00:00 — Stats Tab — What-If Simulator
+
+**Files**: app/apps/game-analytics/lib/calculations.ts, app/apps/game-analytics/components/WhatIfSimulator.tsx, app/apps/game-analytics/components/StatsView.tsx
+**Risk**: not risky
+
+Added an interactive "Alternate Reality Simulator" to the Stats tab with four thought-provoking scenarios: skipping impulse buys, never buying games you later abandoned, completing your backlog, and buying on sale vs. full price. Each scenario shows a before/after stat comparison, the specific games affected (with thumbnails), and a punchy insight tailored to the user's data. Users with messy buying habits will see high-impact warnings; users with clean habits get positive confirmation.
+
+FOLLOW-UP: Could add a 5th scenario — "only bought games rated 7+" — showing the hypothetical quality-filtered library.
+
 ## 2026-05-22 18:00 — Games Tab — Game search bar
 
 **Files**: app/apps/game-analytics/page.tsx

--- a/app/apps/game-analytics/components/StatsView.tsx
+++ b/app/apps/game-analytics/components/StatsView.tsx
@@ -64,6 +64,7 @@ import { TrophyRoomV2 } from './TrophyRoomV2';
 import { TrophyProgress, TrophyScoreSummary } from '../lib/trophy-calculations';
 import { DiscoverPanel } from './DiscoverPanel';
 import { WeeklyDigest } from './WeeklyDigest';
+import { WhatIfSimulator } from './WhatIfSimulator';
 import { PlayedSummary, BoughtSummary } from './RangeGlance';
 import clsx from 'clsx';
 
@@ -1002,6 +1003,9 @@ export function StatsView({ games, summary, budgets = [], onSetBudget, trophies,
 
       {/* Advanced Analytics Panel (Phase 2) */}
       <AnalyticsPanel games={games} />
+
+      {/* Alternate Reality / What-If Simulator */}
+      <WhatIfSimulator games={games} />
 
       {/* Trophy Room V2 — 100 Trophies */}
       {trophies && trophySummary && onToggleTrophyPin ? (

--- a/app/apps/game-analytics/components/WhatIfSimulator.tsx
+++ b/app/apps/game-analytics/components/WhatIfSimulator.tsx
@@ -1,0 +1,221 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { Shuffle, ChevronDown, ChevronUp, Sparkles, TrendingDown, TrendingUp, AlertCircle } from 'lucide-react';
+import { Game } from '../lib/types';
+import { getWhatIfSimulatorData, WhatIfSimulatorScenario } from '../lib/calculations';
+import clsx from 'clsx';
+
+interface WhatIfSimulatorProps {
+  games: Game[];
+}
+
+const SCENARIO_COLORS: Record<string, { border: string; bg: string; accent: string; pill: string }> = {
+  impulse:   { border: 'border-amber-500/20',  bg: 'from-amber-500/10 to-orange-500/5',  accent: 'text-amber-400',   pill: 'bg-amber-500/15 text-amber-300' },
+  abandoned: { border: 'border-red-500/20',    bg: 'from-red-500/10 to-rose-500/5',      accent: 'text-red-400',     pill: 'bg-red-500/15 text-red-300' },
+  backlog:   { border: 'border-violet-500/20', bg: 'from-violet-500/10 to-purple-500/5', accent: 'text-violet-400',  pill: 'bg-violet-500/15 text-violet-300' },
+  fullprice: { border: 'border-emerald-500/20',bg: 'from-emerald-500/10 to-green-500/5', accent: 'text-emerald-400', pill: 'bg-emerald-500/15 text-emerald-300' },
+};
+
+const SEVERITY_BADGE: Record<WhatIfSimulatorScenario['severity'], { label: string; color: string }> = {
+  high:   { label: 'High impact',   color: 'text-red-400 bg-red-500/10 border border-red-500/20' },
+  medium: { label: 'Medium impact', color: 'text-amber-400 bg-amber-500/10 border border-amber-500/20' },
+  low:    { label: 'Low impact',    color: 'text-emerald-400 bg-emerald-500/10 border border-emerald-500/20' },
+};
+
+function ScenarioCard({ scenario, isOpen, onToggle }: {
+  scenario: WhatIfSimulatorScenario;
+  isOpen: boolean;
+  onToggle: () => void;
+}) {
+  const colors = SCENARIO_COLORS[scenario.id] || SCENARIO_COLORS.impulse;
+  const severity = SEVERITY_BADGE[scenario.severity];
+
+  return (
+    <div className={clsx('rounded-xl border transition-all overflow-hidden', colors.border)}>
+      {/* Header row — always visible */}
+      <button
+        onClick={onToggle}
+        className={clsx(
+          'w-full p-4 text-left bg-gradient-to-br transition-all',
+          colors.bg,
+          isOpen ? 'rounded-t-xl rounded-b-none' : 'rounded-xl hover:brightness-110'
+        )}
+      >
+        <div className="flex items-start gap-3">
+          {/* Emoji */}
+          <span className="text-2xl leading-none mt-0.5 shrink-0">{scenario.emoji}</span>
+
+          {/* Title + subtitle */}
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="text-sm font-semibold text-white">{scenario.title}</span>
+              <span className={clsx('text-[10px] font-medium px-1.5 py-0.5 rounded', severity.color)}>
+                {severity.label}
+              </span>
+            </div>
+            <p className="text-xs text-white/40 mt-0.5 leading-snug">{scenario.subtitle}</p>
+          </div>
+
+          {/* Primary metric */}
+          <div className="text-right shrink-0 ml-1">
+            <div className={clsx('text-lg font-black', scenario.primaryPositive ? 'text-emerald-400' : colors.accent)}>
+              {scenario.primaryValue}
+            </div>
+            <div className="text-[9px] text-white/30 leading-tight max-w-[80px] text-right">
+              {scenario.primaryLabel}
+            </div>
+          </div>
+
+          {/* Chevron */}
+          <div className="shrink-0 self-center ml-1">
+            {isOpen
+              ? <ChevronUp size={16} className="text-white/30" />
+              : <ChevronDown size={16} className="text-white/30" />
+            }
+          </div>
+        </div>
+      </button>
+
+      {/* Expanded content */}
+      {isOpen && (
+        <div className="p-4 space-y-4 bg-[#0e0e16] border-t border-white/5">
+
+          {/* Before / After stats */}
+          <div className="space-y-2">
+            {scenario.stats.map((stat, i) => (
+              <div key={i} className="flex items-center justify-between text-xs gap-2">
+                <span className="text-white/40 shrink-0">{stat.label}</span>
+                <div className="flex items-center gap-1.5 min-w-0">
+                  <span className="text-white/30 truncate">{stat.before}</span>
+                  <span className="text-white/15 shrink-0">→</span>
+                  <span className={clsx(
+                    'font-semibold truncate',
+                    stat.betterAfter ? 'text-emerald-400' : 'text-red-400/80'
+                  )}>
+                    {stat.after}
+                    {stat.betterAfter
+                      ? <TrendingDown size={10} className="inline ml-1 mb-0.5" />
+                      : <TrendingUp size={10} className="inline ml-1 mb-0.5" />
+                    }
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Insight / takeaway */}
+          <div className={clsx('p-3 rounded-lg border', colors.border, `bg-gradient-to-r ${colors.bg}`)}>
+            <p className="text-xs text-white/60 italic leading-relaxed">
+              &ldquo;{scenario.takeaway}&rdquo;
+            </p>
+          </div>
+
+          {/* Affected games */}
+          {scenario.affectedGames.length > 0 && (
+            <div>
+              <div className="flex items-center gap-1.5 mb-2">
+                <AlertCircle size={11} className="text-white/25" />
+                <span className="text-[10px] text-white/25 uppercase tracking-wider font-medium">
+                  Affected Games ({scenario.affectedGames.length})
+                </span>
+              </div>
+              <div className="space-y-1.5">
+                {scenario.affectedGames.map(({ game, note }) => (
+                  <div key={game.id} className="flex items-center gap-2.5 px-2.5 py-2 bg-white/[0.03] rounded-lg border border-white/5">
+                    {game.thumbnail ? (
+                      <img
+                        src={game.thumbnail}
+                        alt={game.name}
+                        className="w-8 h-8 object-cover rounded shrink-0"
+                        loading="lazy"
+                      />
+                    ) : (
+                      <div className="w-8 h-8 rounded bg-white/10 shrink-0 flex items-center justify-center text-sm">
+                        🎮
+                      </div>
+                    )}
+                    <div className="flex-1 min-w-0">
+                      <div className="text-xs text-white/75 truncate font-medium">{game.name}</div>
+                      <div className="text-[10px] text-white/30 truncate">{note}</div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Empty state */}
+          {!scenario.hasImpact && (
+            <div className="flex items-center gap-2 text-xs text-emerald-400/70">
+              <Sparkles size={13} />
+              <span>No issues here — you&apos;re doing great on this front.</span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function WhatIfSimulator({ games }: WhatIfSimulatorProps) {
+  const [openId, setOpenId] = useState<string | null>(null);
+
+  const scenarios = useMemo(() => getWhatIfSimulatorData(games), [games]);
+
+  const ownedGames = games.filter(g => g.status !== 'Wishlist' && !g.acquiredFree);
+  if (ownedGames.length < 3) return null;
+
+  // Summary stat: total alternate-reality impact
+  const totalImpact = scenarios
+    .filter(s => s.id !== 'fullprice') // fullprice is positive, keep separate
+    .reduce((sum, s) => {
+      const val = parseFloat(s.primaryValue.replace(/[$h]/g, ''));
+      return sum + (isNaN(val) ? 0 : val);
+    }, 0);
+
+  const highCount = scenarios.filter(s => s.severity === 'high').length;
+
+  const toggle = (id: string) => setOpenId(prev => prev === id ? null : id);
+
+  return (
+    <div className="space-y-3">
+      {/* Section header */}
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-medium text-white/50 flex items-center gap-2">
+          <Shuffle size={14} className="text-violet-400" />
+          Alternate Reality Simulator
+        </h3>
+        {highCount > 0 && (
+          <span className="text-[10px] text-red-400 bg-red-500/10 border border-red-500/20 px-2 py-0.5 rounded-full font-medium">
+            {highCount} high-impact area{highCount !== 1 ? 's' : ''}
+          </span>
+        )}
+      </div>
+
+      <p className="text-xs text-white/30 leading-relaxed">
+        What would your library look like with different choices? Tap each scenario to explore.
+      </p>
+
+      {/* Scenario cards */}
+      <div className="space-y-2">
+        {scenarios.map(scenario => (
+          <ScenarioCard
+            key={scenario.id}
+            scenario={scenario}
+            isOpen={openId === scenario.id}
+            onToggle={() => toggle(scenario.id)}
+          />
+        ))}
+      </div>
+
+      {/* Footer nudge */}
+      {highCount === 0 && ownedGames.length >= 5 && (
+        <div className="flex items-center gap-2 p-3 bg-emerald-500/5 border border-emerald-500/15 rounded-xl text-xs text-emerald-400/70">
+          <Sparkles size={13} className="shrink-0" />
+          <span>No high-impact scenarios detected — your spending habits look healthy.</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/apps/game-analytics/data/whats-new.json
+++ b/app/apps/game-analytics/data/whats-new.json
@@ -1,6 +1,12 @@
 {
   "entries": [
     {
+      "date": "2026-06-01",
+      "area": "Stats tab",
+      "title": "What would your library look like with better choices?",
+      "body": "The new Alternate Reality Simulator in the Stats tab lets you explore four \"what if\" scenarios: what if you'd skipped impulse buys, never bought games you later abandoned, cleared your backlog, or always bought on sale? Each scenario shows the exact games affected, a before/after stat comparison, and a frank insight about your spending habits."
+    },
+    {
       "date": "2026-05-22",
       "area": "Games tab",
       "title": "Search your library instantly",

--- a/app/apps/game-analytics/lib/calculations.ts
+++ b/app/apps/game-analytics/lib/calculations.ts
@@ -13817,3 +13817,273 @@ export function toDateKey(d: Date): string {
   const day = String(d.getDate()).padStart(2, '0');
   return `${y}-${m}-${day}`;
 }
+
+// ============================================================
+// WHAT-IF SIMULATOR
+// ============================================================
+
+export interface WhatIfSimulatorGameEntry {
+  game: Game;
+  note: string;
+  money: number;
+}
+
+export interface WhatIfSimulatorStat {
+  label: string;
+  before: string;
+  after: string;
+  betterAfter: boolean;
+}
+
+export interface WhatIfSimulatorScenario {
+  id: string;
+  emoji: string;
+  title: string;
+  subtitle: string;
+  primaryValue: string;
+  primaryLabel: string;
+  primaryPositive: boolean;
+  stats: WhatIfSimulatorStat[];
+  affectedGames: WhatIfSimulatorGameEntry[];
+  takeaway: string;
+  severity: 'low' | 'medium' | 'high';
+  hasImpact: boolean;
+}
+
+export function getWhatIfSimulatorData(games: Game[]): WhatIfSimulatorScenario[] {
+  const owned = games.filter(g => g.status !== 'Wishlist');
+  const paidOwned = owned.filter(g => !g.acquiredFree);
+  const totalSpent = paidOwned.reduce((s, g) => s + g.price, 0);
+  const totalHours = paidOwned.reduce((s, g) => s + getTotalHours(g), 0);
+  const avgCPH = totalHours > 0 ? totalSpent / totalHours : 0;
+
+  // ── Scenario 1: Skip impulse buys ──────────────────────────────
+  const impulseGames = paidOwned.filter(g => g.price >= 10 && getTotalHours(g) < 2);
+  const impulseSpent = impulseGames.reduce((s, g) => s + g.price, 0);
+  const impulseHours = impulseGames.reduce((s, g) => s + getTotalHours(g), 0);
+  const afterImpulseSpent = totalSpent - impulseSpent;
+  const afterImpulseHours = totalHours - impulseHours;
+  const afterImpulseCPH = afterImpulseHours > 0 ? afterImpulseSpent / afterImpulseHours : 0;
+
+  // ── Scenario 2: Never bought abandoned games ───────────────────
+  const abandonedGames = paidOwned.filter(g => g.status === 'Abandoned');
+  const abandonedSpent = abandonedGames.reduce((s, g) => s + g.price, 0);
+  const abandonedHours = abandonedGames.reduce((s, g) => s + getTotalHours(g), 0);
+  const afterAbandSpent = totalSpent - abandonedSpent;
+  const afterAbandHours = totalHours - abandonedHours;
+  const afterAbandCPH = afterAbandHours > 0 ? afterAbandSpent / afterAbandHours : 0;
+  const abandonedRated = abandonedGames.filter(g => g.rating > 0);
+  const abandonedAvgRating = abandonedRated.length > 0
+    ? abandonedRated.reduce((s, g) => s + g.rating, 0) / abandonedRated.length
+    : null;
+  const overallRated = paidOwned.filter(g => g.rating > 0);
+  const overallAvgRating = overallRated.length > 0
+    ? overallRated.reduce((s, g) => s + g.rating, 0) / overallRated.length
+    : null;
+  const afterRated = paidOwned.filter(g => g.status !== 'Abandoned' && g.rating > 0);
+  const afterAvgRating = afterRated.length > 0
+    ? afterRated.reduce((s, g) => s + g.rating, 0) / afterRated.length
+    : null;
+
+  // ── Scenario 3: Complete your backlog ─────────────────────────
+  const backlogResult = whatIfCompletedBacklog(games);
+  const backlogGames = owned.filter(g =>
+    g.status === 'Not Started' || (g.status === 'In Progress' && getTotalHours(g) < 10)
+  );
+  const estimatedAdditionalHours = backlogGames.reduce(
+    (s, g) => s + Math.max(20 - getTotalHours(g), 0), 0
+  );
+  const cphDelta = avgCPH - backlogResult.after.value;
+
+  // ── Scenario 4: Sale hunting success ──────────────────────────
+  const discountedGames = paidOwned.filter(g => g.originalPrice && g.originalPrice > g.price);
+  const savedByDiscounts = discountedGames.reduce(
+    (s, g) => s + (g.originalPrice! - g.price), 0
+  );
+  const fullPriceSpent = totalSpent + savedByDiscounts;
+  const fullPriceCPH = totalHours > 0 ? fullPriceSpent / totalHours : 0;
+
+  return [
+    {
+      id: 'impulse',
+      emoji: '⚡',
+      title: 'Skip Impulse Buys',
+      subtitle: 'Never bought games you barely touched',
+      primaryValue: `$${impulseSpent.toFixed(0)}`,
+      primaryLabel: impulseSpent > 0 ? 'spent on games played < 2h' : 'zero impulse buys — impressive',
+      primaryPositive: impulseSpent === 0,
+      stats: [
+        {
+          label: 'Total spent',
+          before: `$${totalSpent.toFixed(0)}`,
+          after: `$${afterImpulseSpent.toFixed(0)}`,
+          betterAfter: true,
+        },
+        {
+          label: 'Avg $/hr',
+          before: `$${avgCPH.toFixed(2)}/hr`,
+          after: afterImpulseHours > 0 ? `$${afterImpulseCPH.toFixed(2)}/hr` : '—',
+          betterAfter: afterImpulseCPH <= avgCPH,
+        },
+        {
+          label: 'Games removed',
+          before: `${paidOwned.length} owned`,
+          after: `${paidOwned.length - impulseGames.length} owned`,
+          betterAfter: false,
+        },
+      ],
+      affectedGames: [...impulseGames]
+        .sort((a, b) => b.price - a.price)
+        .slice(0, 6)
+        .map(g => ({
+          game: g,
+          note: `${getTotalHours(g).toFixed(1)}h played · $${g.price.toFixed(0)} paid`,
+          money: g.price,
+        })),
+      takeaway: impulseGames.length === 0
+        ? 'Every game you paid for got at least 2 hours of play. Rare discipline.'
+        : impulseSpent >= 100
+        ? `$${impulseSpent.toFixed(0)} on ${impulseGames.length} games you never committed to. The next shelf-warmer is already in your cart.`
+        : `$${impulseSpent.toFixed(0)} across ${impulseGames.length} game${impulseGames.length !== 1 ? 's' : ''} that never got off the ground.`,
+      severity: impulseSpent >= 100 ? 'high' : impulseSpent >= 30 ? 'medium' : 'low',
+      hasImpact: impulseGames.length > 0,
+    },
+
+    {
+      id: 'abandoned',
+      emoji: '🪦',
+      title: 'No Abandonments',
+      subtitle: 'What if hindsight guided every purchase?',
+      primaryValue: `$${abandonedSpent.toFixed(0)}`,
+      primaryLabel: abandonedSpent > 0 ? 'spent on abandoned games' : 'nothing abandoned',
+      primaryPositive: abandonedSpent === 0,
+      stats: [
+        {
+          label: 'Total spent',
+          before: `$${totalSpent.toFixed(0)}`,
+          after: `$${afterAbandSpent.toFixed(0)}`,
+          betterAfter: true,
+        },
+        {
+          label: 'Avg $/hr',
+          before: `$${avgCPH.toFixed(2)}/hr`,
+          after: afterAbandHours > 0 ? `$${afterAbandCPH.toFixed(2)}/hr` : '—',
+          betterAfter: afterAbandCPH <= avgCPH,
+        },
+        ...(overallAvgRating && afterAvgRating
+          ? [{
+              label: 'Avg rating',
+              before: `${overallAvgRating.toFixed(1)}/10`,
+              after: `${afterAvgRating.toFixed(1)}/10`,
+              betterAfter: afterAvgRating >= overallAvgRating,
+            }]
+          : []),
+      ],
+      affectedGames: [...abandonedGames]
+        .sort((a, b) => b.price - a.price)
+        .slice(0, 6)
+        .map(g => ({
+          game: g,
+          note: `${getTotalHours(g).toFixed(1)}h played · $${g.price.toFixed(0)} paid${g.rating > 0 ? ` · ${g.rating}/10` : ''}`,
+          money: g.price,
+        })),
+      takeaway: abandonedGames.length === 0
+        ? 'You finish (or at least keep going with) everything you start. That\'s a great completion mentality.'
+        : `${abandonedGames.length} abandoned game${abandonedGames.length !== 1 ? 's' : ''} cost $${abandonedSpent.toFixed(0)}.${abandonedAvgRating ? ` Average rating: ${abandonedAvgRating.toFixed(1)}/10 — the data agrees they weren\'t worth it.` : ''}`,
+      severity: abandonedSpent >= 80 ? 'high' : abandonedSpent >= 25 ? 'medium' : 'low',
+      hasImpact: abandonedGames.length > 0,
+    },
+
+    {
+      id: 'backlog',
+      emoji: '🏁',
+      title: 'Clear the Backlog',
+      subtitle: `${backlogGames.length} game${backlogGames.length !== 1 ? 's' : ''} already paid for, unplayed`,
+      primaryValue: `${estimatedAdditionalHours}h`,
+      primaryLabel: 'of gaming already sitting on your shelf',
+      primaryPositive: false,
+      stats: [
+        {
+          label: 'Avg $/hr',
+          before: backlogResult.before.label,
+          after: backlogResult.after.label,
+          betterAfter: true,
+        },
+        {
+          label: 'Unplayed games',
+          before: `${backlogGames.length}`,
+          after: '0',
+          betterAfter: true,
+        },
+        {
+          label: 'Total hours',
+          before: `${totalHours.toFixed(0)}h`,
+          after: `${(totalHours + estimatedAdditionalHours).toFixed(0)}h`,
+          betterAfter: true,
+        },
+      ],
+      affectedGames: [...backlogGames]
+        .sort((a, b) => b.price - a.price)
+        .slice(0, 6)
+        .map(g => ({
+          game: g,
+          note: `~${Math.max(20 - getTotalHours(g), 0).toFixed(0)}h est. remaining · $${g.price.toFixed(0)} paid`,
+          money: g.price,
+        })),
+      takeaway: backlogGames.length === 0
+        ? 'Your backlog is clear — every owned game has been played. Seriously impressive.'
+        : cphDelta > 0.5
+        ? `Finishing your backlog would drop your cost/hr from ${backlogResult.before.label} to ${backlogResult.after.label}. You\'re sitting on gold.`
+        : `${estimatedAdditionalHours} hours of gaming already paid for and waiting.`,
+      severity: backlogGames.length >= 10 ? 'high' : backlogGames.length >= 4 ? 'medium' : 'low',
+      hasImpact: backlogGames.length > 0,
+    },
+
+    {
+      id: 'fullprice',
+      emoji: '💸',
+      title: 'Full Price, No Patience',
+      subtitle: 'What if you\'d never bought a single sale?',
+      primaryValue: savedByDiscounts > 0 ? `$${savedByDiscounts.toFixed(0)}` : '$0',
+      primaryLabel: savedByDiscounts > 0 ? 'saved by buying on sale' : 'no discount data tracked',
+      primaryPositive: true,
+      stats: [
+        {
+          label: 'You paid',
+          before: `$${totalSpent.toFixed(0)} (actual)`,
+          after: `$${fullPriceSpent.toFixed(0)} (full price)`,
+          betterAfter: false,
+        },
+        {
+          label: 'Avg $/hr',
+          before: `$${avgCPH.toFixed(2)}/hr (actual)`,
+          after: `$${fullPriceCPH.toFixed(2)}/hr (full price)`,
+          betterAfter: false,
+        },
+        {
+          label: 'Best deal',
+          before: `${discountedGames.length} discounted`,
+          after: discountedGames.length > 0
+            ? `avg $${(savedByDiscounts / discountedGames.length).toFixed(0)} saved/game`
+            : 'none tracked',
+          betterAfter: true,
+        },
+      ],
+      affectedGames: [...discountedGames]
+        .sort((a, b) => ((b.originalPrice || 0) - b.price) - ((a.originalPrice || 0) - a.price))
+        .slice(0, 6)
+        .map(g => ({
+          game: g,
+          note: `Paid $${g.price.toFixed(0)} · saved $${((g.originalPrice || 0) - g.price).toFixed(0)} (${(((g.originalPrice || 0) - g.price) / (g.originalPrice || 1) * 100).toFixed(0)}% off)`,
+          money: (g.originalPrice || 0) - g.price,
+        })),
+      takeaway: discountedGames.length === 0
+        ? 'Add original prices to your games to track how much you\'re saving by buying on sale.'
+        : savedByDiscounts >= 50
+        ? `Your patience saved $${savedByDiscounts.toFixed(0)}. That\'s nearly ${Math.round(savedByDiscounts / 25)} more games at a $25 sale price.`
+        : `$${savedByDiscounts.toFixed(0)} saved by not paying full price. Every bit counts.`,
+      severity: savedByDiscounts >= 50 ? 'high' : savedByDiscounts >= 15 ? 'medium' : 'low',
+      hasImpact: discountedGames.length > 0,
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
Added an interactive "Alternate Reality Simulator" to the Stats tab that explores four thought-provoking "what if" scenarios based on a user's game library. Each scenario presents a before/after comparison with affected games, impact severity badges, and personalized insights.

## Key Changes

- **New calculation engine** (`getWhatIfSimulatorData`): Generates four scenarios analyzing spending and play patterns:
  - **Skip Impulse Buys**: Games purchased for ≥$10 but played <2 hours
  - **No Abandonments**: Games marked as "Abandoned" and their cost impact
  - **Clear the Backlog**: Unplayed/barely-started games and estimated completion hours
  - **Full Price vs. Sale**: Savings from buying discounted vs. full-price games

- **New `WhatIfSimulator` component**: Collapsible card UI with:
  - Color-coded scenarios (amber, red, violet, emerald)
  - Impact severity badges (high/medium/low)
  - Before/after stat comparisons with trend indicators
  - Affected games list with thumbnails and contextual notes
  - Personalized takeaway text based on user data
  - Empty state messaging for users with healthy habits

- **Integration**: Added to `StatsView.tsx` and included in `whats-new.json` changelog

## Implementation Details

- Scenarios only display if user has ≥3 paid, owned games (prevents noise for small libraries)
- Severity calculated dynamically based on impact thresholds (e.g., impulse buys ≥$100 = high)
- Affected games sorted by financial impact and limited to top 6 per scenario
- Takeaway text adapts tone based on data (congratulatory for clean habits, cautionary for issues)
- Uses existing `getTotalHours` utility and game status enums for consistency
- Responsive design with gradient backgrounds and semantic color coding

https://claude.ai/code/session_012UmTcqmfEQQdeZ7Uoyf76S