### PR TITLE
Add gentle review-nudge system for finished games

### DIFF
--- a/app/apps/game-analytics/components/GameBottomSheet.tsx
+++ b/app/apps/game-analytics/components/GameBottomSheet.tsx
@@ -19,6 +19,7 @@ import {
   getLibraryRankBars,
   getNextMilestone,
   getLibraryUniqueness,
+  hasReview,
 } from '../lib/calculations';
 import { generateGameInsightPack, GameInsightPack } from '../lib/ai-game-service';
 import { RatingStars } from './RatingStars';
@@ -620,6 +621,20 @@ export function GameBottomSheet({
                     </div>
                   );
                 })}
+              </div>
+            </div>
+          )}
+
+          {/* Gentle review nudge — only for finished games with nothing written yet */}
+          {!hasReview(game) && (game.status === 'Completed' || game.status === 'Abandoned') && (
+            <div className="mx-5 mb-3">
+              <div className="flex items-center gap-2 rounded-xl border border-emerald-500/20 bg-gradient-to-r from-emerald-500/10 to-teal-500/10 px-3 py-2.5">
+                <Sparkles size={14} className="shrink-0 text-emerald-300" />
+                <p className="text-xs leading-snug text-emerald-100/80">
+                  {game.status === 'Completed'
+                    ? `You finished ${game.name} — capture a few thoughts while they're fresh.`
+                    : `${Math.round(getTotalHours(game))}h in ${game.name}. Worth a quick note on why you stepped away.`}
+                </p>
               </div>
             </div>
           )}

--- a/app/apps/game-analytics/components/ReviewNudgeBanner.tsx
+++ b/app/apps/game-analytics/components/ReviewNudgeBanner.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { PenLine, X, ChevronRight, Check } from 'lucide-react';
+import clsx from 'clsx';
+import { getReviewNudges, ReviewNudge, ReviewNudgeReason } from '../lib/calculations';
+import { Game } from '../lib/types';
+
+interface ReviewNudgeBannerProps {
+  games: Game[];
+  /** Opens the review chat / interview for the chosen game. */
+  onReview: (game: Game) => void;
+}
+
+const SNOOZE_KEY = 'review-nudge-snooze'; // { [gameId]: ISO snooze-until }
+const DISMISS_KEY = 'review-nudge-dismissed-on'; // toDateString of last full dismiss
+const SNOOZE_DAYS = 6;
+
+const reasonStyle: Record<ReviewNudgeReason, { bg: string; text: string; border: string; label: string }> = {
+  'just-finished':        { bg: 'from-emerald-500/10 to-teal-500/10',  text: 'text-emerald-300', border: 'border-emerald-500/20', label: 'Just finished' },
+  'special-unreviewed':   { bg: 'from-yellow-500/10 to-amber-500/10',  text: 'text-amber-300',   border: 'border-amber-500/20',   label: 'One of your specials' },
+  'completed-unreviewed': { bg: 'from-blue-500/10 to-indigo-500/10',   text: 'text-blue-300',    border: 'border-blue-500/20',    label: 'Completed' },
+  'farewell':             { bg: 'from-purple-500/10 to-fuchsia-500/10', text: 'text-purple-300',  border: 'border-purple-500/20',  label: 'Abandoned' },
+  'rated-no-words':       { bg: 'from-pink-500/10 to-rose-500/10',     text: 'text-pink-300',    border: 'border-pink-500/20',    label: 'Rated, not reviewed' },
+  'invested-no-words':    { bg: 'from-cyan-500/10 to-sky-500/10',      text: 'text-cyan-300',    border: 'border-cyan-500/20',    label: 'Hours invested' },
+};
+
+function readSnoozes(): Record<string, string> {
+  if (typeof window === 'undefined') return {};
+  try {
+    return JSON.parse(localStorage.getItem(SNOOZE_KEY) || '{}');
+  } catch {
+    return {};
+  }
+}
+
+export function ReviewNudgeBanner({ games, onReview }: ReviewNudgeBannerProps) {
+  const [dismissedToday, setDismissedToday] = useState(false);
+  const [snoozes, setSnoozes] = useState<Record<string, string>>({});
+  const [idx, setIdx] = useState(0);
+
+  useEffect(() => {
+    const today = new Date().toDateString();
+    if (typeof window !== 'undefined' && localStorage.getItem(DISMISS_KEY) === today) {
+      setDismissedToday(true);
+    }
+    setSnoozes(readSnoozes());
+  }, []);
+
+  const summary = useMemo(() => getReviewNudges(games), [games]);
+
+  // Candidates not currently snoozed.
+  const active = useMemo(() => {
+    const now = Date.now();
+    return summary.candidates.filter(n => {
+      const until = snoozes[n.game.id];
+      return !until || new Date(until).getTime() <= now;
+    });
+  }, [summary.candidates, snoozes]);
+
+  const nudge: ReviewNudge | undefined = active[Math.min(idx, active.length - 1)];
+
+  if (dismissedToday || !nudge || summary.reviewableCount === 0) return null;
+
+  const style = reasonStyle[nudge.reason];
+  const { reviewedCount, reviewableCount } = summary;
+  const progress = reviewableCount > 0 ? Math.round((reviewedCount / reviewableCount) * 100) : 0;
+  const remaining = active.length;
+
+  const snooze = (gameId: string) => {
+    const until = new Date(Date.now() + SNOOZE_DAYS * 86_400_000).toISOString();
+    const next = { ...readSnoozes(), [gameId]: until };
+    if (typeof window !== 'undefined') localStorage.setItem(SNOOZE_KEY, JSON.stringify(next));
+    setSnoozes(next);
+    setIdx(0);
+  };
+
+  const dismissForToday = () => {
+    if (typeof window !== 'undefined') localStorage.setItem(DISMISS_KEY, new Date().toDateString());
+    setDismissedToday(true);
+  };
+
+  return (
+    <AnimatePresence mode="wait">
+      <motion.div
+        key={nudge.game.id}
+        initial={{ opacity: 0, y: -8, scale: 0.98 }}
+        animate={{ opacity: 1, y: 0, scale: 1 }}
+        exit={{ opacity: 0, y: -8, scale: 0.98 }}
+        transition={{ type: 'spring', stiffness: 320, damping: 26 }}
+        className={`relative mb-4 overflow-hidden rounded-xl border bg-gradient-to-r ${style.bg} ${style.border}`}
+      >
+        {/* Dismiss for the day */}
+        <button
+          onClick={dismissForToday}
+          className="absolute top-2 right-2 z-10 rounded-md p-1 text-white/20 transition-colors hover:bg-white/10 hover:text-white/50"
+          aria-label="Not now"
+          title="Not now"
+        >
+          <X size={12} />
+        </button>
+
+        <div className="flex items-start gap-3 px-4 py-3">
+          {/* Thumbnail / icon */}
+          {nudge.game.thumbnail ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={nudge.game.thumbnail}
+              alt={nudge.game.name}
+              className="h-14 w-14 shrink-0 rounded-lg object-cover ring-1 ring-white/10"
+            />
+          ) : (
+            <div className={`flex h-14 w-14 shrink-0 items-center justify-center rounded-lg bg-white/5 ${style.text}`}>
+              <PenLine size={20} />
+            </div>
+          )}
+
+          <div className="min-w-0 flex-1 pr-5">
+            <div className="mb-0.5 flex items-center gap-2">
+              <span className={`text-[10px] font-semibold uppercase tracking-wide ${style.text}`}>
+                {style.label}
+              </span>
+              {remaining > 1 && (
+                <span className="text-[10px] text-white/30">· {remaining} games waiting</span>
+              )}
+            </div>
+
+            <p className="text-sm leading-snug text-white/80">{nudge.headline}</p>
+
+            {/* Actions */}
+            <div className="mt-2.5 flex flex-wrap items-center gap-2">
+              <button
+                onClick={() => onReview(nudge.game)}
+                className={clsx(
+                  'inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium',
+                  'bg-white/10 text-white transition-colors hover:bg-white/20'
+                )}
+              >
+                <PenLine size={13} />
+                {nudge.ctaLabel}
+              </button>
+
+              <button
+                onClick={() => snooze(nudge.game.id)}
+                className="rounded-lg px-2.5 py-1.5 text-xs text-white/40 transition-colors hover:text-white/70"
+              >
+                Maybe later
+              </button>
+
+              {remaining > 1 && (
+                <button
+                  onClick={() => setIdx(i => (i + 1) % remaining)}
+                  className="ml-auto inline-flex items-center gap-1 rounded-lg px-2 py-1.5 text-xs text-white/40 transition-colors hover:text-white/70"
+                  title="Show another"
+                >
+                  Next <ChevronRight size={13} />
+                </button>
+              )}
+            </div>
+
+            {/* Gentle progress — frames reviewing as a finishable collection */}
+            {reviewableCount > 1 && (
+              <div className="mt-3 flex items-center gap-2">
+                <div className="h-1 flex-1 overflow-hidden rounded-full bg-white/10">
+                  <motion.div
+                    className={`h-full rounded-full bg-gradient-to-r ${style.bg.replace(/\/10/g, '/70')}`}
+                    initial={{ width: 0 }}
+                    animate={{ width: `${progress}%` }}
+                    transition={{ duration: 0.6, ease: 'easeOut' }}
+                  />
+                </div>
+                <span className="flex shrink-0 items-center gap-1 text-[10px] text-white/40">
+                  <Check size={10} className={progress === 100 ? 'text-emerald-400' : 'text-white/30'} />
+                  {reviewedCount}/{reviewableCount} reviewed
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/app/apps/game-analytics/lib/calculations.ts
+++ b/app/apps/game-analytics/lib/calculations.ts
@@ -14087,3 +14087,167 @@ export function getWhatIfSimulatorData(games: Game[]): WhatIfSimulatorScenario[]
     },
   ];
 }
+
+// ── Review Nudges ──────────────────────────────────────────────────
+// A gentle system that surfaces finished games worth writing up — not
+// just rating, but reviewing. Powers the Games-tab nudge banner and the
+// per-card "Review?" affordance. Pure, data-driven, never random.
+
+export type ReviewNudgeReason =
+  | 'just-finished'        // Completed within the last ~2 weeks
+  | 'special-unreviewed'   // Marked special/loved but no words yet
+  | 'completed-unreviewed' // Completed a while ago, still no review
+  | 'farewell'             // Abandoned with real hours — worth a goodbye
+  | 'rated-no-words'       // Rated highly but never explained why
+  | 'invested-no-words';   // Sank serious hours, no review
+
+export interface ReviewNudge {
+  game: Game;
+  reason: ReviewNudgeReason;
+  headline: string;       // Warm, curious one-liner referencing the game
+  ctaLabel: string;       // Button copy
+  priority: number;       // Higher = surface sooner
+  daysSinceEnd: number | null;
+}
+
+export interface ReviewNudgeSummary {
+  topNudge: ReviewNudge | null;
+  candidates: ReviewNudge[];   // All reviewable games lacking a review, sorted
+  reviewedCount: number;       // Reviewable games that DO have a review
+  reviewableCount: number;     // Total reviewable games (reviewed + not)
+  recentlyCompletedCount: number; // Completed in last 14 days, unreviewed
+}
+
+/** A game has a "review" if there's review text or any user message in the chat. */
+export function hasReview(game: Game): boolean {
+  if (game.review && game.review.trim().length > 0) return true;
+  return !!game.reviewMessages?.some(m => m.role === 'user' && m.text.trim().length > 0);
+}
+
+/** Whole-day difference between a date and today (>=0 in the past). */
+function daysSinceDate(dateStr?: string): number | null {
+  if (!dateStr) return null;
+  const then = parseLocalDate(dateStr.slice(0, 10)).getTime();
+  if (Number.isNaN(then)) return null;
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  return Math.max(0, Math.round((today - then) / 86_400_000));
+}
+
+/** Is this game something you could meaningfully review? */
+function isReviewable(game: Game): boolean {
+  if (game.status === 'Wishlist' || game.status === 'Not Started') return false;
+  if (game.status === 'Completed') return true;
+  if (game.status === 'Abandoned') return getTotalHours(game) >= 3;
+  // In Progress: only if you've invested real time or already rated it
+  return getTotalHours(game) >= 5 || game.rating > 0;
+}
+
+function buildNudge(game: Game): ReviewNudge | null {
+  const days = daysSinceDate(game.endDate || game.updatedAt);
+  const hours = Math.round(getTotalHours(game));
+  const name = game.name;
+
+  // Just finished — the highest-intent, gentlest moment to ask
+  if (game.status === 'Completed' && days !== null && days <= 14) {
+    const when =
+      days <= 1 ? 'just now' : days <= 3 ? `${days} days ago` : days <= 7 ? 'this week' : 'recently';
+    return {
+      game, reason: 'just-finished',
+      headline:
+        days <= 1
+          ? `You just wrapped ${name} — how was it?`
+          : `You finished ${name} ${when}. Worth a few words while it's fresh?`,
+      ctaLabel: 'Write a quick review',
+      priority: 100 - days * 2,
+      daysSinceEnd: days,
+    };
+  }
+
+  // Special / loved game with no review — capture why it mattered
+  if (game.isSpecial) {
+    return {
+      game, reason: 'special-unreviewed',
+      headline: `${name} is one of your specials — but you never said why. Tell its story?`,
+      ctaLabel: 'Capture what made it special',
+      priority: 90,
+      daysSinceEnd: days,
+    };
+  }
+
+  // Completed a while ago, still unreviewed
+  if (game.status === 'Completed') {
+    return {
+      game, reason: 'completed-unreviewed',
+      headline:
+        days !== null && days > 0
+          ? `You completed ${name}${days > 60 ? ' a while back' : ''} — ${hours}h in and still no review.`
+          : `You completed ${name} but never wrote it up. A few thoughts?`,
+      ctaLabel: 'Look back on it',
+      priority: 62 - Math.min(days ?? 0, 40) * 0.3,
+      daysSinceEnd: days,
+    };
+  }
+
+  // Rated highly but never explained — high signal, low words
+  if (game.rating >= 8) {
+    return {
+      game, reason: 'rated-no-words',
+      headline: `You rated ${name} ${game.rating}/10 — high praise with no words behind it. Why so good?`,
+      ctaLabel: 'Add a few words',
+      priority: 50,
+      daysSinceEnd: days,
+    };
+  }
+
+  // Abandoned with real hours — a goodbye is a review too
+  if (game.status === 'Abandoned') {
+    return {
+      game, reason: 'farewell',
+      headline: `${hours}h into ${name} before you walked away. What went wrong — or right?`,
+      ctaLabel: 'Say a proper goodbye',
+      priority: 40,
+      daysSinceEnd: days,
+    };
+  }
+
+  // Serious time invested, still no words
+  if (hours >= 5) {
+    return {
+      game, reason: 'invested-no-words',
+      headline: `${hours} hours in ${name} and not a word written. Worth reflecting on?`,
+      ctaLabel: 'Jot down your take',
+      priority: 30,
+      daysSinceEnd: days,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Build the prioritized list of games that deserve a review and a few
+ * progress counters so the UI can frame it as a gentle, finishable task.
+ */
+export function getReviewNudges(games: Game[]): ReviewNudgeSummary {
+  const reviewable = games.filter(isReviewable);
+  const reviewedCount = reviewable.filter(hasReview).length;
+
+  const candidates = reviewable
+    .filter(g => !hasReview(g))
+    .map(buildNudge)
+    .filter((n): n is ReviewNudge => n !== null)
+    .sort((a, b) => b.priority - a.priority);
+
+  const recentlyCompletedCount = candidates.filter(
+    n => n.reason === 'just-finished'
+  ).length;
+
+  return {
+    topNudge: candidates[0] ?? null,
+    candidates,
+    reviewedCount,
+    reviewableCount: reviewable.length,
+    recentlyCompletedCount,
+  };
+}

--- a/app/apps/game-analytics/page.tsx
+++ b/app/apps/game-analytics/page.tsx
@@ -40,6 +40,7 @@ import { ProgressRing } from './components/ProgressRing';
 import { ExportPanel } from './components/ExportPanel';
 import { YearlyWrapped } from './components/YearlyWrapped';
 import { FortuneCookie } from './components/FortuneCookie';
+import { ReviewNudgeBanner } from './components/ReviewNudgeBanner';
 import { AwardsHub } from './components/AwardsHub';
 import { useTrophies } from './hooks/useTrophies';
 import { TrophyShowcase } from './components/TrophyShowcase';
@@ -941,6 +942,20 @@ export default function GameAnalyticsPage() {
 
           {/* Daily Fortune Cookie */}
           {games.length > 0 && <div className="mb-4"><FortuneCookie games={games} /></div>}
+
+          {/* Gentle nudge to review finished games — leads into the review chat */}
+          {games.length > 0 && (
+            <ReviewNudgeBanner
+              games={games}
+              onReview={(game) => {
+                const gwm = gamesWithMetrics.find(g => g.id === game.id);
+                if (gwm) {
+                  setReviewChatGame(gwm);
+                  setTabMode('games');
+                }
+              }}
+            />
+          )}
 
           {/* Tab Navigation */}
           <div className="space-y-4 mb-6">


### PR DESCRIPTION
- getReviewNudges() engine: prioritizes reviewable games lacking a
  review (recently completed > specials > older completions > rated-no-
  words > abandoned farewells > hours-invested), plus reviewed/total
  progress counters and a hasReview() helper.
- ReviewNudgeBanner: dismissible, per-game snooze (6d) + dismiss-for-the-
  day, rotates through waiting games, gentle progress meter, opens the
  existing AI review chat. Rendered in the Games tab header.
- GameBottomSheet: contextual prompt when opening a finished/abandoned
  game with no review yet, leading into the review conversation.