### PR TITLE
Add Gaming Timeline Estimator to Game Analytics

### DIFF
--- a/app/apps/game-analytics/components/GameForm.tsx
+++ b/app/apps/game-analytics/components/GameForm.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { useState, useRef, useEffect } from 'react';
-import { ChevronDown, X, Tag, DollarSign, Calendar, MessageSquare, Sparkles } from 'lucide-react';
+import { ChevronDown, X, Tag, DollarSign, Calendar, MessageSquare, Sparkles, Loader2 } from 'lucide-react';
 import { Game, GameStatus, PurchaseSource, SubscriptionSource } from '../lib/types';
 import { calculateCostPerHour, getValueRating, formatRating, getTotalHours } from '../lib/calculations';
+import { lookupGameLength } from '../lib/ai-timeline-service';
 import { AIReviewInterview } from './AIReviewInterview';
 import clsx from 'clsx';
 
@@ -102,10 +103,13 @@ function Section({ title, icon, defaultOpen = false, children, badge }: {
 export function GameForm({ onSubmit, onClose, initialGame, allGames = [], existingFranchises = [] }: GameFormProps) {
   const [loading, setLoading] = useState(false);
   const [showInterview, setShowInterview] = useState(false);
+  const [lengthLoading, setLengthLoading] = useState(false);
+  const [lengthNote, setLengthNote] = useState<string | null>(null);
   const [formData, setFormData] = useState({
     name: initialGame?.name || '',
     price: initialGame?.price !== undefined ? initialGame.price.toString() : '',
     hours: initialGame?.hours !== undefined ? initialGame.hours.toString() : '',
+    expectedHours: initialGame?.expectedHours !== undefined ? initialGame.expectedHours.toString() : '',
     rating: initialGame?.rating || 8,
     status: (initialGame?.status || 'Not Started') as GameStatus,
     platform: initialGame?.platform || 'PS5',
@@ -192,6 +196,7 @@ export function GameForm({ onSubmit, onClose, initialGame, allGames = [], existi
         franchise: formData.franchise ? toTitleCase(formData.franchise.trim()) : undefined,
         price: parseFloat(formData.price) || 0,
         hours: parseFloat(formData.hours) || 0,
+        expectedHours: formData.expectedHours ? parseFloat(formData.expectedHours) : undefined,
         originalPrice: formData.originalPrice ? parseFloat(formData.originalPrice) : undefined,
         purchaseSource: formData.purchaseSource || undefined,
         acquiredFree: formData.acquiredFree || undefined,
@@ -203,6 +208,28 @@ export function GameForm({ onSubmit, onClose, initialGame, allGames = [], existi
       onClose();
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleLookupLength = async () => {
+    if (!formData.name.trim()) {
+      setLengthNote('Enter a game name first');
+      return;
+    }
+    setLengthLoading(true);
+    setLengthNote(null);
+    try {
+      const res = await lookupGameLength(formData.name.trim(), formData.platform);
+      if (res.hours) {
+        setFormData(prev => ({ ...prev, expectedHours: String(res.hours) }));
+        setLengthNote(res.note || `~${res.hours}h to beat`);
+      } else {
+        setLengthNote("Couldn't find an estimate — enter it manually");
+      }
+    } catch {
+      setLengthNote('Lookup failed — enter it manually');
+    } finally {
+      setLengthLoading(false);
     }
   };
 
@@ -352,6 +379,37 @@ export function GameForm({ onSubmit, onClose, initialGame, allGames = [], existi
                 className="w-full px-3 py-3 bg-white/[0.03] border border-white/5 text-white rounded-xl text-sm focus:outline-none focus:bg-white/[0.05] focus:border-white/10 transition-all"
                 placeholder="0.0"
               />
+            </div>
+
+            {/* Expected Hours to Finish (for Timeline Estimator) */}
+            <div>
+              <div className="flex items-center justify-between mb-1.5">
+                <label className="block text-xs font-medium text-white/50">Hours to Finish</label>
+                <button
+                  type="button"
+                  onClick={handleLookupLength}
+                  disabled={lengthLoading}
+                  className="flex items-center gap-1 text-[11px] px-2 py-1 rounded-lg bg-purple-500/10 text-purple-300 hover:bg-purple-500/20 disabled:opacity-50 transition-all"
+                >
+                  {lengthLoading ? <Loader2 size={12} className="animate-spin" /> : <Sparkles size={12} />}
+                  {lengthLoading ? 'Searching…' : 'Estimate with AI'}
+                </button>
+              </div>
+              <input
+                type="number"
+                step="0.5"
+                min="0"
+                value={formData.expectedHours}
+                onChange={e => { setFormData({ ...formData, expectedHours: e.target.value }); setLengthNote(null); }}
+                className="w-full px-3 py-3 bg-white/[0.03] border border-white/5 text-white rounded-xl text-sm focus:outline-none focus:bg-white/[0.05] focus:border-white/10 transition-all"
+                placeholder="e.g. 25 — used by the Timeline Estimator"
+              />
+              {lengthNote && (
+                <p className="mt-1 text-[11px] text-white/40 flex items-center gap-1">
+                  <Sparkles size={10} className="text-purple-400/50" />
+                  {lengthNote}
+                </p>
+              )}
             </div>
 
             {/* Live Value Card */}

--- a/app/apps/game-analytics/components/TimelineEstimatorTab.tsx
+++ b/app/apps/game-analytics/components/TimelineEstimatorTab.tsx
@@ -1,0 +1,437 @@
+'use client';
+
+import { useState, useMemo, useEffect, useCallback } from 'react';
+import {
+  CalendarClock, AlarmClock, TrendingUp, ShoppingCart, Sparkles, Loader2,
+  Wallet, Gamepad2, ArrowRight, Tag, ExternalLink, AlertTriangle, CheckCircle2,
+  Clock, Search,
+} from 'lucide-react';
+import clsx from 'clsx';
+import { Game, PurchaseQueueEntry } from '../lib/types';
+import { getUserGamingPace } from '../lib/calculations';
+import {
+  buildPlaythroughTimeline, detectGap, matchInterimGames, buildPurchaseCalendar,
+  computeScenarios, getRemainingHours,
+  UpcomingRelease,
+} from '../lib/timeline-estimator';
+import { loadEstimatorSettings, saveEstimatorSettings, EstimatorSettings } from '../lib/estimator-settings';
+import { lookupGameLength } from '../lib/ai-timeline-service';
+import { fetchDeals, getDealLink, CheapSharkDeal } from '../lib/cheapshark-api';
+
+interface TimelineEstimatorTabProps {
+  userId: string | null;
+  queuedGames: Game[];        // ordered Up Next queue (active first)
+  allGames: Game[];
+  upcomingEntries: PurchaseQueueEntry[]; // buy-queue entries releasing in the future
+  annualBudget: number | null;
+  yearSpent: number;
+  onUpdateGame: (id: string, updates: Partial<Game>) => Promise<Game>;
+  onGoToQueue?: () => void;
+}
+
+function fmtDate(d: Date | null): string {
+  if (!d) return 'TBA';
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+function humanizeWeeks(weeks: number): string {
+  if (weeks <= 0) return 'now';
+  if (weeks < 1) return `${Math.round(weeks * 7)} days`;
+  if (weeks < 8) return `${weeks.toFixed(1)} weeks`;
+  return `${(weeks / 4.345).toFixed(1)} months`;
+}
+
+export function TimelineEstimatorTab({
+  userId, queuedGames, allGames, upcomingEntries, annualBudget, yearSpent,
+  onUpdateGame, onGoToQueue,
+}: TimelineEstimatorTabProps) {
+  const pace = useMemo(() => getUserGamingPace(allGames), [allGames]);
+  const [settings, setSettings] = useState<EstimatorSettings>(() =>
+    loadEstimatorSettings(userId || 'local-user', pace)
+  );
+
+  // Persist whenever the user tweaks the pace knobs.
+  useEffect(() => {
+    saveEstimatorSettings(userId || 'local-user', settings);
+  }, [settings, userId]);
+
+  const today = useMemo(() => { const d = new Date(); d.setHours(0, 0, 0, 0); return d; }, []);
+
+  const activeQueue = useMemo(
+    () => queuedGames.filter(g => g.status !== 'Completed' && g.status !== 'Abandoned'),
+    [queuedGames]
+  );
+  const queuedIds = useMemo(() => new Set(queuedGames.map(g => g.id)), [queuedGames]);
+
+  const timeline = useMemo(
+    () => buildPlaythroughTimeline(activeQueue, settings.weeklyHours, today, allGames),
+    [activeQueue, settings.weeklyHours, today, allGames]
+  );
+
+  const upcomingReleases: UpcomingRelease[] = useMemo(() =>
+    upcomingEntries
+      .filter(e => e.releaseDate)
+      .map(e => ({
+        id: e.id,
+        name: e.gameName,
+        date: new Date(e.releaseDate as string),
+        price: e.targetPrice ?? e.currentPrice ?? e.msrpEstimate ?? 70,
+        isDayOne: e.isDayOneBuy,
+        thumbnail: e.thumbnail,
+      })),
+    [upcomingEntries]
+  );
+
+  const queueEndDate = timeline.length > 0 ? timeline[timeline.length - 1].endDate : today;
+  const gap = useMemo(
+    () => detectGap(queueEndDate, upcomingReleases, settings.weeklyHours),
+    [queueEndDate, upcomingReleases, settings.weeklyHours]
+  );
+
+  const interim = useMemo(
+    () => matchInterimGames(gap.gapHours, settings.weeklyHours, allGames, queuedIds),
+    [gap.gapHours, settings.weeklyHours, allGames, queuedIds]
+  );
+
+  const purchaseCalendar = useMemo(
+    () => buildPurchaseCalendar(upcomingEntries, annualBudget, yearSpent),
+    [upcomingEntries, annualBudget, yearSpent]
+  );
+
+  const scenarios = useMemo(() => computeScenarios(activeQueue, allGames, today, [
+    { label: 'Low', weeklyHours: settings.lowPace },
+    { label: 'Mid', weeklyHours: settings.weeklyHours },
+    { label: 'High', weeklyHours: settings.highPace },
+  ]), [activeQueue, allGames, today, settings]);
+
+  const totalRemaining = useMemo(
+    () => activeQueue.reduce((sum, g) => sum + getRemainingHours(g, allGames), 0),
+    [activeQueue, allGames]
+  );
+
+  // ── AI length lookup for queued games missing an estimate ──────────
+  const missingLength = useMemo(
+    () => activeQueue.filter(g => !(g.expectedHours && g.expectedHours > 0)),
+    [activeQueue]
+  );
+  const [estimatingAll, setEstimatingAll] = useState(false);
+  const handleEstimateAll = useCallback(async () => {
+    setEstimatingAll(true);
+    try {
+      for (const g of missingLength) {
+        const res = await lookupGameLength(g.name, g.platform);
+        if (res.hours) await onUpdateGame(g.id, { expectedHours: res.hours });
+      }
+    } finally {
+      setEstimatingAll(false);
+    }
+  }, [missingLength, onUpdateGame]);
+
+  // ── CheapShark deal search to fill the gap cheaply ─────────────────
+  const [deals, setDeals] = useState<CheapSharkDeal[]>([]);
+  const [dealsLoading, setDealsLoading] = useState(false);
+  const [dealsSearched, setDealsSearched] = useState(false);
+  const handleFindDeals = useCallback(async () => {
+    setDealsLoading(true);
+    setDealsSearched(true);
+    try {
+      // Cheap, well-reviewed games on sale right now make the best gap fillers.
+      const results = await fetchDeals({ onSale: true, sortBy: 'Savings', upperPrice: 30, metacritic: 70, pageSize: 8 });
+      setDeals(results);
+    } catch {
+      setDeals([]);
+    } finally {
+      setDealsLoading(false);
+    }
+  }, []);
+
+  const updatePace = (key: keyof EstimatorSettings, value: number) =>
+    setSettings(prev => ({ ...prev, [key]: Math.max(0.5, value) }));
+
+  // ── Empty state ────────────────────────────────────────────────────
+  if (activeQueue.length === 0) {
+    return (
+      <div className="text-center py-16">
+        <CalendarClock size={48} className="mx-auto mb-4 text-white/10" />
+        <p className="text-white/40 text-sm">Nothing lined up to estimate yet</p>
+        <p className="text-white/25 text-xs mt-1 max-w-xs mx-auto">
+          Add games to your Up Next queue — the estimator turns that order into completion dates and a purchase calendar.
+        </p>
+        {onGoToQueue && (
+          <button
+            onClick={onGoToQueue}
+            className="mt-4 inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-purple-600/20 text-purple-300 hover:bg-purple-600/30 text-sm transition-all"
+          >
+            <Gamepad2 size={16} /> Go to Up Next
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  const gapColor =
+    gap.severity === 'long' ? 'text-red-400 border-red-500/30 bg-red-500/5'
+    : gap.severity === 'medium' ? 'text-amber-400 border-amber-500/30 bg-amber-500/5'
+    : gap.severity === 'open-ended' ? 'text-white/50 border-white/10 bg-white/[0.02]'
+    : 'text-emerald-400 border-emerald-500/30 bg-emerald-500/5';
+
+  return (
+    <div className="space-y-5">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <CalendarClock size={24} className="text-purple-400" />
+        <div>
+          <h2 className="text-xl font-semibold text-white">Timeline Estimator</h2>
+          <p className="text-xs text-white/40">When you&apos;ll finish, and what to buy next</p>
+        </div>
+      </div>
+
+      {/* Pace controls */}
+      <div className="p-4 rounded-xl bg-white/[0.02] border border-white/5 space-y-3">
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-medium text-white/80 flex items-center gap-2">
+            <Clock size={15} className="text-white/40" /> Your weekly pace
+          </span>
+          {pace > 0 && (
+            <span className="text-[11px] text-white/35">recent actual: ~{pace.toFixed(1)} h/wk</span>
+          )}
+        </div>
+        <div className="grid grid-cols-3 gap-2">
+          {([
+            { key: 'lowPace' as const, label: 'Low' },
+            { key: 'weeklyHours' as const, label: 'Main' },
+            { key: 'highPace' as const, label: 'High' },
+          ]).map(({ key, label }) => (
+            <label key={key} className="block">
+              <span className="text-[11px] text-white/40">{label} (h/wk)</span>
+              <input
+                type="number" step="0.5" min="0.5"
+                value={settings[key]}
+                onChange={e => updatePace(key, parseFloat(e.target.value) || 0)}
+                className={clsx(
+                  'w-full mt-1 px-3 py-2 bg-white/[0.03] border rounded-lg text-sm text-white focus:outline-none transition-all',
+                  key === 'weeklyHours' ? 'border-purple-500/30 focus:border-purple-500/60' : 'border-white/5 focus:border-white/10'
+                )}
+              />
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {/* Missing-length nudge */}
+      {missingLength.length > 0 && (
+        <div className="p-3 rounded-xl border border-purple-500/20 bg-purple-500/5 flex items-center justify-between gap-3">
+          <p className="text-xs text-white/60">
+            {missingLength.length} queued game{missingLength.length !== 1 ? 's' : ''} {missingLength.length !== 1 ? 'have' : 'has'} no length set — using genre estimates for now.
+          </p>
+          <button
+            onClick={handleEstimateAll}
+            disabled={estimatingAll}
+            className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-purple-600/30 text-purple-200 hover:bg-purple-600/40 disabled:opacity-50 text-xs font-medium transition-all"
+          >
+            {estimatingAll ? <Loader2 size={13} className="animate-spin" /> : <Sparkles size={13} />}
+            {estimatingAll ? 'Looking up…' : 'Estimate all with AI'}
+          </button>
+        </div>
+      )}
+
+      {/* Completion timeline */}
+      <section className="space-y-2">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-white/80 flex items-center gap-2">
+            <TrendingUp size={15} className="text-purple-400" /> Completion Timeline
+          </h3>
+          <span className="text-[11px] text-white/40">{Math.round(totalRemaining)}h left · done {fmtDate(queueEndDate)}</span>
+        </div>
+        <div className="space-y-2">
+          {timeline.map((seg, i) => (
+            <div key={seg.game.id} className="flex items-center gap-3 p-3 rounded-xl bg-white/[0.02] border border-white/5">
+              <div className="w-6 h-6 rounded-full bg-purple-500/15 text-purple-300 text-xs font-bold flex items-center justify-center shrink-0">
+                {i + 1}
+              </div>
+              {seg.game.thumbnail && (
+                <img src={seg.game.thumbnail} alt={seg.game.name} className="w-10 h-10 rounded-lg object-cover shrink-0" loading="lazy" />
+              )}
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-white/90 truncate">{seg.game.name}</p>
+                <p className="text-[11px] text-white/40">
+                  {Math.round(seg.remainingHours)}h left · {humanizeWeeks(seg.weeks)}
+                  {seg.isEstimatedLength && <span className="text-white/25"> · est. length</span>}
+                </p>
+              </div>
+              <div className="text-right shrink-0">
+                <p className="text-[10px] text-white/30 uppercase tracking-wide">Done</p>
+                <p className="text-xs font-semibold text-white/80">{fmtDate(seg.endDate)}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Gap analysis */}
+      <section className={clsx('p-4 rounded-xl border space-y-2', gapColor)}>
+        <div className="flex items-center gap-2">
+          {gap.severity === 'long' || gap.severity === 'open-ended'
+            ? <AlertTriangle size={16} />
+            : <CheckCircle2 size={16} />}
+          <h3 className="text-sm font-semibold">
+            {gap.severity === 'open-ended' ? 'Nothing lined up after your queue'
+              : gap.severity === 'long' ? 'Long gap ahead'
+              : gap.severity === 'medium' ? 'Moderate gap ahead'
+              : 'Seamless — next release lands right on time'}
+          </h3>
+        </div>
+        <p className="text-xs opacity-80">
+          {gap.nextRelease ? (
+            <>You&apos;ll wrap your queue around <strong>{fmtDate(gap.queueEndDate)}</strong>, and{' '}
+              <strong>{gap.nextRelease.name}</strong> releases <strong>{fmtDate(gap.nextRelease.date)}</strong> —
+              a {humanizeWeeks(gap.gapWeeks)} gap.</>
+          ) : (
+            <>You&apos;ll wrap your queue around <strong>{fmtDate(gap.queueEndDate)}</strong> with no upcoming
+              releases tracked after that. Add releases in the Buy Queue, or fill the time with your backlog.</>
+          )}
+        </p>
+      </section>
+
+      {/* Interim recommendations (owned backlog) */}
+      {interim.length > 0 && (
+        <section className="space-y-2">
+          <h3 className="text-sm font-semibold text-white/80 flex items-center gap-2">
+            <Gamepad2 size={15} className="text-emerald-400" /> Fill the gap — from your backlog (free, already owned)
+          </h3>
+          <div className="grid sm:grid-cols-2 gap-2">
+            {interim.map(s => (
+              <div key={s.game.id} className="flex items-center gap-3 p-3 rounded-xl bg-white/[0.02] border border-white/5">
+                {s.game.thumbnail && (
+                  <img src={s.game.thumbnail} alt={s.game.name} className="w-10 h-10 rounded-lg object-cover shrink-0" loading="lazy" />
+                )}
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-white/90 truncate">{s.game.name}</p>
+                  <p className="text-[11px] text-white/40">
+                    ~{s.expectedHours}h · {humanizeWeeks(s.weeksToFinish)}
+                  </p>
+                </div>
+                {s.fitsGap && (
+                  <span className="text-[10px] px-2 py-0.5 rounded-full bg-emerald-500/15 text-emerald-400 shrink-0">fits</span>
+                )}
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Discounted deals to fill the gap (live, CheapShark) */}
+      <section className="space-y-2">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-white/80 flex items-center gap-2">
+            <Tag size={15} className="text-amber-400" /> Cheap games on sale right now
+          </h3>
+          <button
+            onClick={handleFindDeals}
+            disabled={dealsLoading}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-amber-500/15 text-amber-300 hover:bg-amber-500/25 disabled:opacity-50 text-xs font-medium transition-all"
+          >
+            {dealsLoading ? <Loader2 size={13} className="animate-spin" /> : <Search size={13} />}
+            {dealsLoading ? 'Searching…' : 'Find deals'}
+          </button>
+        </div>
+        {dealsSearched && !dealsLoading && deals.length === 0 && (
+          <p className="text-xs text-white/35">No deals found right now — try again later.</p>
+        )}
+        {deals.length > 0 && (
+          <div className="grid sm:grid-cols-2 gap-2">
+            {deals.map(deal => (
+              <a
+                key={deal.dealID}
+                href={getDealLink(deal.dealID)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-3 p-3 rounded-xl bg-white/[0.02] border border-white/5 hover:border-amber-500/30 transition-all group"
+              >
+                {deal.thumb && (
+                  <img src={deal.thumb} alt={deal.title} className="w-12 h-10 rounded object-cover shrink-0" loading="lazy" />
+                )}
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-white/90 truncate group-hover:text-amber-300 transition-colors">{deal.title}</p>
+                  <div className="flex items-center gap-1.5 mt-0.5">
+                    <span className="text-xs font-semibold text-emerald-400">${parseFloat(deal.salePrice).toFixed(2)}</span>
+                    <span className="text-[11px] text-white/30 line-through">${parseFloat(deal.normalPrice).toFixed(2)}</span>
+                    <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-amber-500/15 text-amber-400">
+                      -{Math.round(parseFloat(deal.savings))}%
+                    </span>
+                  </div>
+                </div>
+                <ExternalLink size={14} className="text-white/20 group-hover:text-amber-400 transition-colors shrink-0" />
+              </a>
+            ))}
+          </div>
+        )}
+        <p className="text-[10px] text-white/25">Live PC store deals via CheapShark. Console prices may differ.</p>
+      </section>
+
+      {/* Purchase calendar */}
+      {purchaseCalendar.length > 0 && (
+        <section className="space-y-2">
+          <h3 className="text-sm font-semibold text-white/80 flex items-center gap-2">
+            <ShoppingCart size={15} className="text-purple-400" /> Purchase Calendar
+          </h3>
+          <div className="space-y-2">
+            {purchaseCalendar.map(row => (
+              <div key={row.id} className="flex items-center gap-3 p-3 rounded-xl bg-white/[0.02] border border-white/5">
+                {row.thumbnail && (
+                  <img src={row.thumbnail} alt={row.name} className="w-10 h-10 rounded-lg object-cover shrink-0" loading="lazy" />
+                )}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <p className="text-sm font-medium text-white/90 truncate">{row.name}</p>
+                    {row.isDayOne && (
+                      <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-purple-500/20 text-purple-300 shrink-0">day one</span>
+                    )}
+                  </div>
+                  <p className="text-[11px] text-white/40">{fmtDate(row.date)}</p>
+                </div>
+                <div className="text-right shrink-0">
+                  <p className="text-sm font-semibold text-white/85">${row.price.toFixed(0)}</p>
+                  {row.remaining !== null && (
+                    <p className={clsx('text-[10px]', row.remaining < 0 ? 'text-red-400' : 'text-white/35')}>
+                      ${row.remaining.toFixed(0)} left
+                    </p>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+          {annualBudget !== null && (
+            <div className="flex items-center justify-between px-3 py-2 rounded-lg bg-white/[0.02] border border-white/5 text-xs">
+              <span className="text-white/50 flex items-center gap-1.5"><Wallet size={13} /> Annual budget</span>
+              <span className="text-white/70">
+                ${(purchaseCalendar[purchaseCalendar.length - 1].cumulative).toFixed(0)} of ${annualBudget.toFixed(0)} planned
+              </span>
+            </div>
+          )}
+        </section>
+      )}
+
+      {/* Scenario comparison */}
+      <section className="space-y-2">
+        <h3 className="text-sm font-semibold text-white/80 flex items-center gap-2">
+          <AlarmClock size={15} className="text-cyan-400" /> Pace Scenarios — when you&apos;d clear the queue
+        </h3>
+        <div className="grid grid-cols-3 gap-2">
+          {scenarios.map(s => (
+            <div key={s.label} className={clsx(
+              'p-3 rounded-xl border text-center',
+              s.label === 'Mid' ? 'bg-purple-500/5 border-purple-500/20' : 'bg-white/[0.02] border-white/5'
+            )}>
+              <p className="text-[11px] text-white/40">{s.label} · {s.weeklyHours}h/wk</p>
+              <p className="text-sm font-semibold text-white/85 mt-1 flex items-center justify-center gap-1">
+                <ArrowRight size={12} className="text-white/30" /> {fmtDate(s.endDate)}
+              </p>
+              <p className="text-[10px] text-white/35 mt-0.5">{humanizeWeeks(s.weeks)}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/apps/game-analytics/components/UpNextTab.tsx
+++ b/app/apps/game-analytics/components/UpNextTab.tsx
@@ -19,7 +19,7 @@ import {
 import {
   ListOrdered, Search, Plus, Gamepad2, Swords, Sparkles, Brain,
   MessageSquare, TrendingUp, ChevronDown, ChevronUp, RefreshCw,
-  Flame, Zap, Map, BookOpen,
+  Flame, Zap, Map, BookOpen, Trash2,
 } from 'lucide-react';
 import { QueueGameCard } from './QueueGameCard';
 import { GameWithMetrics } from '../hooks/useAnalytics';
@@ -43,6 +43,7 @@ interface UpNextTabProps {
   onAddToQueue: (gameId: string) => Promise<void>;
   onRemoveFromQueue: (gameId: string) => Promise<void>;
   onReorderQueue: (gameId: string, newPosition: number) => Promise<void>;
+  onClearUpcoming?: () => Promise<void>;
   onLogTime?: (game: GameWithMetrics) => void;
   onStartGame?: (game: GameWithMetrics) => void;
 }
@@ -58,6 +59,7 @@ export function UpNextTab({
   onAddToQueue,
   onRemoveFromQueue,
   onReorderQueue,
+  onClearUpcoming,
   onLogTime,
   onStartGame,
 }: UpNextTabProps) {
@@ -115,6 +117,16 @@ export function UpNextTab({
     }
     return { count: activeGames.length, totalHours: Math.round(totalHours), timeLabel };
   }, [queuedGames, weeklyPace]);
+
+  // "Clear Upcoming" only touches queued games that aren't currently being played.
+  const currentlyPlayingCount = useMemo(
+    () => queuedGames.filter(g => g.status === 'In Progress').length,
+    [queuedGames]
+  );
+  const clearableCount = useMemo(
+    () => queuedGames.filter(g => g.status !== 'In Progress').length,
+    [queuedGames]
+  );
 
   // Index of the last In Progress game (for On Deck divider placement)
   const lastHeroIndex = useMemo(() => {
@@ -261,6 +273,22 @@ export function UpNextTab({
         </div>
 
         <div className="flex items-center gap-2">
+          {onClearUpcoming && clearableCount > 0 && (
+            <button
+              onClick={async () => {
+                if (window.confirm(
+                  `Clear ${clearableCount} upcoming game${clearableCount !== 1 ? 's' : ''} from the queue? Your current game${currentlyPlayingCount !== 1 ? 's' : ''} stay${currentlyPlayingCount === 1 ? 's' : ''} put.`
+                )) {
+                  await onClearUpcoming();
+                }
+              }}
+              title="Clear everything planned for after today (keeps what you're playing now)"
+              className="flex items-center gap-2 px-3 py-2 rounded-lg text-xs font-medium transition-all bg-white/5 text-white/60 border border-white/5 hover:bg-red-500/10 hover:text-red-400 hover:border-red-500/30"
+            >
+              <Trash2 size={14} />
+              Clear Upcoming
+            </button>
+          )}
           <button
             onClick={onToggleHideFinished}
             className={clsx(

--- a/app/apps/game-analytics/hooks/useGameQueue.ts
+++ b/app/apps/game-analytics/hooks/useGameQueue.ts
@@ -119,6 +119,17 @@ export function useGameQueue(
     await Promise.all(updates.map(u => updateGame(u.id, { queuePosition: u.position })));
   };
 
+  // Clear everything planned for "after today" — removes all queued games EXCEPT
+  // the ones currently being played (In Progress). The active game(s) stay put;
+  // the on-deck/backlog you'd planned for later get cleared out.
+  const clearUpcoming = async () => {
+    const toClear = games.filter(
+      g => g.queuePosition !== undefined && g.status !== 'In Progress'
+    );
+    if (toClear.length === 0) return;
+    await Promise.all(toClear.map(g => updateGame(g.id, { queuePosition: undefined })));
+  };
+
   // Check if a game is in the queue
   const isInQueue = (gameId: string): boolean => {
     const game = games.find(g => g.id === gameId);
@@ -133,6 +144,7 @@ export function useGameQueue(
     addToQueue,
     removeFromQueue,
     reorderQueue,
+    clearUpcoming,
     isInQueue,
   };
 }

--- a/app/apps/game-analytics/lib/ai-timeline-service.ts
+++ b/app/apps/game-analytics/lib/ai-timeline-service.ts
@@ -1,0 +1,64 @@
+'use client';
+
+import { getAI, getGenerativeModel, GoogleAIBackend } from 'firebase/ai';
+import { initializeApp, getApps } from 'firebase/app';
+
+const firebaseConfig = {
+  apiKey: "AIzaSyBS3IVvszDrm_zjjXu8TATgs1H-FlegHtM",
+  authDomain: "oneapp-943e3.firebaseapp.com",
+  projectId: "oneapp-943e3",
+  storageBucket: "oneapp-943e3.firebasestorage.app",
+  messagingSenderId: "1052736128978",
+  appId: "1:1052736128978:web:9d42b47c6a343eac35aa0b",
+};
+
+// Grounded model — uses Google Search so length/price estimates reflect real data
+// (HowLongToBeat figures, current store prices) rather than the model's memory.
+function getGroundedAIModel() {
+  const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+  const ai = getAI(app, { backend: new GoogleAIBackend() });
+  return getGenerativeModel(ai, {
+    model: "gemini-2.5-flash",
+    tools: [{ googleSearch: {} }],
+  } as Parameters<typeof getGenerativeModel>[1]);
+}
+
+function stripJsonFences(raw: string): string {
+  return raw.replace(/^```[a-z]*\n?/i, '').replace(/\n?```$/i, '').trim();
+}
+
+export interface GameLengthEstimate {
+  hours: number | null;       // estimated hours to finish (main story / "beat the game")
+  completionist?: number | null; // optional 100% estimate
+  note?: string;              // short human-readable source/context
+  error?: string;
+}
+
+/**
+ * Look up how long a game takes to beat, grounded in a live web search
+ * (HowLongToBeat-style "main story" hours). Returns null hours on failure so
+ * callers can fall back to manual entry / a genre estimate.
+ */
+export async function lookupGameLength(gameName: string, platform?: string): Promise<GameLengthEstimate> {
+  const model = getGroundedAIModel();
+  const prompt = `Search the web for how many hours it takes to finish the video game "${gameName}"${platform ? ` on ${platform}` : ''}.
+Use HowLongToBeat-style figures: "main story" (just the critical path) and "completionist" (100%).
+
+Respond with ONLY valid JSON (no markdown, no code fences):
+{"hours": <main story hours as a number>, "completionist": <100% hours as a number or null>, "note": "<one short phrase, e.g. 'HowLongToBeat: ~25h main story'>"}
+
+If you genuinely cannot find a reliable figure, respond with {"hours": null, "note": "not found"}.`;
+
+  try {
+    const result = await model.generateContent(prompt);
+    const parsed = JSON.parse(stripJsonFences(result.response.text().trim()));
+    const hours = typeof parsed.hours === 'number' && parsed.hours > 0 ? parsed.hours : null;
+    const completionist = typeof parsed.completionist === 'number' && parsed.completionist > 0
+      ? parsed.completionist
+      : null;
+    return { hours, completionist, note: typeof parsed.note === 'string' ? parsed.note : undefined };
+  } catch (e) {
+    console.error('lookupGameLength error:', e);
+    return { hours: null, error: String(e) };
+  }
+}

--- a/app/apps/game-analytics/lib/estimator-settings.ts
+++ b/app/apps/game-analytics/lib/estimator-settings.ts
@@ -1,0 +1,57 @@
+'use client';
+
+/**
+ * Timeline Estimator settings — weekly playtime + pace scenarios.
+ * Stored in localStorage (per user), SSR-safe. These are planning knobs, not
+ * core game data, so they don't need the Hybrid/Firebase repository treatment.
+ */
+
+export interface EstimatorSettings {
+  weeklyHours: number;   // the pace used for the main timeline
+  lowPace: number;       // "Low pace" scenario
+  highPace: number;      // "High pace" scenario
+}
+
+export const DEFAULT_ESTIMATOR_SETTINGS: EstimatorSettings = {
+  weeklyHours: 8.5,
+  lowPace: 7,
+  highPace: 10,
+};
+
+const keyFor = (userId: string) => `ga-estimator-settings-${userId || 'local-user'}`;
+
+export function loadEstimatorSettings(userId: string, paceHint?: number): EstimatorSettings {
+  if (typeof window === 'undefined') return { ...DEFAULT_ESTIMATOR_SETTINGS };
+  try {
+    const raw = localStorage.getItem(keyFor(userId));
+    if (raw) {
+      const parsed = JSON.parse(raw) as Partial<EstimatorSettings>;
+      return {
+        weeklyHours: numOr(parsed.weeklyHours, DEFAULT_ESTIMATOR_SETTINGS.weeklyHours),
+        lowPace: numOr(parsed.lowPace, DEFAULT_ESTIMATOR_SETTINGS.lowPace),
+        highPace: numOr(parsed.highPace, DEFAULT_ESTIMATOR_SETTINGS.highPace),
+      };
+    }
+  } catch {
+    /* fall through to defaults */
+  }
+  // No saved settings — seed the main pace from the user's actual recent pace if we have one.
+  if (paceHint && paceHint > 0) {
+    const mid = Math.round(paceHint * 10) / 10;
+    return { weeklyHours: mid, lowPace: Math.max(1, Math.round(mid * 0.7)), highPace: Math.round(mid * 1.25) };
+  }
+  return { ...DEFAULT_ESTIMATOR_SETTINGS };
+}
+
+export function saveEstimatorSettings(userId: string, settings: EstimatorSettings): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(keyFor(userId), JSON.stringify(settings));
+  } catch {
+    /* ignore quota / disabled storage */
+  }
+}
+
+function numOr(v: unknown, fallback: number): number {
+  return typeof v === 'number' && isFinite(v) && v > 0 ? v : fallback;
+}

--- a/app/apps/game-analytics/lib/timeline-estimator.ts
+++ b/app/apps/game-analytics/lib/timeline-estimator.ts
@@ -1,0 +1,275 @@
+import { Game, PurchaseQueueEntry } from './types';
+import { getTotalHours } from './calculations';
+
+/**
+ * Gaming Timeline Estimator — pure planning calculations.
+ *
+ * Sequences your Up Next queue into completion dates at a chosen weekly pace,
+ * detects idle gaps before upcoming releases, suggests interim fills, and lays
+ * out a budgeted purchase calendar. No side effects; all dates are real Dates.
+ */
+
+export const DEFAULT_EXPECTED_HOURS = 20;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export function addDays(date: Date, days: number): Date {
+  return new Date(date.getTime() + days * DAY_MS);
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+/**
+ * Best estimate of how long a game takes to finish:
+ *   1. explicit expectedHours (manual or AI lookup)
+ *   2. median total hours of completed games in the same genre
+ *   3. median total hours of all completed games
+ *   4. a sane global default
+ */
+export function getEffectiveExpectedHours(game: Game, allGames: Game[]): number {
+  if (game.expectedHours && game.expectedHours > 0) return game.expectedHours;
+
+  const completed = allGames.filter(g => g.status === 'Completed' && getTotalHours(g) > 0);
+
+  if (game.genre) {
+    const sameGenre = completed.filter(g => g.genre === game.genre).map(getTotalHours);
+    if (sameGenre.length >= 2) return Math.round(median(sameGenre));
+  }
+  if (completed.length >= 2) return Math.round(median(completed.map(getTotalHours)));
+  return DEFAULT_EXPECTED_HOURS;
+}
+
+/** Hours still left to finish a game (never negative). */
+export function getRemainingHours(game: Game, allGames: Game[]): number {
+  const expected = getEffectiveExpectedHours(game, allGames);
+  const played = getTotalHours(game);
+  return Math.max(expected - played, 0);
+}
+
+export interface TimelineSegment {
+  game: Game;
+  remainingHours: number;
+  weeks: number;
+  startDate: Date;
+  endDate: Date;
+  isEstimatedLength: boolean; // true when expectedHours wasn't set (we guessed)
+}
+
+/**
+ * Walk the ordered queue back-to-back from `startDate`, producing a completion
+ * date for each game at the given weekly pace. Already-finished games are skipped.
+ */
+export function buildPlaythroughTimeline(
+  orderedGames: Game[],
+  weeklyHours: number,
+  startDate: Date,
+  allGames: Game[]
+): TimelineSegment[] {
+  const segments: TimelineSegment[] = [];
+  let cursor = new Date(startDate);
+  const pace = weeklyHours > 0 ? weeklyHours : 1;
+
+  for (const game of orderedGames) {
+    if (game.status === 'Completed' || game.status === 'Abandoned') continue;
+    const remainingHours = getRemainingHours(game, allGames);
+    const weeks = remainingHours / pace;
+    const segStart = new Date(cursor);
+    const segEnd = addDays(segStart, Math.ceil(weeks * 7));
+    segments.push({
+      game,
+      remainingHours,
+      weeks,
+      startDate: segStart,
+      endDate: segEnd,
+      isEstimatedLength: !(game.expectedHours && game.expectedHours > 0),
+    });
+    cursor = segEnd;
+  }
+  return segments;
+}
+
+export type GapSeverity = 'short' | 'medium' | 'long' | 'open-ended';
+
+export interface UpcomingRelease {
+  id: string;
+  name: string;
+  date: Date;
+  price: number;
+  isDayOne: boolean;
+  thumbnail?: string;
+}
+
+export interface GapInfo {
+  hasGap: boolean;
+  queueEndDate: Date;
+  gapWeeks: number;
+  gapHours: number;          // gapWeeks × weeklyHours — how much play the gap could absorb
+  nextRelease: UpcomingRelease | null;
+  severity: GapSeverity;
+}
+
+function severityForWeeks(weeks: number): GapSeverity {
+  if (weeks > 4) return 'long';
+  if (weeks >= 2) return 'medium';
+  return 'short';
+}
+
+/**
+ * The idle window between finishing your queue and your next wanted release.
+ * If nothing is lined up after the queue ends, the gap is "open-ended".
+ */
+export function detectGap(
+  queueEndDate: Date,
+  upcomingReleases: UpcomingRelease[],
+  weeklyHours: number
+): GapInfo {
+  const future = upcomingReleases
+    .filter(r => r.date.getTime() > queueEndDate.getTime())
+    .sort((a, b) => a.date.getTime() - b.date.getTime());
+
+  const pace = weeklyHours > 0 ? weeklyHours : 1;
+
+  if (future.length === 0) {
+    return {
+      hasGap: true,
+      queueEndDate,
+      gapWeeks: 0,
+      gapHours: 0,
+      nextRelease: null,
+      severity: 'open-ended',
+    };
+  }
+
+  const next = future[0];
+  const gapWeeks = (next.date.getTime() - queueEndDate.getTime()) / (7 * DAY_MS);
+  return {
+    hasGap: gapWeeks > 0.5,
+    queueEndDate,
+    gapWeeks,
+    gapHours: gapWeeks * pace,
+    nextRelease: next,
+    severity: severityForWeeks(gapWeeks),
+  };
+}
+
+export interface InterimSuggestion {
+  game: Game;
+  expectedHours: number;
+  weeksToFinish: number;
+  fitsGap: boolean;
+  source: 'owned-backlog';
+}
+
+/**
+ * Rank owned-but-unplayed games (free to play — you already own them) as gap
+ * fillers, preferring lengths that fit the available window.
+ */
+export function matchInterimGames(
+  gapHours: number,
+  weeklyHours: number,
+  allGames: Game[],
+  queuedIds: Set<string>,
+  limit = 4
+): InterimSuggestion[] {
+  const pace = weeklyHours > 0 ? weeklyHours : 1;
+  const target = gapHours > 0 ? gapHours : pace * 4; // open-ended → assume ~4 weeks of play
+
+  const backlog = allGames.filter(
+    g => g.status === 'Not Started' && !queuedIds.has(g.id)
+  );
+
+  return backlog
+    .map(game => {
+      const expectedHours = getEffectiveExpectedHours(game, allGames);
+      return {
+        game,
+        expectedHours,
+        weeksToFinish: expectedHours / pace,
+        fitsGap: expectedHours <= target * 1.2,
+        source: 'owned-backlog' as const,
+      };
+    })
+    .sort((a, b) => Math.abs(a.expectedHours - target) - Math.abs(b.expectedHours - target))
+    .slice(0, limit);
+}
+
+export interface PurchaseCalendarRow {
+  id: string;
+  name: string;
+  date: Date | null;     // release/buy date; null = TBA
+  price: number;
+  isDayOne: boolean;
+  thumbnail?: string;
+  cumulative: number;    // running total spent through this row
+  remaining: number | null; // budget left after this purchase (null when no budget set)
+}
+
+const priceOf = (e: PurchaseQueueEntry): number =>
+  e.targetPrice ?? e.currentPrice ?? e.msrpEstimate ?? 70;
+
+/**
+ * Dated purchase calendar with a running budget. Entries sort by release date
+ * (TBA last); cumulative spend and remaining budget are computed in order.
+ */
+export function buildPurchaseCalendar(
+  entries: PurchaseQueueEntry[],
+  annualBudget: number | null,
+  alreadySpent: number
+): PurchaseCalendarRow[] {
+  const sorted = [...entries].sort((a, b) => {
+    const ta = a.releaseDate ? new Date(a.releaseDate).getTime() : Infinity;
+    const tb = b.releaseDate ? new Date(b.releaseDate).getTime() : Infinity;
+    return ta - tb;
+  });
+
+  let cumulative = alreadySpent;
+  return sorted.map(e => {
+    const price = priceOf(e);
+    cumulative += price;
+    return {
+      id: e.id,
+      name: e.gameName,
+      date: e.releaseDate ? new Date(e.releaseDate) : null,
+      price,
+      isDayOne: e.isDayOneBuy,
+      thumbnail: e.thumbnail,
+      cumulative,
+      remaining: annualBudget !== null ? annualBudget - cumulative : null,
+    };
+  });
+}
+
+export interface ScenarioResult {
+  label: string;
+  weeklyHours: number;
+  totalRemainingHours: number;
+  weeks: number;
+  endDate: Date;
+}
+
+/** Compute the queue-finish date under several weekly paces, side by side. */
+export function computeScenarios(
+  orderedGames: Game[],
+  allGames: Game[],
+  startDate: Date,
+  paces: { label: string; weeklyHours: number }[]
+): ScenarioResult[] {
+  const active = orderedGames.filter(g => g.status !== 'Completed' && g.status !== 'Abandoned');
+  const totalRemainingHours = active.reduce((sum, g) => sum + getRemainingHours(g, allGames), 0);
+
+  return paces.map(({ label, weeklyHours }) => {
+    const pace = weeklyHours > 0 ? weeklyHours : 1;
+    const weeks = totalRemainingHours / pace;
+    return {
+      label,
+      weeklyHours,
+      totalRemainingHours,
+      weeks,
+      endDate: addDays(startDate, Math.ceil(weeks * 7)),
+    };
+  });
+}

--- a/app/apps/game-analytics/lib/types.ts
+++ b/app/apps/game-analytics/lib/types.ts
@@ -46,6 +46,7 @@ export interface Game {
   name: string;
   price: number;
   hours: number; // Total hours (manual entry or sum of logs)
+  expectedHours?: number; // Estimated hours to finish the game (manual or AI-looked-up) — used by Timeline Estimator
   rating: number;
   status: GameStatus;
   platform?: string;

--- a/app/apps/game-analytics/page.tsx
+++ b/app/apps/game-analytics/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useMemo, useEffect, useCallback, useRef } from 'react';
-import { Plus, Sparkles, Gamepad2, Clock, DollarSign, Star, TrendingUp, Eye, Trophy, Flame, BarChart3, Calendar, List, MessageCircle, ListOrdered, ListPlus, Check, Heart, ChevronUp, ChevronDown, Compass, Zap, Target, ArrowUpRight, ArrowDownRight, Minus, Shield, MoreVertical, Download, Gift, ShoppingCart, Search, X } from 'lucide-react';
+import { Plus, Sparkles, Gamepad2, Clock, DollarSign, Star, TrendingUp, Eye, Trophy, Flame, BarChart3, Calendar, CalendarClock, List, MessageCircle, ListOrdered, ListPlus, Check, Heart, ChevronUp, ChevronDown, Compass, Zap, Target, ArrowUpRight, ArrowDownRight, Minus, Shield, MoreVertical, Download, Gift, ShoppingCart, Search, X } from 'lucide-react';
 import { useGames } from './hooks/useGames';
 import { useAnalytics, GameWithMetrics } from './hooks/useAnalytics';
 import { useBudget } from './hooks/useBudget';
@@ -34,6 +34,8 @@ import { GameBottomSheet } from './components/GameBottomSheet';
 import { DiscoverTab } from './components/DiscoverTab';
 import { LeaderboardTab } from './components/LeaderboardTab';
 import { BuyQueueTab } from './components/BuyQueueTab';
+import { TimelineEstimatorTab } from './components/TimelineEstimatorTab';
+import { usePurchaseQueue } from './hooks/usePurchaseQueue';
 import { RatingStars } from './components/RatingStars';
 import { MomentumDots } from './components/MomentumDots';
 import { ProgressRing } from './components/ProgressRing';
@@ -52,7 +54,7 @@ import { GameCompareModal } from './components/GameCompareModal';
 import clsx from 'clsx';
 
 type ViewMode = 'all' | 'owned' | 'wishlist';
-type TabMode = 'games' | 'timeline' | 'stats' | 'ai-coach' | 'up-next' | 'discover' | 'leaderboard' | 'buy-queue';
+type TabMode = 'games' | 'timeline' | 'stats' | 'ai-coach' | 'up-next' | 'discover' | 'leaderboard' | 'buy-queue' | 'estimator';
 type CardViewMode = 'poster' | 'compact';
 
 function getValueColor(rating: string): string {
@@ -139,6 +141,7 @@ export default function GameAnalyticsPage() {
   const { games, loading, error, addGame, updateGame, deleteGame, refresh } = useGames(user?.uid ?? null);
   const { gamesWithMetrics, summary } = useAnalytics(games);
   const { budgets, setBudget } = useBudget(user?.uid ?? null);
+  const { upcomingEntries } = usePurchaseQueue(user?.uid ?? null);
   const { loading: thumbnailsLoading, fetchedCount } = useGameThumbnails(games, updateGame);
   const gameColors = useGameColors(games);
   const { quips: gameQuips } = useGameQuips(games, user?.uid ?? null);
@@ -181,6 +184,7 @@ export default function GameAnalyticsPage() {
     addToQueue,
     removeFromQueue,
     reorderQueue,
+    clearUpcoming,
     isInQueue,
   } = useGameQueue(games, updateGame);
   const [isFormOpen, setIsFormOpen] = useState(false);
@@ -992,6 +996,7 @@ export default function GameAnalyticsPage() {
                   { id: 'discover',    icon: <Compass size={16} />,     title: 'Discover' },
                   { id: 'leaderboard', icon: <Trophy size={16} />,      title: 'Ranks' },
                   { id: 'buy-queue',   icon: <ShoppingCart size={16} />, title: 'Buy Queue' },
+                  { id: 'estimator',   icon: <CalendarClock size={16} />, title: 'Timeline Estimator' },
                 ] as const).map((tab) => (
                   <button
                     key={tab.id}
@@ -1321,6 +1326,14 @@ export default function GameAnalyticsPage() {
                   showToast(`Failed to reorder queue: ${(e as Error).message}`, 'error');
                 }
               }}
+              onClearUpcoming={async () => {
+                try {
+                  await clearUpcoming();
+                  showToast('Cleared upcoming games from the queue', 'success');
+                } catch (e) {
+                  showToast(`Failed to clear queue: ${(e as Error).message}`, 'error');
+                }
+              }}
               onLogTime={(game) => {
                 const gameWithMetrics = gamesWithMetrics.find(g => g.id === game.id);
                 if (gameWithMetrics) {
@@ -1396,6 +1409,19 @@ export default function GameAnalyticsPage() {
                 await addToQueue(gameId);
                 showToast('Added to Up Next', 'success');
               }}
+            />
+          )}
+
+          {tabMode === 'estimator' && (
+            <TimelineEstimatorTab
+              userId={user?.uid ?? null}
+              queuedGames={queuedGames}
+              allGames={games}
+              upcomingEntries={upcomingEntries}
+              annualBudget={budgets.find(b => b.year === new Date().getFullYear())?.yearlyBudget ?? null}
+              yearSpent={currentYearSpent}
+              onUpdateGame={updateGame}
+              onGoToQueue={() => setTabMode('up-next')}
             />
           )}
         </div>


### PR DESCRIPTION
## Gaming Timeline Estimator

A planning tool that turns your **Up Next** queue into completion dates, detects idle gaps before upcoming releases, and lays out a budgeted purchase calendar.

### New "Timeline Estimator" tab
- **Completion timeline** — sequences active queued games back-to-back into real finish dates at your chosen weekly pace (hours left + per-game "Done" date).
- **Adjustable pace controls** — Low / Main / High hrs-per-week, seeded from your actual recent pace (`getUserGamingPace`) and persisted in localStorage.
- **Gap analysis** — the idle window between finishing your queue and your next tracked release, color-coded (red >4wk, amber 2–4wk, green on-time, neutral when nothing's lined up).
- **Interim fills from your backlog** — owned, unplayed games ranked to fit the gap (free, already owned).
- **Live discounted deals** — a "Find deals" button that searches **CheapShark** for cheap, well-reviewed games on sale now (sale price, % off, buy link).
- **Purchase calendar** — upcoming Buy Queue releases dated out with running spend vs. annual budget and day-one flags.
- **Pace scenarios** — when you'd clear the queue at all three paces, side by side.

### Supporting changes
- **`expectedHours` on `Game`** (optional) + an **"Estimate with AI"** button in `GameForm` using Gemini + Google Search grounding (HowLongToBeat-style "hours to beat"), with genre-median fallbacks when unset. The estimator can also batch "Estimate all with AI" for queued games missing a length.
- **"Clear Upcoming"** button in Up Next (`clearUpcoming`) — clears everything planned for after today while keeping the currently-playing game in place.

### New files
- `lib/timeline-estimator.ts` — pure planning calculations
- `lib/ai-timeline-service.ts` — grounded AI game-length lookup
- `lib/estimator-settings.ts` — localStorage pace settings
- `components/TimelineEstimatorTab.tsx` — the tab UI

### Notes
- Grounded AI lookups and live prices depend on outbound network + Firebase AI grounding; all calls degrade gracefully (manual entry / genre fallback / "no deals found") on failure.
- CheapShark returns PC store deals — console prices may differ (noted in the UI).

### Verification
- `next build` compiles successfully
- `tsc --noEmit` clean (0 errors)
- Lint shows only the same `<img>` advisory warnings as the rest of the app — no new errors

https://claude.ai/code/session_01DXKgfyRA2Wjh4LEnorDGeB

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXKgfyRA2Wjh4LEnorDGeB)_