### PR TITLE
Add AI agent actions to Game Analytics coach

### DIFF
--- a/app/apps/game-analytics/components/AIActionCard.tsx
+++ b/app/apps/game-analytics/components/AIActionCard.tsx
@@ -7,6 +7,7 @@ import {
   PendingAction,
   InterestedDestination,
   summarizeAction,
+  validateAction,
   isDestructive,
 } from '../lib/ai-actions';
 
@@ -98,6 +99,14 @@ export function AIActionCard({ actions, games, isLoading, onConfirm, onCancel, o
                   </button>
                 )}
               </div>
+
+              {/* Non-blocking warnings: duplicates, out-of-range values, missing refs */}
+              {validateAction(action, games).map((warning, wi) => (
+                <div key={wi} className="flex items-start gap-1.5 mt-1.5 text-[11px] text-amber-300/90">
+                  <AlertTriangle size={12} className="shrink-0 mt-0.5" />
+                  <span className="leading-snug">{warning}</span>
+                </div>
+              ))}
 
               {/* Per-game destination editing for the interested-games batch */}
               {action.kind === 'addGames' && (

--- a/app/apps/game-analytics/components/AIActionCard.tsx
+++ b/app/apps/game-analytics/components/AIActionCard.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { Check, X, AlertTriangle, Loader2, ShoppingCart, Heart, Layers } from 'lucide-react';
+import clsx from 'clsx';
+import { Game } from '../lib/types';
+import {
+  PendingAction,
+  InterestedDestination,
+  summarizeAction,
+  isDestructive,
+} from '../lib/ai-actions';
+
+interface AIActionCardProps {
+  actions: PendingAction[];
+  games: Game[];
+  isLoading: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+  onChange: (actions: PendingAction[]) => void;
+}
+
+const DEST_OPTIONS: { value: InterestedDestination; label: string; icon: typeof ShoppingCart }[] = [
+  { value: 'queue', label: 'Queue', icon: ShoppingCart },
+  { value: 'wishlist', label: 'Wishlist', icon: Heart },
+  { value: 'both', label: 'Both', icon: Layers },
+];
+
+export function AIActionCard({ actions, games, isLoading, onConfirm, onCancel, onChange }: AIActionCardProps) {
+  if (actions.length === 0) return null;
+
+  const hasDestructive = actions.some(a => isDestructive(a.kind));
+
+  // Remove a whole action from the batch.
+  const removeAction = (index: number) => {
+    onChange(actions.filter((_, i) => i !== index));
+  };
+
+  // Edit one game within an addGames action.
+  const setGameDestination = (actionIndex: number, gameIndex: number, dest: InterestedDestination) => {
+    onChange(actions.map((a, i) => {
+      if (i !== actionIndex || a.kind !== 'addGames') return a;
+      return {
+        ...a,
+        args: { games: a.args.games.map((g, gi) => (gi === gameIndex ? { ...g, destination: dest } : g)) },
+      };
+    }));
+  };
+
+  const removeGame = (actionIndex: number, gameIndex: number) => {
+    const next = actions
+      .map((a, i) => {
+        if (i !== actionIndex || a.kind !== 'addGames') return a;
+        return { ...a, args: { games: a.args.games.filter((_, gi) => gi !== gameIndex) } };
+      })
+      // Drop the action entirely if it has no games left.
+      .filter(a => !(a.kind === 'addGames' && a.args.games.length === 0));
+    onChange(next);
+  };
+
+  return (
+    <div className="flex justify-start">
+      <div
+        className={clsx(
+          'max-w-[92%] w-full rounded-2xl border p-4',
+          hasDestructive ? 'border-red-500/30 bg-red-500/5' : 'border-purple-500/30 bg-purple-500/5',
+        )}
+      >
+        <div className="flex items-center gap-2 mb-3">
+          {hasDestructive ? (
+            <AlertTriangle size={16} className="text-red-400" />
+          ) : (
+            <Check size={16} className="text-purple-400" />
+          )}
+          <span className={clsx('text-xs font-semibold', hasDestructive ? 'text-red-300' : 'text-purple-300')}>
+            {hasDestructive ? 'Confirm — this is permanent' : 'Confirm these changes'}
+          </span>
+        </div>
+
+        <div className="space-y-2">
+          {actions.map((action, ai) => (
+            <div
+              key={ai}
+              className={clsx(
+                'rounded-lg px-3 py-2.5 text-sm',
+                isDestructive(action.kind) ? 'bg-red-500/10 text-red-100' : 'bg-white/5 text-white/90',
+              )}
+            >
+              <div className="flex items-start justify-between gap-2">
+                <span className="leading-snug">{summarizeAction(action, games)}</span>
+                {actions.length > 1 && (
+                  <button
+                    onClick={() => removeAction(ai)}
+                    disabled={isLoading}
+                    className="text-white/30 hover:text-white/70 shrink-0"
+                    aria-label="Remove this action"
+                  >
+                    <X size={14} />
+                  </button>
+                )}
+              </div>
+
+              {/* Per-game destination editing for the interested-games batch */}
+              {action.kind === 'addGames' && (
+                <div className="mt-2 space-y-1.5">
+                  {action.args.games.map((g, gi) => (
+                    <div key={gi} className="flex items-center gap-2 flex-wrap bg-black/20 rounded-md px-2 py-1.5">
+                      <div className="min-w-0 flex-1">
+                        <p className="text-xs font-medium text-white/90 truncate">{g.name}</p>
+                        <p className="text-[10px] text-white/40">
+                          {g.releaseDate ? `Releases ${g.releaseDate}` : 'Release date: TBA'}
+                          {g.metacritic ? ` · MC ${g.metacritic}` : ''}
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-0.5 bg-black/30 rounded-md p-0.5">
+                        {DEST_OPTIONS.map(opt => {
+                          const Icon = opt.icon;
+                          const active = g.destination === opt.value;
+                          return (
+                            <button
+                              key={opt.value}
+                              onClick={() => setGameDestination(ai, gi, opt.value)}
+                              disabled={isLoading}
+                              className={clsx(
+                                'flex items-center gap-1 px-1.5 py-1 rounded text-[10px] font-medium transition-colors',
+                                active ? 'bg-purple-600 text-white' : 'text-white/50 hover:text-white/80',
+                              )}
+                            >
+                              <Icon size={11} />
+                              {opt.label}
+                            </button>
+                          );
+                        })}
+                      </div>
+                      <button
+                        onClick={() => removeGame(ai, gi)}
+                        disabled={isLoading}
+                        className="text-white/30 hover:text-white/70 shrink-0"
+                        aria-label="Remove this game"
+                      >
+                        <X size={13} />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+
+        <div className="flex gap-2 mt-3">
+          <button
+            onClick={onConfirm}
+            disabled={isLoading || actions.length === 0}
+            className={clsx(
+              'flex-1 flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl text-sm font-semibold transition-all disabled:opacity-50',
+              hasDestructive
+                ? 'bg-red-600 hover:bg-red-500 text-white'
+                : 'bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-500 hover:to-pink-500 text-white',
+            )}
+          >
+            {isLoading ? <Loader2 size={16} className="animate-spin" /> : <Check size={16} />}
+            {hasDestructive ? 'Yes, do it' : 'Confirm'}
+          </button>
+          <button
+            onClick={onCancel}
+            disabled={isLoading}
+            className="px-4 py-2.5 rounded-xl text-sm font-medium bg-white/5 hover:bg-white/10 text-white/70 transition-colors disabled:opacity-50"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/apps/game-analytics/components/AIChatTab.tsx
+++ b/app/apps/game-analytics/components/AIChatTab.tsx
@@ -5,93 +5,51 @@ import { Send, Sparkles, MessageCircle, Loader2, ArrowLeft } from 'lucide-react'
 import { motion, AnimatePresence } from 'framer-motion';
 import { Game } from '../lib/types';
 import { WeekInReviewData } from '../lib/calculations';
-import { generateChatResponse } from '../lib/ai-service';
+import { AgentExecutors } from '../lib/ai-actions';
+import { useAIAgent } from '../hooks/useAIAgent';
+import { AIActionCard } from './AIActionCard';
 
 interface AIChatTabProps {
   weekData: WeekInReviewData | null;
   monthGames: Game[];
   allGames: Game[];
+  executors: AgentExecutors;
   onBack?: () => void;
 }
 
-interface ChatMessage {
-  id: string;
-  role: 'user' | 'assistant';
-  content: string;
-  timestamp: Date;
-}
+export function AIChatTab({ weekData, monthGames, allGames, executors, onBack }: AIChatTabProps) {
+  const {
+    messages,
+    isLoading,
+    pending,
+    sendMessage,
+    confirmPending,
+    cancelPending,
+    updatePendingActions,
+  } = useAIAgent({
+    context: { weekData, monthGames, allGames },
+    games: allGames,
+    executors,
+  });
 
-export function AIChatTab({ weekData, monthGames, allGames, onBack }: AIChatTabProps) {
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  // Auto-scroll to bottom when new messages arrive
+  // Auto-scroll to bottom when new messages or a confirmation card arrive
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages]);
-
-  // Add welcome message on mount
-  useEffect(() => {
-    if (messages.length === 0) {
-      setMessages([{
-        id: '1',
-        role: 'assistant',
-        content: "Hey! I'm your AI gaming companion. Ask me anything about your gaming stats, habits, or get insights about your library. I have access to your week and month data!",
-        timestamp: new Date(),
-      }]);
-    }
-  }, []);
+  }, [messages, pending, isLoading]);
 
   // Focus input
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
 
-  const handleSend = async () => {
+  const handleSend = () => {
     if (!input.trim() || isLoading) return;
-
-    const userMessage: ChatMessage = {
-      id: Date.now().toString(),
-      role: 'user',
-      content: input.trim(),
-      timestamp: new Date(),
-    };
-
-    setMessages(prev => [...prev, userMessage]);
+    sendMessage(input);
     setInput('');
-    setIsLoading(true);
-
-    try {
-      const response = await generateChatResponse(input.trim(), {
-        weekData,
-        monthGames,
-        allGames,
-        conversationHistory: messages,
-      });
-
-      const assistantMessage: ChatMessage = {
-        id: (Date.now() + 1).toString(),
-        role: 'assistant',
-        content: response,
-        timestamp: new Date(),
-      };
-
-      setMessages(prev => [...prev, assistantMessage]);
-    } catch (error) {
-      console.error('Chat error:', error);
-      const errorMessage: ChatMessage = {
-        id: (Date.now() + 1).toString(),
-        role: 'assistant',
-        content: "Oops! I had trouble processing that. Can you try rephrasing your question?",
-        timestamp: new Date(),
-      };
-      setMessages(prev => [...prev, errorMessage]);
-    } finally {
-      setIsLoading(false);
-    }
   };
 
   const handleKeyPress = (e: React.KeyboardEvent) => {
@@ -102,11 +60,11 @@ export function AIChatTab({ weekData, monthGames, allGames, onBack }: AIChatTabP
   };
 
   const suggestedQuestions = [
-    "What games should I focus on this week?",
-    "How is my gaming balance?",
+    "Log 2 hours on my most played game",
+    "I'm interested in Silksong and Hades 2 — find release dates and add them",
+    "Mark my current game as completed",
     "What's my most efficient game?",
-    "Am I getting good value from my library?",
-    "Which genres do I play the most?",
+    "Add Stardew Valley to my Up Next queue",
   ];
 
   return (
@@ -127,7 +85,7 @@ export function AIChatTab({ weekData, monthGames, allGames, onBack }: AIChatTabP
         </div>
         <div>
           <h2 className="text-xl font-bold text-white">AI Gaming Coach</h2>
-          <p className="text-sm text-white/50">Ask me anything about your gaming</p>
+          <p className="text-sm text-white/50">Ask questions or tell me to do things</p>
         </div>
       </div>
 
@@ -164,6 +122,20 @@ export function AIChatTab({ weekData, monthGames, allGames, onBack }: AIChatTabP
           ))}
         </AnimatePresence>
 
+        {/* Pending action confirmation card */}
+        {pending && (
+          <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.2 }}>
+            <AIActionCard
+              actions={pending.actions}
+              games={allGames}
+              isLoading={isLoading}
+              onConfirm={confirmPending}
+              onCancel={cancelPending}
+              onChange={updatePendingActions}
+            />
+          </motion.div>
+        )}
+
         {isLoading && (
           <motion.div
             initial={{ opacity: 0, y: 10 }}
@@ -172,7 +144,7 @@ export function AIChatTab({ weekData, monthGames, allGames, onBack }: AIChatTabP
           >
             <div className="bg-white/10 rounded-2xl px-4 py-3 flex items-center gap-2 border border-white/5">
               <Loader2 size={16} className="text-purple-400 animate-spin" />
-              <span className="text-sm text-white/70">AI Coach is thinking...</span>
+              <span className="text-sm text-white/70">Working on it...</span>
             </div>
           </motion.div>
         )}
@@ -181,9 +153,9 @@ export function AIChatTab({ weekData, monthGames, allGames, onBack }: AIChatTabP
       </div>
 
       {/* Suggested Questions */}
-      {messages.length <= 1 && !isLoading && (
+      {messages.length <= 1 && !isLoading && !pending && (
         <div className="px-4 pb-3">
-          <p className="text-xs text-white/40 mb-2">Try asking:</p>
+          <p className="text-xs text-white/40 mb-2">Try:</p>
           <div className="flex flex-wrap gap-2">
             {suggestedQuestions.map((question, index) => (
               <button
@@ -207,7 +179,7 @@ export function AIChatTab({ weekData, monthGames, allGames, onBack }: AIChatTabP
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyPress={handleKeyPress}
-            placeholder="Ask about your gaming stats, habits, or recommendations..."
+            placeholder="Ask about your gaming, or tell me to do something..."
             className="flex-1 px-5 py-4 bg-white/5 border border-white/10 rounded-2xl text-white text-base placeholder-white/40 focus:outline-none focus:border-purple-500/50 focus:bg-white/10 transition-colors"
             disabled={isLoading}
           />
@@ -220,7 +192,7 @@ export function AIChatTab({ weekData, monthGames, allGames, onBack }: AIChatTabP
           </button>
         </div>
         <p className="text-xs text-white/30 mt-3 text-center">
-          Press Enter to send • AI has access to your week & month gaming data
+          I confirm before changing anything • I can add, log, queue, update & more
         </p>
       </div>
     </div>

--- a/app/apps/game-analytics/hooks/useAIAgent.ts
+++ b/app/apps/game-analytics/hooks/useAIAgent.ts
@@ -1,0 +1,157 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+import { Game } from '../lib/types';
+import {
+  AgentChatContext,
+  AgentTurn,
+  AgentActionResult,
+  runAgentTurn,
+} from '../lib/ai-service';
+import {
+  PendingAction,
+  AgentExecutors,
+  executeAction,
+} from '../lib/ai-actions';
+
+export interface ChatMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp: Date;
+}
+
+export interface PendingProposal {
+  id: string;
+  actions: PendingAction[];
+  resume: (results: AgentActionResult[]) => Promise<AgentTurn>;
+}
+
+const WELCOME =
+  "Hey! I'm your AI gaming coach — and now I can take action too. Ask me about your stats, or tell me to do things like \"log 2 hours on Elden Ring\", \"mark Hades as completed\", or \"I'm interested in Silksong and Hades 2, find their release dates and add them\". I'll always confirm before changing anything.";
+
+function uid(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+/**
+ * Owns the agent conversation: message history, pending-action confirmations,
+ * and execution against the host's hooks. Both the AI tab and modal can use this.
+ */
+export function useAIAgent(params: {
+  context: AgentChatContext;
+  games: Game[];
+  executors: AgentExecutors;
+}) {
+  const [messages, setMessages] = useState<ChatMessage[]>([
+    { id: 'welcome', role: 'assistant', content: WELCOME, timestamp: new Date() },
+  ]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [pending, setPending] = useState<PendingProposal | null>(null);
+
+  // Keep latest props available to async closures without stale captures.
+  const ctxRef = useRef(params.context);
+  const gamesRef = useRef(params.games);
+  const execRef = useRef(params.executors);
+  ctxRef.current = params.context;
+  gamesRef.current = params.games;
+  execRef.current = params.executors;
+
+  const pushAssistant = useCallback((content: string) => {
+    if (!content.trim()) return;
+    setMessages(prev => [...prev, { id: uid(), role: 'assistant', content, timestamp: new Date() }]);
+  }, []);
+
+  // Apply an AgentTurn to the UI — either show text or stage a confirmation.
+  const applyTurn = useCallback((turn: AgentTurn) => {
+    if (turn.kind === 'text') {
+      pushAssistant(turn.text);
+      setPending(null);
+      return;
+    }
+    pushAssistant(turn.text);
+    setPending({ id: uid(), actions: turn.actions, resume: turn.resume });
+  }, [pushAssistant]);
+
+  const sendMessage = useCallback(async (text: string) => {
+    const trimmed = text.trim();
+    if (!trimmed || isLoading) return;
+
+    const history = messages
+      .filter(m => m.id !== 'welcome')
+      .map(m => ({ role: m.role, content: m.content }));
+
+    setMessages(prev => [...prev, { id: uid(), role: 'user', content: trimmed, timestamp: new Date() }]);
+    setPending(null);
+    setIsLoading(true);
+    try {
+      const turn = await runAgentTurn({
+        userMessage: trimmed,
+        context: ctxRef.current,
+        history,
+      });
+      applyTurn(turn);
+    } catch (e) {
+      console.error('Agent send error:', e);
+      pushAssistant("Oops — something went wrong. Want to try again?");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [messages, isLoading, applyTurn, pushAssistant]);
+
+  /** Replace the staged actions (e.g. after the user edits destinations / unchecks items). */
+  const updatePendingActions = useCallback((actions: PendingAction[]) => {
+    setPending(prev => (prev ? { ...prev, actions } : prev));
+  }, []);
+
+  const confirmPending = useCallback(async () => {
+    if (!pending || isLoading) return;
+    const proposal = pending;
+    setPending(null);
+    setIsLoading(true);
+
+    const results: AgentActionResult[] = [];
+    for (const action of proposal.actions) {
+      try {
+        const summary = await executeAction(action, execRef.current, gamesRef.current);
+        results.push({ summary, ok: true });
+      } catch (e) {
+        console.error('Action execution failed:', e);
+        results.push({ summary: `Failed: ${(e as Error).message}`, ok: false });
+      }
+    }
+
+    try {
+      const turn = await proposal.resume(results);
+      applyTurn(turn);
+    } catch (e) {
+      console.error('Agent resume error:', e);
+      // Even if the model follow-up fails, the actions already ran — report locally.
+      const ok = results.filter(r => r.ok).map(r => r.summary);
+      const failed = results.filter(r => !r.ok).map(r => r.summary);
+      pushAssistant(
+        [ok.length ? `Done: ${ok.join(' ')}` : '', failed.length ? `Issues: ${failed.join(' ')}` : '']
+          .filter(Boolean)
+          .join('\n') || 'Done.',
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [pending, isLoading, applyTurn, pushAssistant]);
+
+  const cancelPending = useCallback(() => {
+    if (!pending) return;
+    setPending(null);
+    pushAssistant("No problem — I won't make any changes. Anything else?");
+  }, [pending, pushAssistant]);
+
+  return {
+    messages,
+    isLoading,
+    pending,
+    sendMessage,
+    confirmPending,
+    cancelPending,
+    updatePendingActions,
+  };
+}

--- a/app/apps/game-analytics/lib/ai-actions.ts
+++ b/app/apps/game-analytics/lib/ai-actions.ts
@@ -442,7 +442,87 @@ export function summarizeAction(action: PendingAction, games: Game[]): string {
   }
 }
 
+// ── Validation & dedup (surfaced as warnings in the confirmation card) ───────
+
+/** Loose name match for duplicate detection: case/space/punctuation-insensitive. */
+function normalizeName(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+function findByName(games: Game[], name: string): Game | undefined {
+  const target = normalizeName(name);
+  return games.find(g => normalizeName(g.name) === target);
+}
+
+const ID_ACTIONS: ActionKind[] = [
+  'updateGame', 'setGameStatus', 'logPlaySession', 'addToQueue',
+  'removeFromQueue', 'deleteGame', 'setReview', 'markSpecial',
+];
+
+/**
+ * Non-blocking checks shown to the user before they confirm: duplicate adds,
+ * out-of-range values, missing game references. Returning warnings (not errors)
+ * keeps the user in control — they can drop a flagged item or proceed anyway.
+ */
+export function validateAction(action: PendingAction, games: Game[]): string[] {
+  const warnings: string[] = [];
+
+  if (ID_ACTIONS.includes(action.kind)) {
+    const id = (action.args as { gameId?: string }).gameId;
+    if (id && !games.some(g => g.id === id)) {
+      warnings.push("Couldn't find that game in your library — it may have been deleted.");
+    }
+  }
+
+  switch (action.kind) {
+    case 'addGame': {
+      const dup = findByName(games, action.args.name);
+      if (dup) warnings.push(`"${dup.name}" is already in your library (${dup.status}). This would create a duplicate.`);
+      if (action.args.rating !== undefined && (action.args.rating < 0 || action.args.rating > 10)) {
+        warnings.push(`Rating ${action.args.rating} is out of range — it'll be clamped to 1–10.`);
+      }
+      if (action.args.price !== undefined && action.args.price < 0) warnings.push('Negative price will be treated as $0.');
+      if (action.args.hours !== undefined && action.args.hours < 0) warnings.push('Negative hours will be treated as 0.');
+      break;
+    }
+    case 'addGames': {
+      for (const g of action.args.games) {
+        const dup = findByName(games, g.name);
+        if (dup) warnings.push(`"${g.name}" is already in your library (${dup.status}).`);
+      }
+      break;
+    }
+    case 'updateGame': {
+      const r = action.args.updates.rating;
+      if (r !== undefined && (r < 0 || r > 10)) warnings.push(`Rating ${r} is out of range — it'll be clamped to 1–10.`);
+      const p = action.args.updates.price;
+      if (p !== undefined && p < 0) warnings.push('Negative price will be treated as $0.');
+      break;
+    }
+    case 'logPlaySession':
+      if (action.args.hours <= 0) warnings.push('Session hours should be greater than 0.');
+      break;
+    case 'setBudget':
+      if (action.args.amount < 0) warnings.push('Budget cannot be negative.');
+      break;
+    default:
+      break;
+  }
+
+  return warnings;
+}
+
 // ── Execute a confirmed action ───────────────────────────────────────────────
+
+/** Clamp a rating into the app's 1–10 scale (0/undefined left as-is for "unrated"). */
+function clampRating(r: number | undefined): number | undefined {
+  if (r === undefined) return undefined;
+  if (r === 0) return 0; // 0 = explicitly unrated
+  return Math.min(10, Math.max(1, r));
+}
+
+const nonNeg = (n: number | undefined): number | undefined =>
+  n === undefined ? undefined : Math.max(0, n);
 
 function todayISO(): string {
   const d = new Date();
@@ -463,14 +543,22 @@ export async function executeAction(
   executors: AgentExecutors,
   games: Game[],
 ): Promise<string> {
+  // Hard guard: actions on an existing game must reference a real id.
+  if (ID_ACTIONS.includes(action.kind)) {
+    const id = (action.args as { gameId?: string }).gameId;
+    if (!id || !games.some(g => g.id === id)) {
+      throw new Error("That game isn't in your library anymore.");
+    }
+  }
+
   switch (action.kind) {
     case 'addGame': {
       const a = action.args;
       await executors.addGame({
         name: a.name,
-        price: a.price ?? 0,
-        hours: a.hours ?? 0,
-        rating: a.rating ?? 0,
+        price: nonNeg(a.price) ?? 0,
+        hours: nonNeg(a.hours) ?? 0,
+        rating: clampRating(a.rating) ?? 0,
         status: a.status ?? 'Not Started',
         platform: a.platform,
         genre: a.genre,
@@ -518,9 +606,14 @@ export async function executeAction(
       }
       return `Added: ${results.join('; ')}.`;
     }
-    case 'updateGame':
-      await executors.updateGame(action.args.gameId, action.args.updates);
+    case 'updateGame': {
+      const updates = { ...action.args.updates };
+      if (updates.rating !== undefined) updates.rating = clampRating(updates.rating);
+      if (updates.price !== undefined) updates.price = nonNeg(updates.price);
+      if (updates.hours !== undefined) updates.hours = nonNeg(updates.hours);
+      await executors.updateGame(action.args.gameId, updates);
       return `Updated "${nameOf(games, action.args.gameId)}".`;
+    }
     case 'setGameStatus': {
       const { gameId, status } = action.args;
       const game = games.find(g => g.id === gameId);
@@ -534,7 +627,8 @@ export async function executeAction(
       const { gameId, hours, date, notes, mood, vibe } = action.args;
       const game = games.find(g => g.id === gameId);
       const logDate = date ?? todayISO();
-      const newLog: PlayLog = { id: genId(), date: logDate, hours, notes, mood, vibe };
+      const safeHours = Math.max(0, hours);
+      const newLog: PlayLog = { id: genId(), date: logDate, hours: safeHours, notes, mood, vibe };
       const existing = game?.playLogs ?? [];
       const updates: Partial<Game> = { playLogs: [...existing, newLog] };
       // Auto-start a backlog game on its first session, mirroring the manual flow.

--- a/app/apps/game-analytics/lib/ai-actions.ts
+++ b/app/apps/game-analytics/lib/ai-actions.ts
@@ -1,0 +1,572 @@
+'use client';
+
+/**
+ * AI Action Registry
+ * ------------------
+ * Single source of truth for the actions the AI Gaming Coach can perform.
+ *
+ * Each write action has three faces:
+ *   1. A Gemini `FunctionDeclaration` (so the model can propose it)
+ *   2. A human-readable summary (rendered in the in-chat confirmation card)
+ *   3. An executor binding to the existing app hooks (run only after the user confirms)
+ *
+ * Design rule: the model PROPOSES, the app DISPOSES. Gemini never touches storage
+ * directly — it emits a structured intent that the host executes post-confirmation.
+ *
+ * Read tools (findGames, lookupGames) are handled inside ai-service.ts and run
+ * without confirmation since they never mutate anything.
+ */
+
+import { Schema, FunctionDeclaration } from 'firebase/ai';
+import {
+  Game,
+  GameStatus,
+  PlayLog,
+  PurchaseQueueEntry,
+  SessionMood,
+  SessionVibe,
+  PurchaseSource,
+} from './types';
+
+// ── Constants shared with the schema ─────────────────────────────────────────
+
+export const GAME_STATUSES: GameStatus[] = [
+  'Not Started', 'In Progress', 'Completed', 'Wishlist', 'Abandoned',
+];
+const SESSION_MOODS: SessionMood[] = ['great', 'good', 'meh', 'grind'];
+const SESSION_VIBES: SessionVibe[] = [
+  'wind-down', 'competitive', 'exploration', 'story', 'achievement-hunting', 'social',
+];
+const PURCHASE_SOURCES: PurchaseSource[] = [
+  'Steam', 'PlayStation', 'Xbox', 'Nintendo', 'Epic', 'GOG', 'Physical', 'Other',
+];
+export type InterestedDestination = 'queue' | 'wishlist' | 'both';
+const DESTINATIONS: InterestedDestination[] = ['queue', 'wishlist', 'both'];
+
+// ── Pending action shapes ────────────────────────────────────────────────────
+
+export interface InterestedGameItem {
+  name: string;
+  destination: InterestedDestination;
+  releaseDate?: string;
+  genre?: string;
+  platform?: string;
+  thumbnail?: string;
+  metacritic?: number;
+  rawgRating?: number;
+}
+
+export interface AddGameArgs {
+  name: string;
+  price?: number;
+  hours?: number;
+  rating?: number;
+  status?: GameStatus;
+  platform?: string;
+  genre?: string;
+  franchise?: string;
+  purchaseSource?: PurchaseSource;
+  notes?: string;
+  datePurchased?: string;
+}
+
+/** A write action the model has proposed, awaiting user confirmation. */
+export type PendingAction =
+  | { kind: 'addGame'; args: AddGameArgs }
+  | { kind: 'addGames'; args: { games: InterestedGameItem[] } }
+  | { kind: 'updateGame'; args: { gameId: string; updates: Partial<Game> } }
+  | { kind: 'setGameStatus'; args: { gameId: string; status: GameStatus } }
+  | { kind: 'logPlaySession'; args: { gameId: string; hours: number; date?: string; notes?: string; mood?: SessionMood; vibe?: SessionVibe } }
+  | { kind: 'addToQueue'; args: { gameId: string } }
+  | { kind: 'removeFromQueue'; args: { gameId: string } }
+  | { kind: 'clearUpcoming'; args: Record<string, never> }
+  | { kind: 'setBudget'; args: { year: number; amount: number } }
+  | { kind: 'deleteGame'; args: { gameId: string } }
+  | { kind: 'setReview'; args: { gameId: string; review: string } }
+  | { kind: 'markSpecial'; args: { gameId: string; special: boolean } };
+
+export type ActionKind = PendingAction['kind'];
+
+/** Actions that destroy data get an extra-explicit confirmation in the UI. */
+export const DESTRUCTIVE_ACTIONS: ActionKind[] = ['deleteGame', 'clearUpcoming'];
+
+export function isDestructive(kind: ActionKind): boolean {
+  return DESTRUCTIVE_ACTIONS.includes(kind);
+}
+
+// ── Host-provided executors ──────────────────────────────────────────────────
+
+export interface AgentExecutors {
+  addGame: (data: Omit<Game, 'id' | 'userId' | 'createdAt' | 'updatedAt'>) => Promise<Game>;
+  updateGame: (id: string, updates: Partial<Game>) => Promise<Game>;
+  deleteGame: (id: string) => Promise<void>;
+  addToQueue: (gameId: string) => Promise<void>;
+  removeFromQueue: (gameId: string) => Promise<void>;
+  clearUpcoming: () => Promise<void>;
+  setBudget: (year: number, amount: number) => Promise<void>;
+  addPurchaseEntry: (
+    data: Omit<PurchaseQueueEntry, 'id' | 'userId' | 'createdAt' | 'updatedAt'>
+  ) => Promise<PurchaseQueueEntry>;
+}
+
+// ── Function declarations (what Gemini sees) ─────────────────────────────────
+
+const gameItemSchema = Schema.object({
+  properties: {
+    name: Schema.string({ description: 'Exact game name' }),
+    destination: Schema.enumString({
+      enum: DESTINATIONS,
+      description: 'queue = Purchase/Buy queue (best for unreleased), wishlist = library wishlist, both = add to both',
+    }),
+    releaseDate: Schema.string({ description: 'ISO date (YYYY-MM-DD) from the lookupGames result, omit if TBA/unknown' }),
+    genre: Schema.string(),
+    platform: Schema.string(),
+    thumbnail: Schema.string({ description: 'Thumbnail URL from lookupGames' }),
+    metacritic: Schema.number(),
+    rawgRating: Schema.number(),
+  },
+  optionalProperties: ['releaseDate', 'genre', 'platform', 'thumbnail', 'metacritic', 'rawgRating'],
+});
+
+/**
+ * The write tools. Names MUST match PendingAction['kind'] exactly — the dispatcher
+ * relies on this 1:1 mapping.
+ */
+export const WRITE_FUNCTION_DECLARATIONS: FunctionDeclaration[] = [
+  {
+    name: 'addGame',
+    description: 'Add a single owned game to the library. Use for games the user owns or has played, not for "interested in" games (use addGames for those).',
+    parameters: Schema.object({
+      properties: {
+        name: Schema.string(),
+        price: Schema.number({ description: 'Price paid in dollars' }),
+        hours: Schema.number({ description: 'Total hours played' }),
+        rating: Schema.number({ description: 'Rating 1-10' }),
+        status: Schema.enumString({ enum: GAME_STATUSES }),
+        platform: Schema.string(),
+        genre: Schema.string(),
+        franchise: Schema.string(),
+        purchaseSource: Schema.enumString({ enum: PURCHASE_SOURCES }),
+        notes: Schema.string(),
+        datePurchased: Schema.string({ description: 'ISO date YYYY-MM-DD' }),
+      },
+      optionalProperties: ['price', 'hours', 'rating', 'status', 'platform', 'genre', 'franchise', 'purchaseSource', 'notes', 'datePurchased'],
+    }),
+  },
+  {
+    name: 'addGames',
+    description: 'Batch-add games the user is INTERESTED in (not yet owned). Always call lookupGames first to get real release dates and thumbnails, then pass them here. Default unreleased/TBA games to "queue" and already-released games to "wishlist" unless the user says otherwise.',
+    parameters: Schema.object({
+      properties: {
+        games: Schema.array({ items: gameItemSchema, description: 'Games to add with their resolved metadata' }),
+      },
+    }),
+  },
+  {
+    name: 'updateGame',
+    description: 'Update fields on an existing game. Resolve gameId with findGames first. Only include fields that change.',
+    parameters: Schema.object({
+      properties: {
+        gameId: Schema.string({ description: 'The id from findGames' }),
+        name: Schema.string(),
+        price: Schema.number(),
+        hours: Schema.number(),
+        rating: Schema.number({ description: '1-10' }),
+        status: Schema.enumString({ enum: GAME_STATUSES }),
+        platform: Schema.string(),
+        genre: Schema.string(),
+        franchise: Schema.string(),
+        notes: Schema.string(),
+      },
+      optionalProperties: ['name', 'price', 'hours', 'rating', 'status', 'platform', 'genre', 'franchise', 'notes'],
+    }),
+  },
+  {
+    name: 'setGameStatus',
+    description: 'Change a game\'s status (e.g. mark Completed, In Progress, Abandoned). Resolve gameId with findGames first. Auto-stamps start/end dates as appropriate.',
+    parameters: Schema.object({
+      properties: {
+        gameId: Schema.string(),
+        status: Schema.enumString({ enum: GAME_STATUSES }),
+      },
+    }),
+  },
+  {
+    name: 'logPlaySession',
+    description: 'Log a play session for a game. Resolve gameId with findGames first. Date defaults to today.',
+    parameters: Schema.object({
+      properties: {
+        gameId: Schema.string(),
+        hours: Schema.number({ description: 'Hours played in this session' }),
+        date: Schema.string({ description: 'ISO date YYYY-MM-DD, defaults to today' }),
+        notes: Schema.string(),
+        mood: Schema.enumString({ enum: SESSION_MOODS }),
+        vibe: Schema.enumString({ enum: SESSION_VIBES }),
+      },
+      optionalProperties: ['date', 'notes', 'mood', 'vibe'],
+    }),
+  },
+  {
+    name: 'addToQueue',
+    description: 'Add an owned game to the "Up Next" play queue. Resolve gameId with findGames first.',
+    parameters: Schema.object({ properties: { gameId: Schema.string() } }),
+  },
+  {
+    name: 'removeFromQueue',
+    description: 'Remove a game from the "Up Next" play queue. Resolve gameId with findGames first.',
+    parameters: Schema.object({ properties: { gameId: Schema.string() } }),
+  },
+  {
+    name: 'clearUpcoming',
+    description: 'Clear all on-deck games from the Up Next queue, keeping only games currently In Progress.',
+    parameters: Schema.object({ properties: {} }),
+  },
+  {
+    name: 'setBudget',
+    description: 'Set the yearly gaming budget for a given year.',
+    parameters: Schema.object({
+      properties: {
+        year: Schema.number(),
+        amount: Schema.number({ description: 'Budget in dollars' }),
+      },
+    }),
+  },
+  {
+    name: 'deleteGame',
+    description: 'Permanently delete a game from the library. Destructive — only when the user clearly asks. Resolve gameId with findGames first.',
+    parameters: Schema.object({ properties: { gameId: Schema.string() } }),
+  },
+  {
+    name: 'setReview',
+    description: 'Set the user\'s written review/notes text on a game. Resolve gameId with findGames first.',
+    parameters: Schema.object({
+      properties: {
+        gameId: Schema.string(),
+        review: Schema.string(),
+      },
+    }),
+  },
+  {
+    name: 'markSpecial',
+    description: 'Flag or unflag a game as "special" (a personal favorite). Resolve gameId with findGames first.',
+    parameters: Schema.object({
+      properties: {
+        gameId: Schema.string(),
+        special: Schema.boolean(),
+      },
+    }),
+  },
+];
+
+// ── Parse a raw Gemini function call into a typed PendingAction ───────────────
+
+/**
+ * Convert a raw {name, args} function call from Gemini into a typed PendingAction.
+ * Returns null for unknown/read tool names. Coerces numeric strings defensively
+ * since models occasionally emit numbers as strings.
+ */
+export function parseFunctionCall(name: string, rawArgs: Record<string, unknown>): PendingAction | null {
+  const num = (v: unknown): number | undefined => {
+    if (v === undefined || v === null || v === '') return undefined;
+    const n = typeof v === 'number' ? v : parseFloat(String(v));
+    return Number.isFinite(n) ? n : undefined;
+  };
+  const str = (v: unknown): string | undefined =>
+    v === undefined || v === null ? undefined : String(v);
+
+  switch (name) {
+    case 'addGame': {
+      const args: AddGameArgs = {
+        name: str(rawArgs.name) ?? '',
+        price: num(rawArgs.price),
+        hours: num(rawArgs.hours),
+        rating: num(rawArgs.rating),
+        status: rawArgs.status as GameStatus | undefined,
+        platform: str(rawArgs.platform),
+        genre: str(rawArgs.genre),
+        franchise: str(rawArgs.franchise),
+        purchaseSource: rawArgs.purchaseSource as PurchaseSource | undefined,
+        notes: str(rawArgs.notes),
+        datePurchased: str(rawArgs.datePurchased),
+      };
+      if (!args.name) return null;
+      return { kind: 'addGame', args };
+    }
+    case 'addGames': {
+      const rawGames = Array.isArray(rawArgs.games) ? rawArgs.games : [];
+      const games: InterestedGameItem[] = rawGames
+        .map((g): InterestedGameItem | null => {
+          const item = g as Record<string, unknown>;
+          const gName = str(item.name);
+          if (!gName) return null;
+          const dest = (DESTINATIONS as string[]).includes(String(item.destination))
+            ? (item.destination as InterestedDestination)
+            : 'queue';
+          return {
+            name: gName,
+            destination: dest,
+            releaseDate: str(item.releaseDate),
+            genre: str(item.genre),
+            platform: str(item.platform),
+            thumbnail: str(item.thumbnail),
+            metacritic: num(item.metacritic),
+            rawgRating: num(item.rawgRating),
+          };
+        })
+        .filter((g): g is InterestedGameItem => g !== null);
+      if (games.length === 0) return null;
+      return { kind: 'addGames', args: { games } };
+    }
+    case 'updateGame': {
+      const gameId = str(rawArgs.gameId);
+      if (!gameId) return null;
+      const updates: Partial<Game> = {};
+      if (rawArgs.name !== undefined) updates.name = str(rawArgs.name);
+      if (rawArgs.price !== undefined) updates.price = num(rawArgs.price);
+      if (rawArgs.hours !== undefined) updates.hours = num(rawArgs.hours);
+      if (rawArgs.rating !== undefined) updates.rating = num(rawArgs.rating);
+      if (rawArgs.status !== undefined) updates.status = rawArgs.status as GameStatus;
+      if (rawArgs.platform !== undefined) updates.platform = str(rawArgs.platform);
+      if (rawArgs.genre !== undefined) updates.genre = str(rawArgs.genre);
+      if (rawArgs.franchise !== undefined) updates.franchise = str(rawArgs.franchise);
+      if (rawArgs.notes !== undefined) updates.notes = str(rawArgs.notes);
+      if (Object.keys(updates).length === 0) return null;
+      return { kind: 'updateGame', args: { gameId, updates } };
+    }
+    case 'setGameStatus': {
+      const gameId = str(rawArgs.gameId);
+      const status = rawArgs.status as GameStatus | undefined;
+      if (!gameId || !status) return null;
+      return { kind: 'setGameStatus', args: { gameId, status } };
+    }
+    case 'logPlaySession': {
+      const gameId = str(rawArgs.gameId);
+      const hours = num(rawArgs.hours);
+      if (!gameId || hours === undefined) return null;
+      return {
+        kind: 'logPlaySession',
+        args: {
+          gameId,
+          hours,
+          date: str(rawArgs.date),
+          notes: str(rawArgs.notes),
+          mood: rawArgs.mood as SessionMood | undefined,
+          vibe: rawArgs.vibe as SessionVibe | undefined,
+        },
+      };
+    }
+    case 'addToQueue': {
+      const gameId = str(rawArgs.gameId);
+      if (!gameId) return null;
+      return { kind: 'addToQueue', args: { gameId } };
+    }
+    case 'removeFromQueue': {
+      const gameId = str(rawArgs.gameId);
+      if (!gameId) return null;
+      return { kind: 'removeFromQueue', args: { gameId } };
+    }
+    case 'clearUpcoming':
+      return { kind: 'clearUpcoming', args: {} };
+    case 'setBudget': {
+      const year = num(rawArgs.year);
+      const amount = num(rawArgs.amount);
+      if (year === undefined || amount === undefined) return null;
+      return { kind: 'setBudget', args: { year, amount } };
+    }
+    case 'deleteGame': {
+      const gameId = str(rawArgs.gameId);
+      if (!gameId) return null;
+      return { kind: 'deleteGame', args: { gameId } };
+    }
+    case 'setReview': {
+      const gameId = str(rawArgs.gameId);
+      const review = str(rawArgs.review);
+      if (!gameId || review === undefined) return null;
+      return { kind: 'setReview', args: { gameId, review } };
+    }
+    case 'markSpecial': {
+      const gameId = str(rawArgs.gameId);
+      if (!gameId) return null;
+      return { kind: 'markSpecial', args: { gameId, special: rawArgs.special !== false } };
+    }
+    default:
+      return null;
+  }
+}
+
+// ── Human-readable summary for the confirmation card ─────────────────────────
+
+const nameOf = (games: Game[], id: string): string =>
+  games.find(g => g.id === id)?.name ?? 'this game';
+
+export function summarizeAction(action: PendingAction, games: Game[]): string {
+  switch (action.kind) {
+    case 'addGame': {
+      const a = action.args;
+      const bits = [
+        a.price !== undefined ? `$${a.price}` : null,
+        a.rating !== undefined ? `${a.rating}/10` : null,
+        a.status,
+        a.hours !== undefined ? `${a.hours}h` : null,
+      ].filter(Boolean);
+      return `Add "${a.name}"${bits.length ? ` (${bits.join(', ')})` : ''} to your library`;
+    }
+    case 'addGames':
+      return `Add ${action.args.games.length} game${action.args.games.length === 1 ? '' : 's'} you're interested in`;
+    case 'updateGame': {
+      const fields = Object.entries(action.args.updates)
+        .map(([k, v]) => `${k} → ${v}`)
+        .join(', ');
+      return `Update "${nameOf(games, action.args.gameId)}": ${fields}`;
+    }
+    case 'setGameStatus':
+      return `Mark "${nameOf(games, action.args.gameId)}" as ${action.args.status}`;
+    case 'logPlaySession': {
+      const a = action.args;
+      return `Log ${a.hours}h on "${nameOf(games, a.gameId)}"${a.date ? ` (${a.date})` : ' (today)'}`;
+    }
+    case 'addToQueue':
+      return `Add "${nameOf(games, action.args.gameId)}" to Up Next`;
+    case 'removeFromQueue':
+      return `Remove "${nameOf(games, action.args.gameId)}" from Up Next`;
+    case 'clearUpcoming':
+      return 'Clear all on-deck games from Up Next (keeps games In Progress)';
+    case 'setBudget':
+      return `Set ${action.args.year} budget to $${action.args.amount}`;
+    case 'deleteGame':
+      return `Permanently delete "${nameOf(games, action.args.gameId)}"`;
+    case 'setReview':
+      return `Save a review on "${nameOf(games, action.args.gameId)}"`;
+    case 'markSpecial':
+      return `${action.args.special ? 'Mark' : 'Unmark'} "${nameOf(games, action.args.gameId)}" as special`;
+  }
+}
+
+// ── Execute a confirmed action ───────────────────────────────────────────────
+
+function todayISO(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+function genId(): string {
+  return `${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+}
+
+/**
+ * Run a confirmed action against the host executors. Returns a short result
+ * string that is fed back to the model so its closing message is accurate.
+ * Throws on failure (the caller surfaces the error in chat).
+ */
+export async function executeAction(
+  action: PendingAction,
+  executors: AgentExecutors,
+  games: Game[],
+): Promise<string> {
+  switch (action.kind) {
+    case 'addGame': {
+      const a = action.args;
+      await executors.addGame({
+        name: a.name,
+        price: a.price ?? 0,
+        hours: a.hours ?? 0,
+        rating: a.rating ?? 0,
+        status: a.status ?? 'Not Started',
+        platform: a.platform,
+        genre: a.genre,
+        franchise: a.franchise,
+        purchaseSource: a.purchaseSource,
+        notes: a.notes,
+        datePurchased: a.datePurchased,
+      });
+      return `Added "${a.name}" to the library.`;
+    }
+    case 'addGames': {
+      const results: string[] = [];
+      for (const item of action.args.games) {
+        const toQueue = item.destination === 'queue' || item.destination === 'both';
+        const toWishlist = item.destination === 'wishlist' || item.destination === 'both';
+        if (toQueue) {
+          await executors.addPurchaseEntry({
+            gameName: item.name,
+            thumbnail: item.thumbnail,
+            platform: item.platform,
+            genre: item.genre,
+            releaseDate: item.releaseDate,
+            metacriticScore: item.metacritic,
+            rawgRating: item.rawgRating,
+            isDayOneBuy: false,
+            priority: 999,
+            purchased: false,
+            intent: 'committed',
+            addedAt: new Date().toISOString(),
+          });
+        }
+        if (toWishlist) {
+          await executors.addGame({
+            name: item.name,
+            price: 0,
+            hours: 0,
+            rating: 0,
+            status: 'Wishlist',
+            genre: item.genre,
+            platform: item.platform,
+            thumbnail: item.thumbnail,
+          });
+        }
+        results.push(`${item.name} → ${item.destination}`);
+      }
+      return `Added: ${results.join('; ')}.`;
+    }
+    case 'updateGame':
+      await executors.updateGame(action.args.gameId, action.args.updates);
+      return `Updated "${nameOf(games, action.args.gameId)}".`;
+    case 'setGameStatus': {
+      const { gameId, status } = action.args;
+      const game = games.find(g => g.id === gameId);
+      const updates: Partial<Game> = { status };
+      if (status === 'In Progress' && !game?.startDate) updates.startDate = todayISO();
+      if ((status === 'Completed' || status === 'Abandoned') && !game?.endDate) updates.endDate = todayISO();
+      await executors.updateGame(gameId, updates);
+      return `"${nameOf(games, gameId)}" is now ${status}.`;
+    }
+    case 'logPlaySession': {
+      const { gameId, hours, date, notes, mood, vibe } = action.args;
+      const game = games.find(g => g.id === gameId);
+      const logDate = date ?? todayISO();
+      const newLog: PlayLog = { id: genId(), date: logDate, hours, notes, mood, vibe };
+      const existing = game?.playLogs ?? [];
+      const updates: Partial<Game> = { playLogs: [...existing, newLog] };
+      // Auto-start a backlog game on its first session, mirroring the manual flow.
+      if (game?.status === 'Not Started' && existing.length === 0) {
+        updates.status = 'In Progress';
+        updates.startDate = logDate;
+      }
+      await executors.updateGame(gameId, updates);
+      return `Logged ${hours}h on "${nameOf(games, gameId)}".`;
+    }
+    case 'addToQueue':
+      await executors.addToQueue(action.args.gameId);
+      return `Added "${nameOf(games, action.args.gameId)}" to Up Next.`;
+    case 'removeFromQueue':
+      await executors.removeFromQueue(action.args.gameId);
+      return `Removed "${nameOf(games, action.args.gameId)}" from Up Next.`;
+    case 'clearUpcoming':
+      await executors.clearUpcoming();
+      return 'Cleared the on-deck queue.';
+    case 'setBudget':
+      await executors.setBudget(action.args.year, action.args.amount);
+      return `Set the ${action.args.year} budget to $${action.args.amount}.`;
+    case 'deleteGame': {
+      const label = nameOf(games, action.args.gameId);
+      await executors.deleteGame(action.args.gameId);
+      return `Deleted "${label}".`;
+    }
+    case 'setReview':
+      await executors.updateGame(action.args.gameId, { review: action.args.review });
+      return `Saved your review on "${nameOf(games, action.args.gameId)}".`;
+    case 'markSpecial':
+      await executors.updateGame(action.args.gameId, { isSpecial: action.args.special });
+      return `${action.args.special ? 'Marked' : 'Unmarked'} "${nameOf(games, action.args.gameId)}" as special.`;
+  }
+}

--- a/app/apps/game-analytics/lib/ai-service.ts
+++ b/app/apps/game-analytics/lib/ai-service.ts
@@ -1,9 +1,11 @@
 'use client';
 
-import { getAI, getGenerativeModel, GoogleAIBackend } from 'firebase/ai';
+import { getAI, getGenerativeModel, GoogleAIBackend, Schema, FunctionDeclaration, Content } from 'firebase/ai';
 import { initializeApp, getApps } from 'firebase/app';
-import { WeekInReviewData, MonthInReviewData, OscarAward, buildTasteProfile } from './calculations';
+import { WeekInReviewData, MonthInReviewData, OscarAward, buildTasteProfile, getTotalHours } from './calculations';
 import { Game, TasteProfile } from './types';
+import { WRITE_FUNCTION_DECLARATIONS, parseFunctionCall, PendingAction } from './ai-actions';
+import { searchRAWGGame } from './rawg-api';
 
 const firebaseConfig = {
   apiKey: "AIzaSyBS3IVvszDrm_zjjXu8TATgs1H-FlegHtM",
@@ -819,6 +821,251 @@ Return ONLY the review prose — no headings, no quotes, no JSON.`;
       .map(t => t.text)
       .join(' ');
     return { review: fallback, error: String(e) };
+  }
+}
+
+// ── AGENT MODE ─────────────────────────────────────────────────────
+// Turns the chat into an agent that can perform app actions via Gemini
+// function calling. The model PROPOSES write actions; the host executes
+// them only after the user confirms (one confirmation per proposal turn).
+// Read tools (findGames, lookupGames) run here directly — they never mutate.
+
+export interface AgentChatContext {
+  weekData: WeekInReviewData | null;
+  monthGames: Game[];
+  allGames: Game[];
+}
+
+export interface AgentActionResult {
+  summary: string;
+  ok: boolean;
+}
+
+/** Result of one agent turn: either plain text, or a set of actions awaiting confirmation. */
+export type AgentTurn =
+  | { kind: 'text'; text: string }
+  | {
+      kind: 'actions';
+      text: string; // any prose the model said alongside the proposal (may be empty)
+      actions: PendingAction[];
+      /** Call after the user confirms + the host runs the actions. Resumes the model. */
+      resume: (results: AgentActionResult[]) => Promise<AgentTurn>;
+    };
+
+const READ_FUNCTION_DECLARATIONS: FunctionDeclaration[] = [
+  {
+    name: 'findGames',
+    description: 'Search the user\'s library to resolve a game name to its id (needed before any update/log/status/queue/delete action). Returns matching games with ids. Call this whenever the user refers to a game by name.',
+    parameters: Schema.object({
+      properties: {
+        query: Schema.string({ description: 'Partial or full game name to match. Omit to list everything.' }),
+        status: Schema.enumString({
+          enum: ['Not Started', 'In Progress', 'Completed', 'Wishlist', 'Abandoned'],
+          description: 'Optional status filter',
+        }),
+      },
+      optionalProperties: ['query', 'status'],
+    }),
+  },
+  {
+    name: 'lookupGames',
+    description: 'Look up real metadata (release date, metacritic, rating, thumbnail) for games by name from the games database. ALWAYS call this before addGames so release dates are real, not guessed.',
+    parameters: Schema.object({
+      properties: {
+        names: Schema.array({ items: Schema.string(), description: 'Game names to look up' }),
+      },
+    }),
+  },
+];
+
+const READ_NAMES = new Set(['findGames', 'lookupGames']);
+
+/** Minimal shape of the SDK response we rely on (text + functionCalls accessors). */
+interface AgentResponse {
+  text: () => string;
+  functionCalls: () => Array<{ name: string; args: Record<string, unknown> }> | undefined;
+}
+
+function getAgentModel(systemInstruction: string) {
+  const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+  const ai = getAI(app, { backend: new GoogleAIBackend() });
+  return getGenerativeModel(ai, {
+    model: 'gemini-2.5-flash',
+    tools: [{ functionDeclarations: [...READ_FUNCTION_DECLARATIONS, ...WRITE_FUNCTION_DECLARATIONS] }],
+    systemInstruction,
+  });
+}
+
+function buildAgentSystemInstruction(context: AgentChatContext): string {
+  return `You are an AI gaming coach AND assistant for a game-tracking app. You can BOTH answer questions about the player's gaming data and PERFORM actions on their behalf using the provided tools.
+
+${buildChatContext(context)}
+
+ACTION RULES:
+- To act on an existing game (update, log a session, change status, queue, delete, review, mark special), FIRST call findGames to resolve the game's id, then call the write tool with that id.
+- For games the user is "interested in" but doesn't own yet, FIRST call lookupGames to fetch real release dates and thumbnails, THEN call addGames. Default unreleased/TBA games to the "queue" destination and already-released games to "wishlist", unless the user specifies otherwise. If they say "both", use "both".
+- For a game the user already owns/played, use addGame (not addGames).
+- You may propose multiple write actions in one turn when the user asks for several things — they will be confirmed together.
+- The app shows the user a confirmation card for every write action and runs it only if they approve. Do NOT ask "should I?" in prose — just call the tool; the confirmation UI handles approval. After an action runs you receive its result; then give a brief, friendly confirmation.
+- Never invent release dates, ratings, or metadata — only use values returned by lookupGames or findGames.
+- Keep prose concise and specific to the player's data.`;
+}
+
+async function executeReadTool(
+  name: string,
+  args: Record<string, unknown>,
+  context: AgentChatContext,
+): Promise<object> {
+  if (name === 'findGames') {
+    const query = args.query ? String(args.query).toLowerCase() : '';
+    const status = args.status ? String(args.status) : '';
+    const matches = context.allGames
+      .filter(g => (!query || g.name.toLowerCase().includes(query)) && (!status || g.status === status))
+      .slice(0, 20)
+      .map(g => ({
+        id: g.id,
+        name: g.name,
+        status: g.status,
+        hours: Math.round(getTotalHours(g) * 10) / 10,
+        rating: g.rating,
+        genre: g.genre ?? null,
+        platform: g.platform ?? null,
+        inQueue: g.queuePosition !== undefined,
+      }));
+    return { count: matches.length, games: matches };
+  }
+
+  if (name === 'lookupGames') {
+    const names: string[] = Array.isArray(args.names) ? args.names.map(String) : [];
+    const results = await Promise.all(
+      names.map(async (n) => {
+        const data = await searchRAWGGame(n);
+        return {
+          query: n,
+          found: !!data,
+          name: data?.name ?? n,
+          released: data?.released ?? null,
+          metacritic: data?.metacritic ?? null,
+          rawgRating: data?.rating ?? null,
+          thumbnail: data?.backgroundImage ?? null,
+        };
+      }),
+    );
+    return { results };
+  }
+
+  return { error: `Unknown read tool: ${name}` };
+}
+
+/**
+ * Drive the model forward from a response, auto-handling read tools until it
+ * either returns prose or proposes write actions (which pause for confirmation).
+ */
+async function advanceAgent(
+  chat: ReturnType<ReturnType<typeof getAgentModel>['startChat']>,
+  initialResponse: AgentResponse,
+  context: AgentChatContext,
+): Promise<AgentTurn> {
+  let response = initialResponse;
+
+  for (let i = 0; i < 8; i++) {
+    const calls = response.functionCalls() ?? [];
+    if (!calls || calls.length === 0) {
+      return { kind: 'text', text: response.text() || 'Done.' };
+    }
+
+    const reads = calls.filter((c: { name: string }) => READ_NAMES.has(c.name));
+    const writes = calls.filter((c: { name: string }) => !READ_NAMES.has(c.name));
+
+    // Resolve read tools immediately — they're side-effect free.
+    const readParts = await Promise.all(
+      reads.map(async (c: { name: string; args: Record<string, unknown> }) => ({
+        functionResponse: { name: c.name, response: await executeReadTool(c.name, c.args, context) },
+      })),
+    );
+
+    if (writes.length > 0) {
+      // Parse each write into a PendingAction (parallel array; nulls = invalid).
+      const parsed = writes.map((c: { name: string; args: Record<string, unknown> }) =>
+        parseFunctionCall(c.name, c.args),
+      );
+      const actions = parsed.filter((a: PendingAction | null): a is PendingAction => a !== null);
+
+      if (actions.length === 0) {
+        // Nothing executable — tell the model and keep going.
+        const errParts = writes.map((c: { name: string }) => ({
+          functionResponse: { name: c.name, response: { error: 'Invalid or incomplete arguments.' } },
+        }));
+        response = (await chat.sendMessage([...readParts, ...errParts])).response as unknown as AgentResponse;
+        continue;
+      }
+
+      const text = response.text() || '';
+      const resume = async (results: AgentActionResult[]): Promise<AgentTurn> => {
+        let ri = 0;
+        const writeParts = writes.map((c: { name: string }, idx: number) => {
+          if (parsed[idx] === null) {
+            return { functionResponse: { name: c.name, response: { error: 'Invalid arguments, skipped.' } } };
+          }
+          const r = results[ri++];
+          return {
+            functionResponse: {
+              name: c.name,
+              response: r
+                ? { success: r.ok, result: r.summary }
+                : { success: false, result: 'No result returned.' },
+            },
+          };
+        });
+        const next = (await chat.sendMessage([...readParts, ...writeParts])).response as unknown as AgentResponse;
+        return advanceAgent(chat, next, context);
+      };
+
+      return { kind: 'actions', text, actions, resume };
+    }
+
+    // Reads only — feed results back and continue the loop.
+    response = (await chat.sendMessage(readParts)).response as unknown as AgentResponse;
+  }
+
+  return { kind: 'text', text: response.text() || 'Done.' };
+}
+
+/**
+ * Start one agent turn. Returns plain text or a set of actions awaiting
+ * confirmation (with a `resume` continuation to call after they run).
+ */
+export async function runAgentTurn(params: {
+  userMessage: string;
+  context: AgentChatContext;
+  history: Array<{ role: 'user' | 'assistant'; content: string }>;
+}): Promise<AgentTurn> {
+  const { userMessage, context, history } = params;
+  const model = getAgentModel(buildAgentSystemInstruction(context));
+
+  // Gemini requires history to start with a user turn and alternate roles.
+  // Merge consecutive same-role messages (e.g. proposal text + cancel note).
+  const mappedHistory: Content[] = [];
+  for (const m of history.slice(-12)) {
+    const role: 'user' | 'model' = m.role === 'user' ? 'user' : 'model';
+    const last = mappedHistory[mappedHistory.length - 1];
+    if (last && last.role === role) {
+      last.parts.push({ text: m.content });
+    } else {
+      mappedHistory.push({ role, parts: [{ text: m.content }] });
+    }
+  }
+  while (mappedHistory.length && mappedHistory[0].role !== 'user') {
+    mappedHistory.shift();
+  }
+
+  try {
+    const chat = model.startChat({ history: mappedHistory });
+    const response = (await chat.sendMessage(userMessage)).response as unknown as AgentResponse;
+    return await advanceAgent(chat, response, context);
+  } catch (error) {
+    console.error('Agent turn error:', error);
+    return { kind: 'text', text: "Sorry, I hit a snag processing that. Mind trying again?" };
   }
 }
 

--- a/app/apps/game-analytics/lib/ai-service.ts
+++ b/app/apps/game-analytics/lib/ai-service.ts
@@ -905,6 +905,7 @@ ACTION RULES:
 - To act on an existing game (update, log a session, change status, queue, delete, review, mark special), FIRST call findGames to resolve the game's id, then call the write tool with that id.
 - For games the user is "interested in" but doesn't own yet, FIRST call lookupGames to fetch real release dates and thumbnails, THEN call addGames. Default unreleased/TBA games to the "queue" destination and already-released games to "wishlist", unless the user specifies otherwise. If they say "both", use "both".
 - For a game the user already owns/played, use addGame (not addGames).
+- Avoid duplicates: before adding any game, call findGames to check it isn't already tracked. If it already exists and the user wants to change something about it, use updateGame/setGameStatus/logPlaySession on the existing game instead of adding a new copy. Only add a duplicate if the user explicitly insists.
 - You may propose multiple write actions in one turn when the user asks for several things — they will be confirmed together.
 - The app shows the user a confirmation card for every write action and runs it only if they approve. Do NOT ask "should I?" in prose — just call the tool; the confirmation UI handles approval. After an action runs you receive its result; then give a brief, friendly confirmation.
 - Never invent release dates, ratings, or metadata — only use values returned by lookupGames or findGames.

--- a/app/apps/game-analytics/page.tsx
+++ b/app/apps/game-analytics/page.tsx
@@ -14,6 +14,7 @@ import { PlayLogModal } from './components/PlayLogModal';
 import { TimelineView } from './components/TimelineView';
 import { StatsView } from './components/StatsView';
 import { AIChatTab } from './components/AIChatTab';
+import { AgentExecutors } from './lib/ai-actions';
 import { UpNextTab } from './components/UpNextTab';
 import { Game, GameStatus, PlayLog, GameRanking, GameAward, AwardPeriodType, GameTier, TierAssignmentMap, ReviewMessage } from './lib/types';
 import { useTierAssignments } from './hooks/useTierAssignments';
@@ -141,7 +142,7 @@ export default function GameAnalyticsPage() {
   const { games, loading, error, addGame, updateGame, deleteGame, refresh } = useGames(user?.uid ?? null);
   const { gamesWithMetrics, summary } = useAnalytics(games);
   const { budgets, setBudget } = useBudget(user?.uid ?? null);
-  const { upcomingEntries } = usePurchaseQueue(user?.uid ?? null);
+  const { upcomingEntries, addEntry: addPurchaseEntry } = usePurchaseQueue(user?.uid ?? null);
   const { loading: thumbnailsLoading, fetchedCount } = useGameThumbnails(games, updateGame);
   const gameColors = useGameColors(games);
   const { quips: gameQuips } = useGameQuips(games, user?.uid ?? null);
@@ -448,6 +449,19 @@ export default function GameAnalyticsPage() {
       });
     } catch { /* non-critical */ }
   }, [user?.uid, allTimeRankings]);
+
+  // Executors the AI Coach uses to perform confirmed actions. All route through
+  // the existing hooks so per-user storage rules and optimistic UI still apply.
+  const aiExecutors: AgentExecutors = useMemo(() => ({
+    addGame,
+    updateGame,
+    deleteGame,
+    addToQueue,
+    removeFromQueue,
+    clearUpcoming,
+    setBudget,
+    addPurchaseEntry,
+  }), [addGame, updateGame, deleteGame, addToQueue, removeFromQueue, clearUpcoming, setBudget, addPurchaseEntry]);
 
   const handleBulkWishlist = async (gamesToAdd: Omit<Game, 'id' | 'userId' | 'createdAt' | 'updatedAt'>[]) => {
     try {
@@ -1289,6 +1303,7 @@ export default function GameAnalyticsPage() {
               weekData={weekData}
               monthGames={monthGames}
               allGames={games}
+              executors={aiExecutors}
               onBack={() => setTabMode('games')}
             />
           )}


### PR DESCRIPTION
The AI Gaming Coach can now perform actions through chat, not just answer
questions. It uses Gemini function calling to propose actions; the app shows
a single confirmation card and executes only on approval.

Phase 1 (core loop): function-calling engine in ai-service (runAgentTurn),
useAIAgent hook owning conversation + confirmation state, AIActionCard UI,
findGames resolution, addGame, updateGame, setGameStatus, logPlaySession.

Phase 2 (breadth + lookup): lookupGames (RAWG release dates/metadata, no
confirm), addGames batch for interested games with per-game queue/wishlist/
both destination toggles, queue actions, setBudget, deleteGame, setReview,
markSpecial.

Phase 3 (polish): multi-action batch proposals, stronger confirm styling for
destructive actions, history sanitized to alternating roles.

All writes route through existing hooks, so per-user storage rules and
optimistic UI are preserved. Reads (findGames, lookupGames) run without
confirmation.