### PR TITLE
Fix Up Next queue bugs and add Timeline Estimator synergy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2590,6 +2590,19 @@ fortune-fade           — Gentle fade-in for daily fortune cookie
 
 ## Changelog
 
+### 2026-06-10 (v2.6.0)
+- **Up Next ⇄ Timeline Estimator synergy + queue bug fixes** (branch `claude/timeline-upnext-synergy-plan-rrdfyo`)
+- **Queue persistence fixes**:
+  - Firebase `update()` now translates an explicit `undefined` field to Firestore's `deleteField()` sentinel (`lib/storage.ts` `prepareFirestoreUpdate`). Previously `queuePosition: undefined` was stripped before `updateDoc`, so removing a game from the queue silently no-op'd for logged-in users and the game reappeared on reload.
+  - Added `updateMany()` to `GameRepository` (Firebase `writeBatch`, localStorage single read-modify-write) + `updateManyGames()` in `useGames`. Queue add/remove/reorder/clear now persist as **one batch** — fixes the localStorage clobber where parallel `update()` calls each rewrote the whole array from a stale snapshot (last write won, dropping position shifts / resurrecting removed games).
+  - `useGameQueue.reorderQueue` replaced with `setQueueOrder(orderedIds)`: drag-and-drop renumbers the whole queue from the **displayed** order, fixing the display-index vs stored-`queuePosition` mismatch caused by floating finished games to the bottom.
+  - Queue card remove/log buttons are always visible (dropped desktop-hover gate).
+- **Synergy features**:
+  - Inline `QueueTimelineStrip` in Up Next — projected completion dates that re-flow live as you reorder, sharing the Estimator's `buildPlaythroughTimeline` + a shared weekly-pace control persisted to the same `estimator-settings` localStorage key.
+  - Gap banner in Up Next using `detectGap` against tracked Buy Queue releases.
+  - `SuggestedNextRail` — curatable "Suggested next" with Add + full **thumbs up/down tuning**. `getPlayNextRecommendations(games, max, prefs?)` now takes learned preferences (`RecommendationPreferences`): disliked games are hidden, liked boosted, and net signals reweight across **genre / price bracket / length bucket**. Prefs persist per-user in localStorage via `lib/queue-preferences.ts` + `hooks/useQueuePreferences.ts` (device-local planning data, same precedent as estimator settings — no Firestore rule needed).
+  - Cross-link: "Full timeline" from the Up Next strip jumps to the Estimator tab.
+
 ### 2026-02-21 (v2.5.0)
 - Added Immersive Experience & Deep Insights Plan: 10 features across 5 areas
 - Timeline: Weather system (9 conditions based on monthly activity), Plot twist markers (10 twist types for dramatic behavioral shifts), Story arc detection (5-act narrative structure overlay)

--- a/app/apps/game-analytics/components/QueueGameCard.tsx
+++ b/app/apps/game-analytics/components/QueueGameCard.tsx
@@ -406,7 +406,7 @@ export function QueueGameCard({
           {onLogTime && (
             <button
               onClick={(e) => { e.stopPropagation(); onLogTime(); }}
-              className="touch-manipulation p-2 -m-1 text-white/20 hover:text-blue-400 hover:bg-blue-500/10 rounded-lg transition-all sm:opacity-0 sm:group-hover:opacity-100"
+              className="touch-manipulation p-2 -m-1 text-white/30 hover:text-blue-400 hover:bg-blue-500/10 rounded-lg transition-all"
               aria-label="Log play session"
             >
               <Clock size={18} />
@@ -414,7 +414,7 @@ export function QueueGameCard({
           )}
           <button
             onClick={(e) => { e.stopPropagation(); onRemove(); }}
-            className="touch-manipulation p-2 -m-1 text-white/20 hover:text-red-400 hover:bg-red-500/10 rounded-lg transition-all shrink-0 sm:opacity-0 sm:group-hover:opacity-100"
+            className="touch-manipulation p-2 -m-1 text-white/30 hover:text-red-400 hover:bg-red-500/10 rounded-lg transition-all shrink-0"
             aria-label="Remove from queue"
           >
             <X size={18} />

--- a/app/apps/game-analytics/components/QueueTimelineStrip.tsx
+++ b/app/apps/game-analytics/components/QueueTimelineStrip.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useMemo } from 'react';
+import { CalendarClock, Flag, ArrowRight } from 'lucide-react';
+import { Game } from '../lib/types';
+import { buildPlaythroughTimeline } from '../lib/timeline-estimator';
+
+interface QueueTimelineStripProps {
+  /** The active queue in play order (finished games already excluded by caller). */
+  activeQueue: Game[];
+  allGames: Game[];
+  weeklyHours: number;
+  onOpenEstimator?: () => void;
+}
+
+function fmtShort(d: Date): string {
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+/**
+ * Compact, horizontally-scrollable completion timeline that lives inside Up Next.
+ * It re-flows live as the queue is reordered (it's derived straight from the
+ * queue order), so the queue *is* the estimate — the core synergy with the
+ * Timeline Estimator tab, which shares the same pace and calculations.
+ */
+export function QueueTimelineStrip({
+  activeQueue, allGames, weeklyHours, onOpenEstimator,
+}: QueueTimelineStripProps) {
+  const today = useMemo(() => { const d = new Date(); d.setHours(0, 0, 0, 0); return d; }, []);
+
+  const segments = useMemo(
+    () => buildPlaythroughTimeline(activeQueue, weeklyHours, today, allGames),
+    [activeQueue, weeklyHours, today, allGames]
+  );
+
+  if (segments.length === 0) return null;
+
+  const finishDate = segments[segments.length - 1].endDate;
+
+  return (
+    <div className="p-3 rounded-xl bg-white/[0.02] border border-white/5">
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-[11px] font-semibold text-white/55 flex items-center gap-1.5 uppercase tracking-wide">
+          <CalendarClock size={13} className="text-purple-400" /> Projected completion
+        </span>
+        <div className="flex items-center gap-2">
+          <span className="text-[11px] text-white/40">all done {fmtShort(finishDate)}</span>
+          {onOpenEstimator && (
+            <button
+              onClick={onOpenEstimator}
+              className="text-[11px] text-purple-300/80 hover:text-purple-200 flex items-center gap-0.5 transition-colors"
+            >
+              Full timeline <ArrowRight size={11} />
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="flex items-stretch gap-1.5 overflow-x-auto pb-1 -mb-1">
+        {segments.map((seg, i) => (
+          <div key={seg.game.id} className="flex items-center gap-1.5 shrink-0">
+            <div className="flex flex-col items-center gap-1 w-24 shrink-0 px-1.5 py-1.5 rounded-lg bg-white/[0.02] border border-white/5">
+              <div className="flex items-center gap-1 w-full">
+                <span className="w-4 h-4 rounded-full bg-purple-500/15 text-purple-300 text-[9px] font-bold flex items-center justify-center shrink-0">
+                  {i + 1}
+                </span>
+                <span className="text-[10px] font-medium text-white/80 truncate flex-1">{seg.game.name}</span>
+              </div>
+              <span className="text-[9px] text-white/40 w-full text-center">
+                {fmtShort(seg.endDate)}{seg.isEstimatedLength ? ' · est' : ''}
+              </span>
+            </div>
+            {i < segments.length - 1 && <ArrowRight size={12} className="text-white/15 shrink-0" />}
+          </div>
+        ))}
+        <div className="flex items-center gap-1.5 shrink-0">
+          <ArrowRight size={12} className="text-white/15 shrink-0" />
+          <div className="flex flex-col items-center justify-center w-16 px-1.5 py-1.5 rounded-lg bg-emerald-500/5 border border-emerald-500/15">
+            <Flag size={12} className="text-emerald-400" />
+            <span className="text-[9px] text-emerald-400/80 mt-0.5">done</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/apps/game-analytics/components/SuggestedNextRail.tsx
+++ b/app/apps/game-analytics/components/SuggestedNextRail.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useMemo } from 'react';
+import { Sparkles, Plus, ThumbsUp, ThumbsDown } from 'lucide-react';
+import clsx from 'clsx';
+import { Game } from '../lib/types';
+import { GameWithMetrics } from '../hooks/useAnalytics';
+import { getPlayNextRecommendations, RecommendationPreferences } from '../lib/calculations';
+import { PreferenceState } from '../lib/queue-preferences';
+
+interface SuggestedNextRailProps {
+  /** Games not already in the queue (backlog + in-progress candidates live here). */
+  availableGames: Game[];
+  prefs: RecommendationPreferences;
+  onAdd: (gameId: string) => void;
+  onLike: (game: Game) => void;
+  onDislike: (game: Game) => void;
+  stateOf: (gameId: string) => PreferenceState;
+}
+
+/**
+ * Curatable "Suggested Next" rail. Surfaces the recommendation engine (already
+ * tuned by the user's thumbs up/down) as something you can act on: Add to queue,
+ * or 👍/👎 to teach it what you like across genre, price, and length.
+ */
+export function SuggestedNextRail({
+  availableGames, prefs, onAdd, onLike, onDislike, stateOf,
+}: SuggestedNextRailProps) {
+  const recommendations = useMemo(
+    () => getPlayNextRecommendations(availableGames, 6, prefs),
+    [availableGames, prefs]
+  );
+
+  if (recommendations.length === 0) return null;
+
+  return (
+    <div className="p-4 rounded-xl bg-gradient-to-br from-purple-500/[0.07] via-white/[0.02] to-transparent border border-purple-500/10">
+      <div className="flex items-center gap-2 mb-3">
+        <Sparkles size={15} className="text-purple-400" />
+        <h3 className="text-sm font-semibold text-white/80">Suggested next</h3>
+        <span className="text-[10px] text-white/30">— 👍 / 👎 to tune what you see</span>
+      </div>
+
+      <div className="flex gap-2.5 overflow-x-auto pb-1 -mb-1">
+        {recommendations.map(({ game, reasons }) => {
+          const state = stateOf(game.id);
+          const g = game as GameWithMetrics;
+          return (
+            <div
+              key={game.id}
+              className="shrink-0 w-44 p-2.5 rounded-xl bg-white/[0.03] border border-white/5 flex flex-col"
+            >
+              {game.thumbnail ? (
+                <img src={game.thumbnail} alt={game.name} className="w-full h-20 object-cover rounded-lg mb-2" loading="lazy" />
+              ) : (
+                <div className="w-full h-20 rounded-lg mb-2 bg-gradient-to-br from-purple-500/15 to-white/[0.02] flex items-center justify-center">
+                  <Sparkles size={18} className="text-white/15" />
+                </div>
+              )}
+
+              <p className="text-xs font-medium text-white/90 truncate">{game.name}</p>
+              <div className="flex items-center gap-1 mt-0.5 flex-wrap">
+                {game.genre && <span className="text-[9px] px-1 py-0.5 bg-white/5 rounded text-white/40">{game.genre}</span>}
+                {typeof g.totalHours === 'number' && g.totalHours > 0 && (
+                  <span className="text-[9px] text-white/30">{Math.round(g.totalHours)}h in</span>
+                )}
+              </div>
+              {reasons[0] && (
+                <p className="text-[10px] text-white/40 mt-1 leading-snug line-clamp-2 min-h-[1.8em]">{reasons[0]}</p>
+              )}
+
+              <div className="flex items-center gap-1 mt-2">
+                <button
+                  onClick={() => onAdd(game.id)}
+                  className="flex-1 flex items-center justify-center gap-1 px-2 py-1.5 rounded-lg bg-purple-600/25 text-purple-200 hover:bg-purple-600/40 text-[11px] font-medium transition-all"
+                >
+                  <Plus size={12} /> Add
+                </button>
+                <button
+                  onClick={() => onLike(game)}
+                  aria-label="I like this suggestion"
+                  className={clsx(
+                    'p-1.5 rounded-lg transition-all',
+                    state === 'like'
+                      ? 'bg-emerald-500/25 text-emerald-300'
+                      : 'bg-white/5 text-white/30 hover:text-emerald-400 hover:bg-emerald-500/10'
+                  )}
+                >
+                  <ThumbsUp size={13} />
+                </button>
+                <button
+                  onClick={() => onDislike(game)}
+                  aria-label="Not interested"
+                  className={clsx(
+                    'p-1.5 rounded-lg transition-all',
+                    state === 'dislike'
+                      ? 'bg-red-500/25 text-red-300'
+                      : 'bg-white/5 text-white/30 hover:text-red-400 hover:bg-red-500/10'
+                  )}
+                >
+                  <ThumbsDown size={13} />
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/apps/game-analytics/components/UpNextTab.tsx
+++ b/app/apps/game-analytics/components/UpNextTab.tsx
@@ -15,19 +15,27 @@ import {
   SortableContext,
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
+  arrayMove,
 } from '@dnd-kit/sortable';
 import {
   ListOrdered, Search, Plus, Gamepad2, Swords, Sparkles, Brain,
   MessageSquare, TrendingUp, ChevronDown, ChevronUp, RefreshCw,
-  Flame, Zap, Map, BookOpen, Trash2,
+  Flame, Zap, Map, BookOpen, Trash2, Clock, AlertTriangle, CheckCircle2,
 } from 'lucide-react';
 import { QueueGameCard } from './QueueGameCard';
+import { QueueTimelineStrip } from './QueueTimelineStrip';
+import { SuggestedNextRail } from './SuggestedNextRail';
 import { GameWithMetrics } from '../hooks/useAnalytics';
-import { Game } from '../lib/types';
+import { useQueuePreferences } from '../hooks/useQueuePreferences';
+import { Game, PurchaseQueueEntry } from '../lib/types';
 import {
   getQueueSmartChirps, getQueueRivalry, getEstimatedHoursToReach,
   buildQueueAIContext, SmartChirp, RivalryData, getUserGamingPace,
 } from '../lib/calculations';
+import {
+  buildPlaythroughTimeline, detectGap, UpcomingRelease,
+} from '../lib/timeline-estimator';
+import { loadEstimatorSettings, saveEstimatorSettings } from '../lib/estimator-settings';
 import {
   generateHypeChirps, generateNarrativeThread, generateQueueRoast,
   generateQueueHype, generateQueueAdvice, clearQueueAICache,
@@ -35,25 +43,30 @@ import {
 import clsx from 'clsx';
 
 interface UpNextTabProps {
+  userId: string | null;
   queuedGames: GameWithMetrics[];
   availableGames: Game[];
   allGames: Game[];
+  upcomingEntries?: PurchaseQueueEntry[];
   hideFinished: boolean;
   onToggleHideFinished: () => void;
   onAddToQueue: (gameId: string) => Promise<void>;
   onRemoveFromQueue: (gameId: string) => Promise<void>;
-  onReorderQueue: (gameId: string, newPosition: number) => Promise<void>;
+  onReorderQueue: (orderedIds: string[]) => Promise<void>;
   onClearUpcoming?: () => Promise<void>;
   onLogTime?: (game: GameWithMetrics) => void;
   onStartGame?: (game: GameWithMetrics) => void;
+  onGoToEstimator?: () => void;
 }
 
 type AIMode = 'hype' | 'roast' | 'narrative' | 'advisor' | null;
 
 export function UpNextTab({
+  userId,
   queuedGames,
   availableGames,
   allGames,
+  upcomingEntries,
   hideFinished,
   onToggleHideFinished,
   onAddToQueue,
@@ -62,6 +75,7 @@ export function UpNextTab({
   onClearUpcoming,
   onLogTime,
   onStartGame,
+  onGoToEstimator,
 }: UpNextTabProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const [isAddingGames, setIsAddingGames] = useState(false);
@@ -99,6 +113,53 @@ export function UpNextTab({
 
   // Weekly gaming pace (hours/week over last 4 weeks)
   const weeklyPace = useMemo(() => getUserGamingPace(allGames), [allGames]);
+
+  // Suggestion tuning (thumbs up/down)
+  const { prefs, like, dislike, stateOf } = useQueuePreferences(userId);
+
+  // Shared planning pace — same localStorage settings the Estimator tab uses, so
+  // adjusting it here keeps both surfaces in sync.
+  const [weeklyHours, setWeeklyHours] = useState<number>(
+    () => loadEstimatorSettings(userId || 'local-user', weeklyPace).weeklyHours
+  );
+  const updateWeeklyHours = useCallback((value: number) => {
+    const next = Math.max(0.5, value);
+    setWeeklyHours(next);
+    const uid = userId || 'local-user';
+    saveEstimatorSettings(uid, { ...loadEstimatorSettings(uid, weeklyPace), weeklyHours: next });
+  }, [userId, weeklyPace]);
+
+  // Active (unfinished) queue in play order — the basis for timeline + gap
+  const activeQueue = useMemo(
+    () => queuedGames.filter(g => g.status !== 'Completed' && g.status !== 'Abandoned'),
+    [queuedGames]
+  );
+
+  // Gap before the next tracked release (synergy with the Buy Queue / Estimator)
+  const gap = useMemo(() => {
+    if (activeQueue.length === 0) return null;
+    const today = new Date(); today.setHours(0, 0, 0, 0);
+    const timeline = buildPlaythroughTimeline(activeQueue, weeklyHours, today, allGames);
+    if (timeline.length === 0) return null;
+    const queueEndDate = timeline[timeline.length - 1].endDate;
+    const releases: UpcomingRelease[] = (upcomingEntries ?? [])
+      .filter(e => e.releaseDate)
+      .map(e => ({
+        id: e.id,
+        name: e.gameName,
+        date: new Date(e.releaseDate as string),
+        price: e.targetPrice ?? e.currentPrice ?? e.msrpEstimate ?? 70,
+        isDayOne: e.isDayOneBuy,
+        thumbnail: e.thumbnail,
+      }));
+    // Only surface a gap banner when there's actually a tracked release ahead.
+    const info = detectGap(queueEndDate, releases, weeklyHours);
+    return info.nextRelease ? info : null;
+  }, [activeQueue, allGames, weeklyHours, upcomingEntries]);
+
+  const fmtGapDate = (d: Date) => d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  const humanizeGap = (weeks: number) =>
+    weeks < 1 ? `${Math.round(weeks * 7)} days` : weeks < 8 ? `${weeks.toFixed(0)} weeks` : `${(weeks / 4.345).toFixed(0)} months`;
 
   // Queue summary: active game count + total estimated remaining hours
   const queueSummary = useMemo(() => {
@@ -161,8 +222,10 @@ export function UpNextTab({
     const oldIndex = queuedGames.findIndex(g => g.id === active.id);
     const newIndex = queuedGames.findIndex(g => g.id === over.id);
     if (oldIndex !== -1 && newIndex !== -1) {
-      const newPosition = newIndex + 1;
-      await onReorderQueue(active.id as string, newPosition);
+      // Renumber from the full displayed order — robust to finished games being
+      // floated to the bottom (display index ≠ stored queuePosition otherwise).
+      const orderedIds = arrayMove(queuedGames, oldIndex, newIndex).map(g => g.id);
+      await onReorderQueue(orderedIds);
     }
   };
 
@@ -334,6 +397,76 @@ export function UpNextTab({
           </div>
         </div>
       )}
+
+      {/* Projected completion timeline (re-flows live as you reorder) + shared pace */}
+      {activeQueue.length > 0 && (
+        <div className="space-y-2">
+          <QueueTimelineStrip
+            activeQueue={activeQueue}
+            allGames={allGames}
+            weeklyHours={weeklyHours}
+            onOpenEstimator={onGoToEstimator}
+          />
+          <div className="flex items-center gap-2 px-1">
+            <Clock size={13} className="text-white/35 shrink-0" />
+            <span className="text-[11px] text-white/45 shrink-0">Pace</span>
+            <input
+              type="range" min="1" max="40" step="0.5"
+              value={weeklyHours}
+              onChange={e => updateWeeklyHours(parseFloat(e.target.value))}
+              className="flex-1 accent-purple-500 h-1"
+              aria-label="Weekly hours pace"
+            />
+            <span className="text-[11px] font-medium text-white/60 w-16 text-right shrink-0">{weeklyHours}h/wk</span>
+            {weeklyPace > 0 && (
+              <button
+                onClick={() => updateWeeklyHours(Math.round(weeklyPace * 10) / 10)}
+                className="text-[10px] text-white/30 hover:text-purple-300 shrink-0 transition-colors"
+                title="Use your recent actual pace"
+              >
+                actual ~{weeklyPace.toFixed(1)}
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Gap before next tracked release */}
+      {gap && gap.nextRelease && (
+        <div className={clsx(
+          'flex items-start gap-2.5 px-4 py-3 rounded-xl border',
+          gap.severity === 'long' ? 'border-red-500/25 bg-red-500/5'
+            : gap.severity === 'medium' ? 'border-amber-500/25 bg-amber-500/5'
+            : 'border-emerald-500/25 bg-emerald-500/5'
+        )}>
+          {gap.severity === 'short'
+            ? <CheckCircle2 size={16} className="text-emerald-400 shrink-0 mt-0.5" />
+            : <AlertTriangle size={16} className={clsx('shrink-0 mt-0.5', gap.severity === 'long' ? 'text-red-400' : 'text-amber-400')} />}
+          <div className="min-w-0">
+            <p className="text-xs text-white/70">
+              You&apos;ll wrap this queue around <strong>{fmtGapDate(gap.queueEndDate)}</strong>
+              {gap.hasGap ? (
+                <> — <strong>{humanizeGap(gap.gapWeeks)}</strong> before <strong>{gap.nextRelease.name}</strong> drops {fmtGapDate(gap.nextRelease.date)}.</>
+              ) : (
+                <> — right as <strong>{gap.nextRelease.name}</strong> drops {fmtGapDate(gap.nextRelease.date)}. Seamless.</>
+              )}
+            </p>
+            {gap.hasGap && (
+              <p className="text-[11px] text-white/35 mt-0.5">Fill it from the suggestions below, or check the estimator for deals.</p>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Curatable suggestions — pick what fits next, teach it what you like */}
+      <SuggestedNextRail
+        availableGames={availableGames}
+        prefs={prefs}
+        onAdd={(id) => { onAddToQueue(id); }}
+        onLike={like}
+        onDislike={dislike}
+        stateOf={stateOf}
+      />
 
       {/* Smart Chirp Banner (secondary) */}
       {statsChirp && queuedGames.length > 0 && (

--- a/app/apps/game-analytics/hooks/useGameQueue.ts
+++ b/app/apps/game-analytics/hooks/useGameQueue.ts
@@ -3,9 +3,11 @@
 import { useState, useMemo } from 'react';
 import { Game } from '../lib/types';
 
+type QueueUpdate = { id: string; changes: Partial<Game> };
+
 export function useGameQueue(
   games: Game[],
-  updateGame: (id: string, updates: Partial<Game>) => Promise<Game>
+  updateManyGames: (updates: QueueUpdate[]) => Promise<void>
 ) {
   const [hideFinished, setHideFinished] = useState(false);
 
@@ -40,83 +42,48 @@ export function useGameQueue(
 
     if (hasHero) {
       // Shift all games at position >= 2 down by 1, then insert at 2
-      const gamesToShift = games.filter(
-        g => g.id !== gameId && g.queuePosition !== undefined && (g.queuePosition || 0) >= 2
-      );
-      await Promise.all([
-        ...gamesToShift.map(g => updateGame(g.id, { queuePosition: (g.queuePosition || 0) + 1 })),
-        updateGame(gameId, { queuePosition: 2 }),
-      ]);
+      const updates: QueueUpdate[] = games
+        .filter(g => g.id !== gameId && g.queuePosition !== undefined && (g.queuePosition || 0) >= 2)
+        .map(g => ({ id: g.id, changes: { queuePosition: (g.queuePosition || 0) + 1 } }));
+      updates.push({ id: gameId, changes: { queuePosition: 2 } });
+      await updateManyGames(updates);
     } else {
       const positions = games
         .filter(g => g.queuePosition !== undefined)
         .map(g => g.queuePosition || 0);
       const nextPosition = positions.length > 0 ? Math.max(...positions) + 1 : 1;
-      await updateGame(gameId, { queuePosition: nextPosition });
+      await updateManyGames([{ id: gameId, changes: { queuePosition: nextPosition } }]);
     }
   };
 
-  // Remove a game from the queue
+  // Remove a game from the queue (clears its position and closes the gap) — one batch
   const removeFromQueue = async (gameId: string) => {
     const game = games.find(g => g.id === gameId);
     if (!game || game.queuePosition === undefined) return;
 
     const removedPosition = game.queuePosition;
+    const updates: QueueUpdate[] = [{ id: gameId, changes: { queuePosition: undefined } }];
+    games
+      .filter(g => g.id !== gameId && g.queuePosition !== undefined && g.queuePosition > removedPosition)
+      .forEach(g => updates.push({ id: g.id, changes: { queuePosition: (g.queuePosition || 0) - 1 } }));
 
-    const gamesToShift = games.filter(
-      g => g.id !== gameId && g.queuePosition !== undefined && g.queuePosition > removedPosition
-    );
-
-    // Run all updates in parallel — React 18 batches the resulting state updates
-    await Promise.all([
-      updateGame(gameId, { queuePosition: undefined }),
-      ...gamesToShift.map(g => updateGame(g.id, { queuePosition: (g.queuePosition || 0) - 1 })),
-    ]);
+    await updateManyGames(updates);
   };
 
-  // Reorder a game in the queue
-  const reorderQueue = async (gameId: string, newPosition: number) => {
-    const game = games.find(g => g.id === gameId);
-    if (!game || game.queuePosition === undefined) return;
-
-    const oldPosition = game.queuePosition;
-    if (oldPosition === newPosition) return;
-
-    // Collect all updates
-    const updates: Array<{ id: string; position: number }> = [];
-
-    // Update the dragged game
-    updates.push({ id: gameId, position: newPosition });
-
-    // Shift other games
-    if (newPosition < oldPosition) {
-      // Moving up - shift down games between new and old position
-      const gamesToShift = games.filter(
-        g => g.id !== gameId &&
-             g.queuePosition !== undefined &&
-             g.queuePosition >= newPosition &&
-             g.queuePosition < oldPosition
-      );
-
-      for (const g of gamesToShift) {
-        updates.push({ id: g.id, position: (g.queuePosition || 0) + 1 });
+  // Set the queue order from a fully-ordered list of game ids (the displayed
+  // order after a drag). Renumbering the whole queue from the visible sequence
+  // avoids the display-index vs stored-position mismatch caused by floating
+  // finished games to the bottom.
+  const setQueueOrder = async (orderedIds: string[]) => {
+    const updates: QueueUpdate[] = [];
+    orderedIds.forEach((id, i) => {
+      const position = i + 1;
+      const g = games.find(x => x.id === id);
+      if (g && g.queuePosition !== position) {
+        updates.push({ id, changes: { queuePosition: position } });
       }
-    } else {
-      // Moving down - shift up games between old and new position
-      const gamesToShift = games.filter(
-        g => g.id !== gameId &&
-             g.queuePosition !== undefined &&
-             g.queuePosition > oldPosition &&
-             g.queuePosition <= newPosition
-      );
-
-      for (const g of gamesToShift) {
-        updates.push({ id: g.id, position: (g.queuePosition || 0) - 1 });
-      }
-    }
-
-    // Run all updates in parallel — React 18 batches the resulting state updates
-    await Promise.all(updates.map(u => updateGame(u.id, { queuePosition: u.position })));
+    });
+    if (updates.length > 0) await updateManyGames(updates);
   };
 
   // Clear everything planned for "after today" — removes all queued games EXCEPT
@@ -127,7 +94,7 @@ export function useGameQueue(
       g => g.queuePosition !== undefined && g.status !== 'In Progress'
     );
     if (toClear.length === 0) return;
-    await Promise.all(toClear.map(g => updateGame(g.id, { queuePosition: undefined })));
+    await updateManyGames(toClear.map(g => ({ id: g.id, changes: { queuePosition: undefined } })));
   };
 
   // Check if a game is in the queue
@@ -143,7 +110,7 @@ export function useGameQueue(
     setHideFinished,
     addToQueue,
     removeFromQueue,
-    reorderQueue,
+    setQueueOrder,
     clearUpcoming,
     isInQueue,
   };

--- a/app/apps/game-analytics/hooks/useGames.ts
+++ b/app/apps/game-analytics/hooks/useGames.ts
@@ -54,6 +54,24 @@ export function useGames(userId: string | null) {
     }
   };
 
+  const updateManyGames = async (updates: Array<{ id: string; changes: Partial<Game> }>) => {
+    if (updates.length === 0) return;
+    try {
+      await gameRepository.updateMany(updates);
+      // Optimistic local merge — mirrors the persisted result without a refresh()
+      // (which would flip loading=true and unmount the UI tree).
+      const now = new Date().toISOString();
+      const changeMap = new Map(updates.map(u => [u.id, u.changes]));
+      setGames(prev => prev.map(g => {
+        const changes = changeMap.get(g.id);
+        return changes ? { ...g, ...changes, updatedAt: now } : g;
+      }));
+    } catch (e) {
+      setError(e as Error);
+      throw e;
+    }
+  };
+
   const deleteGame = async (id: string) => {
     try {
       await gameRepository.delete(id);
@@ -70,6 +88,7 @@ export function useGames(userId: string | null) {
     error,
     addGame,
     updateGame,
+    updateManyGames,
     deleteGame,
     refresh,
   };

--- a/app/apps/game-analytics/hooks/useQueuePreferences.ts
+++ b/app/apps/game-analytics/hooks/useQueuePreferences.ts
@@ -1,0 +1,44 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { Game } from '../lib/types';
+import { RecommendationPreferences } from '../lib/calculations';
+import {
+  loadQueuePreferences,
+  saveQueuePreferences,
+  setPreference,
+  getPreferenceState,
+  PreferenceState,
+} from '../lib/queue-preferences';
+
+/**
+ * Manages the user's thumbs up/down tuning for Up Next suggestions.
+ * Toggling a thumb that's already set returns the game to neutral.
+ */
+export function useQueuePreferences(userId: string | null) {
+  const uid = userId || 'local-user';
+  const [prefs, setPrefs] = useState<RecommendationPreferences>(() => loadQueuePreferences(uid));
+
+  const apply = useCallback((game: Game, target: PreferenceState) => {
+    setPrefs(prev => {
+      const next = setPreference(prev, game, target);
+      if (next !== prev) saveQueuePreferences(uid, next);
+      return next;
+    });
+  }, [uid]);
+
+  const like = useCallback((game: Game) => {
+    apply(game, getPreferenceState(prefs, game.id) === 'like' ? 'none' : 'like');
+  }, [apply, prefs]);
+
+  const dislike = useCallback((game: Game) => {
+    apply(game, getPreferenceState(prefs, game.id) === 'dislike' ? 'none' : 'dislike');
+  }, [apply, prefs]);
+
+  const stateOf = useCallback(
+    (gameId: string): PreferenceState => getPreferenceState(prefs, gameId),
+    [prefs]
+  );
+
+  return { prefs, like, dislike, stateOf };
+}

--- a/app/apps/game-analytics/lib/calculations.ts
+++ b/app/apps/game-analytics/lib/calculations.ts
@@ -4210,9 +4210,53 @@ export interface Recommendation {
   reasons: string[];
 }
 
-export function getPlayNextRecommendations(games: Game[], maxResults: number = 5): Recommendation[] {
+/**
+ * Learned preference signals from the user's thumbs up/down on suggestions.
+ * Weights are net like/dislike tallies per dimension bucket (positive = liked).
+ */
+export interface RecommendationPreferences {
+  liked: string[];                          // explicitly liked game ids
+  disliked: string[];                       // explicitly disliked game ids (hidden from suggestions)
+  genreWeights: Record<string, number>;     // genre → net signal
+  priceWeights: Record<string, number>;     // price bracket → net signal
+  lengthWeights: Record<string, number>;    // length bucket → net signal
+}
+
+/** Price bracket key for preference learning (kept stable across the app). */
+export function getRecPriceBracket(price: number): string {
+  if (!price || price <= 0) return 'free';
+  if (price < 15) return 'budget';
+  if (price < 30) return 'mid';
+  if (price < 50) return 'premium';
+  return 'full';
+}
+
+/** Length bucket key (prefers an explicit estimate, falls back to logged hours). */
+export function getRecLengthBucket(game: Game): string {
+  const h = (game.expectedHours && game.expectedHours > 0) ? game.expectedHours : getTotalHours(game);
+  if (!h || h <= 0) return 'unknown';
+  if (h < 10) return 'short';
+  if (h < 30) return 'medium';
+  if (h < 60) return 'long';
+  return 'epic';
+}
+
+// Convert a net signal weight into a bounded score nudge.
+function prefNudge(weight: number | undefined, perPoint: number, cap: number): number {
+  if (!weight) return 0;
+  return Math.max(-cap, Math.min(cap, weight * perPoint));
+}
+
+export function getPlayNextRecommendations(
+  games: Game[],
+  maxResults: number = 5,
+  prefs?: RecommendationPreferences
+): Recommendation[] {
+  const dislikedSet = new Set(prefs?.disliked ?? []);
+  const likedSet = new Set(prefs?.liked ?? []);
+
   const candidates = games.filter(g =>
-    g.status === 'Not Started' || g.status === 'In Progress'
+    (g.status === 'Not Started' || g.status === 'In Progress') && !dislikedSet.has(g.id)
   );
 
   if (candidates.length === 0) return [];
@@ -4300,6 +4344,21 @@ export function getPlayNextRecommendations(games: Game[], maxResults: number = 5
         score += 5;
         reasons.push(`Been on shelf ${Math.round(monthsOwned)} months`);
       }
+    }
+
+    // Learned preferences — thumbs up/down tuning across game id, genre, price, length
+    if (prefs) {
+      if (likedSet.has(game.id)) {
+        score += 25;
+        reasons.unshift('You liked this suggestion');
+      }
+      if (game.genre) {
+        const g = prefNudge(prefs.genreWeights[game.genre], 6, 18);
+        if (g > 0) reasons.push(`Matches genres you like (${game.genre})`);
+        score += g;
+      }
+      score += prefNudge(prefs.priceWeights[getRecPriceBracket(game.price)], 3, 9);
+      score += prefNudge(prefs.lengthWeights[getRecLengthBucket(game)], 3, 9);
     }
 
     return { game, score: Math.min(100, Math.max(0, score)), reasons };

--- a/app/apps/game-analytics/lib/queue-preferences.ts
+++ b/app/apps/game-analytics/lib/queue-preferences.ts
@@ -1,0 +1,112 @@
+'use client';
+
+/**
+ * Up Next "Suggested Next" preferences — the thumbs up/down signals that tune
+ * which backlog games get recommended. Persisted in localStorage per user
+ * (SSR-safe). Like the estimator settings, these are personal planning knobs
+ * rather than core game data, so they stay device-local and don't go through the
+ * Hybrid/Firebase repository (which would also require a deployed Firestore rule).
+ */
+
+import { Game } from './types';
+import {
+  RecommendationPreferences,
+  getRecPriceBracket,
+  getRecLengthBucket,
+} from './calculations';
+
+export type PreferenceState = 'like' | 'dislike' | 'none';
+
+export const EMPTY_PREFERENCES: RecommendationPreferences = {
+  liked: [],
+  disliked: [],
+  genreWeights: {},
+  priceWeights: {},
+  lengthWeights: {},
+};
+
+const keyFor = (userId: string) => `ga-queue-preferences-${userId || 'local-user'}`;
+
+export function loadQueuePreferences(userId: string): RecommendationPreferences {
+  if (typeof window === 'undefined') return clone(EMPTY_PREFERENCES);
+  try {
+    const raw = localStorage.getItem(keyFor(userId));
+    if (!raw) return clone(EMPTY_PREFERENCES);
+    const parsed = JSON.parse(raw) as Partial<RecommendationPreferences>;
+    return {
+      liked: Array.isArray(parsed.liked) ? parsed.liked : [],
+      disliked: Array.isArray(parsed.disliked) ? parsed.disliked : [],
+      genreWeights: parsed.genreWeights ?? {},
+      priceWeights: parsed.priceWeights ?? {},
+      lengthWeights: parsed.lengthWeights ?? {},
+    };
+  } catch {
+    return clone(EMPTY_PREFERENCES);
+  }
+}
+
+export function saveQueuePreferences(userId: string, prefs: RecommendationPreferences): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(keyFor(userId), JSON.stringify(prefs));
+  } catch {
+    /* ignore quota / disabled storage */
+  }
+}
+
+export function getPreferenceState(prefs: RecommendationPreferences, gameId: string): PreferenceState {
+  if (prefs.liked.includes(gameId)) return 'like';
+  if (prefs.disliked.includes(gameId)) return 'dislike';
+  return 'none';
+}
+
+const signalValue = (state: PreferenceState): number =>
+  state === 'like' ? 1 : state === 'dislike' ? -1 : 0;
+
+/**
+ * Move a game to a target preference state, adjusting the per-dimension weights
+ * by exactly the delta between the old and new state. This keeps the weight
+ * tallies correct under any transition (like→dislike applies a -2 swing, etc.).
+ */
+export function setPreference(
+  prefs: RecommendationPreferences,
+  game: Game,
+  target: PreferenceState
+): RecommendationPreferences {
+  const current = getPreferenceState(prefs, game.id);
+  if (current === target) return prefs;
+
+  const delta = signalValue(target) - signalValue(current);
+  const next: RecommendationPreferences = {
+    liked: prefs.liked.filter(id => id !== game.id),
+    disliked: prefs.disliked.filter(id => id !== game.id),
+    genreWeights: { ...prefs.genreWeights },
+    priceWeights: { ...prefs.priceWeights },
+    lengthWeights: { ...prefs.lengthWeights },
+  };
+
+  if (target === 'like') next.liked.push(game.id);
+  if (target === 'dislike') next.disliked.push(game.id);
+
+  if (game.genre) bump(next.genreWeights, game.genre, delta);
+  bump(next.priceWeights, getRecPriceBracket(game.price), delta);
+  bump(next.lengthWeights, getRecLengthBucket(game), delta);
+
+  return next;
+}
+
+function bump(map: Record<string, number>, key: string, delta: number): void {
+  const value = (map[key] || 0) + delta;
+  if (value === 0) delete map[key];
+  else map[key] = value;
+}
+
+function clone(prefs: RecommendationPreferences): RecommendationPreferences {
+  return {
+    liked: [...prefs.liked],
+    disliked: [...prefs.disliked],
+    genreWeights: { ...prefs.genreWeights },
+    priceWeights: { ...prefs.priceWeights },
+    lengthWeights: { ...prefs.lengthWeights },
+  };
+}

--- a/app/apps/game-analytics/lib/storage.ts
+++ b/app/apps/game-analytics/lib/storage.ts
@@ -11,6 +11,8 @@ import {
   setDoc,
   updateDoc,
   deleteDoc,
+  deleteField,
+  writeBatch,
   query,
   where,
   orderBy,
@@ -37,6 +39,19 @@ function cleanUndefinedValues<T>(obj: T): T {
     return cleaned as T;
   }
   return obj;
+}
+
+// Prepare a Firestore update payload. An explicit `undefined` on a field means
+// "clear this field" → translate to Firestore's deleteField() sentinel (plain
+// stripping would leave the old value in the document, which is exactly the bug
+// that made "remove from queue" a no-op for logged-in users). Defined values
+// still get their nested undefineds cleaned, since Firestore rejects those.
+function prepareFirestoreUpdate(updates: Record<string, unknown>): Record<string, unknown> {
+  const prepared: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(updates)) {
+    prepared[key] = value === undefined ? deleteField() : cleanUndefinedValues(value);
+  }
+  return prepared;
 }
 
 // Firebase Repository - filters by userId
@@ -96,14 +111,27 @@ export class FirebaseGameRepository implements GameRepository {
   async update(id: string, updates: Partial<Game>): Promise<Game> {
     const docRef = doc(this.db, COLLECTION_NAME, id);
 
-    // Clean undefined values recursively - Firestore doesn't accept them
-    const cleanUpdates = cleanUndefinedValues(updates) as Record<string, unknown>;
-    cleanUpdates.updatedAt = new Date().toISOString();
+    // undefined fields → deleteField(); defined fields get nested undefineds cleaned
+    const preparedUpdates = prepareFirestoreUpdate(updates as Record<string, unknown>);
+    preparedUpdates.updatedAt = new Date().toISOString();
 
-    await updateDoc(docRef, cleanUpdates);
+    await updateDoc(docRef, preparedUpdates);
 
     const updated = await getDoc(docRef);
     return updated.data() as Game;
+  }
+
+  async updateMany(updates: Array<{ id: string; changes: Partial<Game> }>): Promise<void> {
+    if (updates.length === 0) return;
+    const batch = writeBatch(this.db);
+    const now = new Date().toISOString();
+    for (const { id, changes } of updates) {
+      const ref = doc(this.db, COLLECTION_NAME, id);
+      const prepared = prepareFirestoreUpdate(changes as Record<string, unknown>);
+      prepared.updatedAt = now;
+      batch.update(ref, prepared);
+    }
+    await batch.commit();
   }
 
   async delete(id: string): Promise<void> {
@@ -165,6 +193,24 @@ export class LocalStorageGameRepository implements GameRepository {
     return games[index];
   }
 
+  async updateMany(updates: Array<{ id: string; changes: Partial<Game> }>): Promise<void> {
+    if (updates.length === 0) return;
+    // Single read-modify-write over the whole array. Doing these as parallel
+    // update() calls each re-reads the same stale snapshot and the last save()
+    // wins — which silently dropped queue position shifts.
+    const games = await this.getAll();
+    const now = new Date().toISOString();
+    const changeMap = new Map(updates.map(u => [u.id, u.changes]));
+    const next = games.map(g => {
+      const changes = changeMap.get(g.id);
+      if (!changes) return g;
+      // Spreading a key whose value is `undefined` sets it to undefined; JSON
+      // serialization then drops it, so "clear field" semantics hold locally too.
+      return { ...g, ...changes, id: g.id, createdAt: g.createdAt, updatedAt: now };
+    });
+    this.save(next);
+  }
+
   async delete(id: string): Promise<void> {
     const games = await this.getAll();
     const filtered = games.filter(g => g.id !== id);
@@ -210,6 +256,10 @@ class HybridGameRepository implements GameRepository {
 
   update(id: string, updates: Partial<Game>): Promise<Game> {
     return this.repo.update(id, updates);
+  }
+
+  updateMany(updates: Array<{ id: string; changes: Partial<Game> }>): Promise<void> {
+    return this.repo.updateMany(updates);
   }
 
   delete(id: string): Promise<void> {

--- a/app/apps/game-analytics/lib/types.ts
+++ b/app/apps/game-analytics/lib/types.ts
@@ -170,6 +170,14 @@ export interface GameRepository {
   getById(id: string): Promise<Game | null>;
   create(game: Omit<Game, 'id' | 'userId' | 'createdAt' | 'updatedAt'>): Promise<Game>;
   update(id: string, updates: Partial<Game>): Promise<Game>;
+  /**
+   * Apply several game updates atomically/in one persist. Critical for queue
+   * operations that shift multiple positions at once — running these as parallel
+   * single updates clobbers localStorage (each call rewrites the whole array from
+   * a stale snapshot) and is non-atomic on Firestore. A `changes` value of
+   * `undefined` clears that field (e.g. removing a game from the queue).
+   */
+  updateMany(updates: Array<{ id: string; changes: Partial<Game> }>): Promise<void>;
   delete(id: string): Promise<void>;
 }
 

--- a/app/apps/game-analytics/page.tsx
+++ b/app/apps/game-analytics/page.tsx
@@ -140,7 +140,7 @@ function getTopAwardBadge(awards: GameAward[]): { label: string; color: string; 
 export default function GameAnalyticsPage() {
   const { user, loading: authLoading } = useAuthContext();
   const { showToast } = useToast();
-  const { games, loading, error, addGame, updateGame, deleteGame, refresh } = useGames(user?.uid ?? null);
+  const { games, loading, error, addGame, updateGame, updateManyGames, deleteGame, refresh } = useGames(user?.uid ?? null);
   const { gamesWithMetrics, summary } = useAnalytics(games);
   const { budgets, setBudget } = useBudget(user?.uid ?? null);
   const { upcomingEntries, addEntry: addPurchaseEntry } = usePurchaseQueue(user?.uid ?? null);
@@ -185,10 +185,10 @@ export default function GameAnalyticsPage() {
     setHideFinished,
     addToQueue,
     removeFromQueue,
-    reorderQueue,
+    setQueueOrder,
     clearUpcoming,
     isInQueue,
-  } = useGameQueue(games, updateGame);
+  } = useGameQueue(games, updateManyGames);
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [editingGame, setEditingGame] = useState<GameWithMetrics | null>(null);
   const [playLogGame, setPlayLogGame] = useState<GameWithMetrics | null>(null);
@@ -1320,12 +1320,15 @@ export default function GameAnalyticsPage() {
 
           {tabMode === 'up-next' && (
             <UpNextTab
+              userId={user?.uid ?? null}
               queuedGames={queuedGames.map(game => {
                 const gameWithMetrics = gamesWithMetrics.find(g => g.id === game.id);
                 return gameWithMetrics || game as GameWithMetrics;
               })}
               availableGames={availableGames}
               allGames={games}
+              upcomingEntries={upcomingEntries}
+              onGoToEstimator={() => setTabMode('estimator')}
               hideFinished={hideFinished}
               onToggleHideFinished={() => setHideFinished(!hideFinished)}
               onAddToQueue={async (gameId) => {
@@ -1344,9 +1347,9 @@ export default function GameAnalyticsPage() {
                   showToast(`Failed to remove game: ${(e as Error).message}`, 'error');
                 }
               }}
-              onReorderQueue={async (gameId, newPosition) => {
+              onReorderQueue={async (orderedIds) => {
                 try {
-                  await reorderQueue(gameId, newPosition);
+                  await setQueueOrder(orderedIds);
                 } catch (e) {
                   showToast(`Failed to reorder queue: ${(e as Error).message}`, 'error');
                 }


### PR DESCRIPTION
Queue persistence fixes:
- Firebase update() now uses deleteField() for explicit undefined fields
  instead of stripping them, so removing a game from the queue actually
  persists for logged-in users (was a silent no-op that reappeared on reload).
- Add updateMany() to GameRepository (Firebase writeBatch / localStorage
  single read-modify-write) + updateManyGames() in useGames. Queue
  add/remove/reorder/clear now persist as one batch, fixing the localStorage
  clobber where parallel updates rewrote the array from a stale snapshot.
- Replace reorderQueue with setQueueOrder(orderedIds): drag-and-drop renumbers
  the whole queue from the displayed order, fixing the display-index vs stored
  queuePosition mismatch from floating finished games to the bottom.
- Queue card remove/log buttons always visible (drop desktop-hover gate).

Synergy + curation:
- Inline QueueTimelineStrip in Up Next: projected completion dates that reflow
  live on reorder, sharing the Estimator's buildPlaythroughTimeline and a
  shared weekly-pace control (same estimator-settings localStorage key).
- Gap banner in Up Next via detectGap against tracked Buy Queue releases.
- SuggestedNextRail: curatable suggestions with Add + thumbs up/down tuning.
  getPlayNextRecommendations now accepts learned RecommendationPreferences
  (hide disliked, boost liked, reweight genre/price/length). Prefs persist
  per-user in localStorage (queue-preferences.ts + useQueuePreferences.ts).
- Cross-link from Up Next strip to the Estimator tab.