### PR TITLE
Fix PS Plus drops not persisting for logged-in users

### DIFF
--- a/app/apps/game-analytics/hooks/useSubscriptionGames.ts
+++ b/app/apps/game-analytics/hooks/useSubscriptionGames.ts
@@ -73,6 +73,9 @@ export function useSubscriptionGames({ userId, games, onAddGame, onAddToQueue, o
       const all = await recommendationRepository.getAll();
       setRecs(all.filter(r => r.subscriptionService === SERVICE));
     } catch (e) {
+      // Don't let a load failure masquerade as "no data" — that's exactly what
+      // made backfilled drops look lost and forced a re-sync every visit.
+      console.error('[PS Plus] Failed to load saved recommendations:', e);
       setError(e instanceof Error ? e : new Error(String(e)));
     } finally {
       setLoading(false);

--- a/app/apps/game-analytics/lib/recommendation-storage.ts
+++ b/app/apps/game-analytics/lib/recommendation-storage.ts
@@ -13,7 +13,6 @@ import {
   deleteDoc,
   query,
   where,
-  orderBy,
 } from 'firebase/firestore';
 
 const STORAGE_KEY = 'game-analytics-recommendations';
@@ -46,9 +45,17 @@ class FirebaseRecommendationRepository implements RecommendationRepository {
 
   async getAll(): Promise<GameRecommendation[]> {
     if (!this.userId) return [];
-    const q = query(this.col, where('userId', '==', this.userId), orderBy('createdAt', 'desc'));
+    // Filter by userId only — do NOT add orderBy('createdAt') here. Combining an
+    // equality filter with an orderBy on a different field needs a composite
+    // Firestore index for `gameRecommendations`, which isn't deployed; without
+    // it the read throws and the caller silently ends up with an empty list
+    // (so backfilled PS Plus drops + triage decisions appeared lost on reload).
+    // Sort newest-first client-side instead — no index required.
+    const q = query(this.col, where('userId', '==', this.userId));
     const snapshot = await getDocs(q);
-    return snapshot.docs.map(d => d.data() as GameRecommendation);
+    return snapshot.docs
+      .map(d => d.data() as GameRecommendation)
+      .sort((a, b) => (b.createdAt || '').localeCompare(a.createdAt || ''));
   }
 
   async create(data: Omit<GameRecommendation, 'id' | 'userId' | 'createdAt' | 'updatedAt'>): Promise<GameRecommendation> {

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -37,6 +37,14 @@
         { "fieldPath": "userId", "order": "ASCENDING" },
         { "fieldPath": "winnerId", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "gameRecommendations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
The gameRecommendations read query combined where('userId') with
orderBy('createdAt'), which needs a composite Firestore index that was
never deployed. The read threw, refresh() swallowed it, and the loaded
list ended up empty — so backfilled PS Plus drops and triage decisions
looked lost on every reload, forcing a re-backfill and re-classify.

- recommendation-storage: drop the server-side orderBy, sort newest-first
  client-side (no index required, works on existing rules)
- firestore.indexes.json: add the gameRecommendations index as a safety net
- useSubscriptionGames: log the load error instead of hiding it as no-data

https://claude.ai/code/session_01V9S3BMrjx3PZqe84nnv6oo