### PR TITLE
Add DNF and Pick Up Later game states

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ This document provides comprehensive guidance for AI assistants working with the
 14. [Card Info Enhancements](#card-info-enhancements-approved)
 15. [Stats Overhaul Plan](#stats-overhaul-plan-approved)
 16. [Immersive Experience & Deep Insights Plan](#immersive-experience--deep-insights-plan-approved)
+17. [DNF & Pick Up Later States](#dnf--pick-up-later-states-approved)
 
 ---
 
@@ -2578,6 +2579,47 @@ fortune-fade           — Gentle fade-in for daily fortune cookie
 
 ---
 
+## DNF & Pick Up Later States (Approved)
+
+One new member added to `GameStatus`: `'Pick Up Later'`. `GameStatus` is now `'Not Started' | 'In Progress' | 'Completed' | 'Wishlist' | 'Abandoned' | 'Pick Up Later'`. Approved 2026-07-01.
+
+**Philosophy**: "DNF" (Did Not Finish) and "Abandoned" are the same concept — not two separate statuses. The underlying `GameStatus` value stays `'Abandoned'` (no data migration, no duplicated logic across the ~230 `calculations.ts` functions that already branch on it); the app just presents it to the user as **"DNF"** in the status picker and badges instead of the old "Dropped" label. `'Pick Up Later'`, by contrast, is a genuinely new, separate status — an intentional pause, distinct from actively `In Progress`.
+
+### Semantics
+
+| Status | Meaning |
+|--------|---------|
+| **Abandoned** (relabeled "DNF" in the UI, same value) | You gave up on it — whether you drifted away or made a deliberate call, it's the same bucket. |
+| **Pick Up Later** (new, separate status) | An intentional pause. You're not playing it right now, but you plan to come back — distinct from actively `In Progress` and distinct from `Abandoned`/DNF (no intent to resume there). |
+
+### Visual identity
+
+| Status | Label (GameForm pill) | Dot/badge color | Notes |
+|--------|------------------------|------------------|-------|
+| Abandoned | "DNF" (was "Dropped") | Red (unchanged) | Same status value/color as before, relabeled. |
+| Pick Up Later | "Pick Up Later" | Cyan/teal (`cyan-400` family) | Visually distinct from both "Playing" (blue) and "Backlog" (grey/white) — reads as "paused," not "new" or "stalled." |
+
+### Integration points
+
+- **Core type**: `lib/types.ts` `GameStatus` gains `'Pick Up Later'`. `AnalyticsSummary` gets `pickUpLaterCount`.
+- **Label-only change**: `components/GameForm.tsx` `STATUS_CONFIG` — Abandoned's `label` changes from `'Dropped'` to `'DNF'`. No other file needs an "Abandoned → DNF" change since the underlying value is untouched.
+- **Hardcoded enum arrays** (must move together): `lib/import-service.ts` `VALID_STATUSES`, `lib/ai-actions.ts` `GAME_STATUSES` (+ Gemini function-calling schemas), `lib/ai-service.ts` inline enum, `lib/coop-match.ts` `PLAYABLE_STATUSES` (Pick Up Later counts as shareable/playable-tonight).
+- **Status picker**: `components/GameForm.tsx` `handleStatusChange` — Pick Up Later does NOT stamp `endDate` (it's paused, not over) and keeps existing `startDate`.
+- **Badge/color maps**: `components/StatsView.tsx` & `components/GameCharts.tsx` `STATUS_COLORS`, `components/UpNextTab.tsx` badge map, `components/QueueGameCard.tsx` status icon/label/color switches, `components/PlayTonightModal.tsx` `StatusBadge` — all need a Pick Up Later entry (Abandoned entries already exist, just relabel display text where they render the word "Dropped"/"Abandoned" verbatim).
+- **`lib/calculations.ts` explicit branches needing a Pick Up Later case**: `getCardRarity`, `getRelationshipStatus` (new label joining the existing 15, e.g. "On Hold"), `getHeroNumber` (headline stat: days-paused), `getCardFreshness` (NOT exempt from aging — dust should still nudge a resume), `getGameSections` (own "Paused" section, doesn't join "The Graveyard"), `generateGameBiography` / `getGameVerdicts` (an "intermission" narrative voice), `getCompletionFunnel` / `getLibraryHealth`, `getShelfLifeExpiry`, `getGameHealthDot`, `getDaysContext`, `getGameSmartOneLiner`, `findShelfWarmers`, `getQueueShameData`, `getParallelUniverseImpact`. `generateGameEulogy` stays gated to `'Abandoned'` only (already covers DNF) — Pick Up Later never gets a eulogy, it's not over.
+- **`lib/trophy-calculations.ts`**: ~60 status filters — Pick Up Later generally follows Not Started/backlog treatment for trophy purposes (it's not actively contributing hours right now).
+- **`lib/timeline-estimator.ts`**: Pick Up Later skipped from active pace projections but can inform "resume" suggestions.
+- **`lib/award-categories.ts`**: no change needed — Abandoned-based nominee pools already cover DNF.
+- **`page.tsx` quick actions**: a "Pick Up Later" quick action added alongside the existing "Abandon"/DNF quick action (e.g. in Backlog Triage / card action row), so users don't have to open the full GameForm for the common case.
+
+### New calculation/type additions
+
+```
+AnalyticsSummary.pickUpLaterCount: number
+```
+
+---
+
 ## Resources
 
 - **Next.js Docs**: https://nextjs.org/docs
@@ -2589,6 +2631,11 @@ fortune-fade           — Gentle fade-in for daily fortune cookie
 ---
 
 ## Changelog
+
+### 2026-07-01 (v2.8.0)
+- Added DNF & Pick Up Later States plan (branch `claude/games-dnf-pickup-later-lk280b`)
+- **DNF**: relabeled the existing `'Abandoned'` status to display as "DNF" — same underlying value, no data migration, no new branching logic needed across `calculations.ts`/`trophy-calculations.ts`/`award-categories.ts` since they already handle `'Abandoned'`.
+- **Pick Up Later**: new, separate `GameStatus` value for an intentional pause (distinct from `In Progress`). Touches the status picker, badge/color maps, `AnalyticsSummary.pickUpLaterCount`, and the explicit status-branches in `calculations.ts` (rarity, relationship status, hero number, freshness, sections, biography/verdicts, shelf life expiry, health dot, etc.) and `trophy-calculations.ts`/`timeline-estimator.ts`.
 
 ### 2026-06-11 (v2.7.0)
 - **PS Plus monthly free games → Discover** (branch `claude/ps-plus-monthly-games-y5kis5`)
@@ -2665,6 +2712,6 @@ fortune-fade           — Gentle fade-in for daily fortune cookie
 
 ---
 
-**Last Updated**: 2026-02-21
-**Version**: 2.5.0
+**Last Updated**: 2026-07-01
+**Version**: 2.8.0
 **Maintained by**: AI assistants and contributors

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -790,9 +790,9 @@ const avgRating = totalRating / games.length;
 Before committing:
 - [ ] Run `npm run build` - Ensure no TypeScript errors
 - [ ] Run `npm run lint` - Ensure no linting errors
-- [ ] Test in browser - Verify functionality works
-- [ ] Check responsive design - Test mobile/tablet views
 - [ ] Review changes - Ensure no unintended modifications
+
+**Do not launch the dev server / drive the app in a browser (Playwright, etc.) unless the user explicitly asks for it.** `npm run build` + `npm run lint` passing is sufficient verification by default. Only do manual/browser testing when the user says to test, verify, or check something in the running app.
 
 ### Code Quality
 
@@ -845,7 +845,7 @@ Test these scenarios:
 
 3. **Type safety first**: Define types before implementing features.
 
-4. **Test locally**: Changes should work with `npm run build` and `npm run dev`.
+4. **Verify with build/lint, not the browser**: Changes should pass `npm run build` and `npm run lint`. Do not start `npm run dev` or drive the app with a browser/Playwright to "verify" a change unless the user explicitly asks for that — a clean build + lint is the default bar for calling work done.
 
 ### Common Pitfalls to Avoid
 

--- a/app/apps/game-analytics/components/BacklogTriageModal.tsx
+++ b/app/apps/game-analytics/components/BacklogTriageModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useMemo, useCallback } from 'react';
-import { X, Gamepad2, ListPlus, HeartCrack, Hourglass, Inbox, PartyPopper } from 'lucide-react';
+import { X, Gamepad2, ListPlus, HeartCrack, Hourglass, Inbox, PartyPopper, PauseCircle } from 'lucide-react';
 import { Game } from '../lib/types';
 import { GameWithMetrics } from '../hooks/useAnalytics';
 import { getBacklogTriageCandidates, TriageCandidate } from '../lib/calculations';
@@ -25,7 +25,7 @@ function writeSnoozed(map: Record<string, string>) {
   localStorage.setItem(SNOOZE_KEY, JSON.stringify(map));
 }
 
-type Decision = 'queued' | 'abandoned' | 'snoozed';
+type Decision = 'queued' | 'abandoned' | 'snoozed' | 'pickUpLater';
 
 interface BacklogTriageModalProps {
   games: Game[];
@@ -33,10 +33,11 @@ interface BacklogTriageModalProps {
   onClose: () => void;
   onQueue: (gameId: string) => Promise<void>;
   onAbandon: (gameId: string) => Promise<void>;
+  onPickUpLater: (gameId: string) => Promise<void>;
   onOpenGame: (game: GameWithMetrics) => void;
 }
 
-export function BacklogTriageModal({ games, gamesWithMetrics, onClose, onQueue, onAbandon, onOpenGame }: BacklogTriageModalProps) {
+export function BacklogTriageModal({ games, gamesWithMetrics, onClose, onQueue, onAbandon, onPickUpLater, onOpenGame }: BacklogTriageModalProps) {
   const [snoozed, setSnoozed] = useState<Record<string, string>>(() => readSnoozed());
   const [index, setIndex] = useState(0);
   const [busy, setBusy] = useState(false);
@@ -64,6 +65,8 @@ export function BacklogTriageModal({ games, gamesWithMetrics, onClose, onQueue, 
         await onQueue(current.game.id);
       } else if (decision === 'abandoned') {
         await onAbandon(current.game.id);
+      } else if (decision === 'pickUpLater') {
+        await onPickUpLater(current.game.id);
       } else {
         const next = { ...snoozed, [current.game.id]: new Date(Date.now() + SNOOZE_DAYS * 24 * 60 * 60 * 1000).toISOString() };
         writeSnoozed(next);
@@ -77,11 +80,12 @@ export function BacklogTriageModal({ games, gamesWithMetrics, onClose, onQueue, 
         setBusy(false);
       }, 220);
     }
-  }, [current, busy, onQueue, onAbandon, snoozed]);
+  }, [current, busy, onQueue, onAbandon, onPickUpLater, snoozed]);
 
   const queuedCount = tally.filter(t => t.decision === 'queued').length;
   const abandonedCount = tally.filter(t => t.decision === 'abandoned').length;
   const snoozedCount = tally.filter(t => t.decision === 'snoozed').length;
+  const pickUpLaterCount = tally.filter(t => t.decision === 'pickUpLater').length;
   const hoursDecided = tally.reduce((sum, t) => sum + t.candidate.totalHours, 0);
   const moneyDecided = tally
     .filter(t => t.decision !== 'snoozed')
@@ -111,10 +115,14 @@ export function BacklogTriageModal({ games, gamesWithMetrics, onClose, onQueue, 
             <PartyPopper size={32} className="mx-auto mb-3 text-purple-400" />
             <p className="text-base text-white font-semibold mb-1">Triage complete</p>
             <p className="text-xs text-white/40 mb-5">You made a call on {tally.length} game{tally.length === 1 ? '' : 's'}.</p>
-            <div className="grid grid-cols-3 gap-2 mb-5">
+            <div className="grid grid-cols-4 gap-2 mb-5">
               <div className="bg-white/5 rounded-lg p-3">
                 <div className="text-lg font-bold text-purple-300">{queuedCount}</div>
                 <div className="text-[10px] text-white/40 mt-0.5">Queued</div>
+              </div>
+              <div className="bg-white/5 rounded-lg p-3">
+                <div className="text-lg font-bold text-cyan-300">{pickUpLaterCount}</div>
+                <div className="text-[10px] text-white/40 mt-0.5">Paused</div>
               </div>
               <div className="bg-white/5 rounded-lg p-3">
                 <div className="text-lg font-bold text-rose-300">{abandonedCount}</div>
@@ -186,7 +194,7 @@ export function BacklogTriageModal({ games, gamesWithMetrics, onClose, onQueue, 
               )}
             </button>
 
-            <div className="grid grid-cols-3 gap-2">
+            <div className="grid grid-cols-4 gap-2">
               <button
                 onClick={() => act('abandoned', 'left')}
                 disabled={busy}
@@ -194,6 +202,14 @@ export function BacklogTriageModal({ games, gamesWithMetrics, onClose, onQueue, 
               >
                 <HeartCrack size={18} />
                 <span className="text-[11px] font-medium">Let it go</span>
+              </button>
+              <button
+                onClick={() => act('pickUpLater', 'up')}
+                disabled={busy}
+                className="flex flex-col items-center gap-1.5 py-3 rounded-xl bg-cyan-500/10 text-cyan-300 hover:bg-cyan-500/20 active:scale-95 transition-all disabled:opacity-40"
+              >
+                <PauseCircle size={18} />
+                <span className="text-[11px] font-medium">Pause it</span>
               </button>
               <button
                 onClick={() => act('snoozed', 'up')}

--- a/app/apps/game-analytics/components/GameBottomSheet.tsx
+++ b/app/apps/game-analytics/components/GameBottomSheet.tsx
@@ -541,7 +541,7 @@ export function GameBottomSheet({
           )}
 
           {/* Completion Probability */}
-          {(game.status === 'In Progress' || game.status === 'Not Started') && (
+          {(game.status === 'In Progress' || game.status === 'Not Started' || game.status === 'Pick Up Later') && (
             <div className="mx-5 mb-4 p-4 bg-white/[0.03] rounded-xl border border-white/5">
               <div className="flex items-center justify-between mb-3">
                 <span className="text-sm font-medium text-white/70">Completion Odds</span>

--- a/app/apps/game-analytics/components/GameCharts.tsx
+++ b/app/apps/game-analytics/components/GameCharts.tsx
@@ -28,6 +28,7 @@ const STATUS_COLORS: Record<GameStatus, string> = {
   'Not Started': '#6b7280',
   'Wishlist': '#a855f7',
   'Abandoned': '#ef4444',
+  'Pick Up Later': '#22d3ee',
 };
 
 const CHART_COLORS = ['#8b5cf6', '#06b6d4', '#10b981', '#f59e0b', '#ef4444', '#ec4899'];

--- a/app/apps/game-analytics/components/GameCompareModal.tsx
+++ b/app/apps/game-analytics/components/GameCompareModal.tsx
@@ -271,7 +271,7 @@ export function GameCompareModal({ game1, allGames, onClose }: Props) {
                       <div className="min-w-0 flex-1">
                         <p className="text-sm font-medium text-white/90 truncate">{g.name}</p>
                         <p className="text-[10px] text-white/35">
-                          {g.status} · {g.totalHours > 0 ? `${g.totalHours.toFixed(1)}h` : 'unplayed'}
+                          {g.status === 'Abandoned' ? 'DNF' : g.status} · {g.totalHours > 0 ? `${g.totalHours.toFixed(1)}h` : 'unplayed'}
                           {g.rating > 0 && ` · ${g.rating}/10`}
                         </p>
                       </div>

--- a/app/apps/game-analytics/components/GameForm.tsx
+++ b/app/apps/game-analytics/components/GameForm.tsx
@@ -25,9 +25,10 @@ const SUBSCRIPTION_SOURCES: SubscriptionSource[] = ['PS Plus', 'Game Pass', 'Epi
 const STATUS_CONFIG: { status: GameStatus; label: string; dotClass: string; activeClass: string }[] = [
   { status: 'Not Started', label: 'Backlog', dotClass: 'bg-white/40', activeClass: 'bg-white/10 text-white/80 ring-1 ring-white/20' },
   { status: 'In Progress', label: 'Playing', dotClass: 'bg-blue-400', activeClass: 'bg-blue-500/20 text-blue-400 ring-1 ring-blue-500/50' },
+  { status: 'Pick Up Later', label: 'Pick Up Later', dotClass: 'bg-cyan-400', activeClass: 'bg-cyan-500/20 text-cyan-400 ring-1 ring-cyan-500/50' },
   { status: 'Completed', label: 'Done', dotClass: 'bg-emerald-400', activeClass: 'bg-emerald-500/20 text-emerald-400 ring-1 ring-emerald-500/50' },
   { status: 'Wishlist', label: 'Wishlist', dotClass: 'bg-purple-400', activeClass: 'bg-purple-500/20 text-purple-400 ring-1 ring-purple-500/50' },
-  { status: 'Abandoned', label: 'Dropped', dotClass: 'bg-red-400', activeClass: 'bg-red-500/20 text-red-400 ring-1 ring-red-500/50' },
+  { status: 'Abandoned', label: 'DNF', dotClass: 'bg-red-400', activeClass: 'bg-red-500/20 text-red-400 ring-1 ring-red-500/50' },
 ];
 
 const RATING_LABELS: Record<number, string> = {
@@ -179,7 +180,8 @@ export function GameForm({ onSubmit, onClose, initialGame, allGames = [], existi
   const valueRating = getValueRating(costPerHour);
 
   const isOwned = formData.status !== 'Wishlist';
-  const showPlayDates = isOwned && (formData.status === 'In Progress' || formData.status === 'Completed' || formData.status === 'Abandoned');
+  const showPlayDates = isOwned && (formData.status === 'In Progress' || formData.status === 'Completed' || formData.status === 'Abandoned' || formData.status === 'Pick Up Later');
+  const showEndDate = showPlayDates && formData.status !== 'Pick Up Later';
   const showRating = formData.status !== 'Not Started' && formData.status !== 'Wishlist';
 
   const budgetImpact = useMemo(() => {
@@ -699,10 +701,10 @@ export function GameForm({ onSubmit, onClose, initialGame, allGames = [], existi
                     </div>
                   )}
                 </div>
-                {showPlayDates && (
+                {showEndDate && (
                   <div>
                     <label className="block text-xs font-medium text-white/50 mb-1.5">
-                      {formData.status === 'Abandoned' ? 'Dropped' : 'Finished'}
+                      {formData.status === 'Abandoned' ? 'Dropped (DNF)' : 'Finished'}
                     </label>
                     <input
                       type="date"

--- a/app/apps/game-analytics/components/GlobalCommandPalette.tsx
+++ b/app/apps/game-analytics/components/GlobalCommandPalette.tsx
@@ -298,7 +298,7 @@ function GameRow({ game, active, onHover, onClick }: { game: GameWithMetrics; ac
       )}
       <span className="flex-1 min-w-0">
         <span className="block text-[13px] text-white/85 truncate">{game.name}</span>
-        <span className="block text-[11px] text-white/35 truncate">{game.status}{game.genre ? ` · ${game.genre}` : ''}</span>
+        <span className="block text-[11px] text-white/35 truncate">{game.status === 'Abandoned' ? 'DNF' : game.status}{game.genre ? ` · ${game.genre}` : ''}</span>
       </span>
     </button>
   );

--- a/app/apps/game-analytics/components/PlayTonightModal.tsx
+++ b/app/apps/game-analytics/components/PlayTonightModal.tsx
@@ -76,6 +76,8 @@ function scoreGame(
 
   // In-progress bonus
   if (game.status === 'In Progress') score += 14;
+  // Pick Up Later bonus — you already decided you want to come back to this one
+  if (game.status === 'Pick Up Later') score += 18;
 
   // Recency shaping
   if (logs.length > 0) {
@@ -106,6 +108,8 @@ function scoreGame(
     } else {
       reason = 'In progress — good time to continue';
     }
+  } else if (game.status === 'Pick Up Later') {
+    reason = 'You paused this one on purpose — tonight could be the night';
   } else if (chemistry.topFactor === 'freshness') {
     reason = 'Untouched — full new-game energy';
   } else if (chemistry.topFactor === 'craving') {
@@ -387,6 +391,14 @@ function StatusBadge({ status }: { status: string }) {
       <span className="flex items-center gap-1 text-[10px] font-medium text-blue-400 bg-blue-500/10 px-2 py-0.5 rounded-full">
         <Star size={9} />
         Fresh Start
+      </span>
+    );
+  }
+  if (status === 'Pick Up Later') {
+    return (
+      <span className="flex items-center gap-1 text-[10px] font-medium text-cyan-400 bg-cyan-500/10 px-2 py-0.5 rounded-full">
+        <Zap size={9} />
+        Resume It
       </span>
     );
   }

--- a/app/apps/game-analytics/components/QueueGameCard.tsx
+++ b/app/apps/game-analytics/components/QueueGameCard.tsx
@@ -2,7 +2,7 @@
 
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { GripVertical, X, CheckCircle2, PlayCircle, Calendar, XCircle, Clock, TrendingDown, Zap, Play } from 'lucide-react';
+import { GripVertical, X, CheckCircle2, PlayCircle, Calendar, XCircle, Clock, TrendingDown, Zap, Play, PauseCircle } from 'lucide-react';
 import { GameWithMetrics } from '../hooks/useAnalytics';
 import { getShelfLife, getOneHourProjection, parseLocalDate, getGameChemistry, getQueueShameData } from '../lib/calculations';
 import { Game } from '../lib/types';
@@ -89,6 +89,7 @@ export function QueueGameCard({
       case 'Completed': return <CheckCircle2 size={isHero ? 16 : 14} className="text-emerald-400" />;
       case 'In Progress': return <PlayCircle size={isHero ? 16 : 14} className="text-blue-400" />;
       case 'Abandoned': return <XCircle size={isHero ? 16 : 14} className="text-red-400" />;
+      case 'Pick Up Later': return <PauseCircle size={isHero ? 16 : 14} className="text-cyan-400" />;
       default: return <Calendar size={isHero ? 16 : 14} className="text-white/30" />;
     }
   };
@@ -97,7 +98,8 @@ export function QueueGameCard({
     switch (game.status) {
       case 'Completed': return 'Completed';
       case 'In Progress': return 'Playing';
-      case 'Abandoned': return 'Abandoned';
+      case 'Abandoned': return 'DNF';
+      case 'Pick Up Later': return 'Pick Up Later';
       default: return 'Upcoming';
     }
   };
@@ -107,6 +109,7 @@ export function QueueGameCard({
       case 'Completed': return 'text-emerald-400';
       case 'In Progress': return 'text-blue-400';
       case 'Abandoned': return 'text-red-400';
+      case 'Pick Up Later': return 'text-cyan-400';
       default: return 'text-white/30';
     }
   };

--- a/app/apps/game-analytics/components/QueueGameCard.tsx
+++ b/app/apps/game-analytics/components/QueueGameCard.tsx
@@ -253,8 +253,8 @@ export function QueueGameCard({
     );
   }
 
-  // ===== STANDARD CARD (Completed, Not Started, Wishlist, Abandoned) =====
-  const canStart = game.status === 'Not Started' || game.status === 'Wishlist';
+  // ===== STANDARD CARD (Completed, Not Started, Wishlist, Abandoned, Pick Up Later) =====
+  const canStart = game.status !== 'In Progress';
 
   return (
     <div

--- a/app/apps/game-analytics/components/ReviewNudgeBanner.tsx
+++ b/app/apps/game-analytics/components/ReviewNudgeBanner.tsx
@@ -21,7 +21,7 @@ const reasonStyle: Record<ReviewNudgeReason, { bg: string; text: string; border:
   'just-finished':        { bg: 'from-emerald-500/10 to-teal-500/10',  text: 'text-emerald-300', border: 'border-emerald-500/20', label: 'Just finished' },
   'special-unreviewed':   { bg: 'from-yellow-500/10 to-amber-500/10',  text: 'text-amber-300',   border: 'border-amber-500/20',   label: 'One of your specials' },
   'completed-unreviewed': { bg: 'from-blue-500/10 to-indigo-500/10',   text: 'text-blue-300',    border: 'border-blue-500/20',    label: 'Completed' },
-  'farewell':             { bg: 'from-purple-500/10 to-fuchsia-500/10', text: 'text-purple-300',  border: 'border-purple-500/20',  label: 'Abandoned' },
+  'farewell':             { bg: 'from-purple-500/10 to-fuchsia-500/10', text: 'text-purple-300',  border: 'border-purple-500/20',  label: 'DNF' },
   'rated-no-words':       { bg: 'from-pink-500/10 to-rose-500/10',     text: 'text-pink-300',    border: 'border-pink-500/20',    label: 'Rated, not reviewed' },
   'invested-no-words':    { bg: 'from-cyan-500/10 to-sky-500/10',      text: 'text-cyan-300',    border: 'border-cyan-500/20',    label: 'Hours invested' },
 };

--- a/app/apps/game-analytics/components/StatsView.tsx
+++ b/app/apps/game-analytics/components/StatsView.tsx
@@ -92,6 +92,7 @@ const STATUS_COLORS: Record<GameStatus, string> = {
   'Not Started': '#6b7280',
   'Wishlist': '#a855f7',
   'Abandoned': '#ef4444',
+  'Pick Up Later': '#22d3ee',
 };
 
 const CHART_COLORS = ['#8b5cf6', '#06b6d4', '#10b981', '#f59e0b', '#ef4444', '#ec4899', '#3b82f6', '#84cc16'];
@@ -796,8 +797,9 @@ export function StatsView({ games, summary, budgets = [], onSetBudget, trophies,
                           'bg-blue-500/20 text-blue-400': game.status === 'In Progress',
                           'bg-white/10 text-white/50': game.status === 'Not Started',
                           'bg-red-500/20 text-red-400': game.status === 'Abandoned',
+                          'bg-cyan-500/20 text-cyan-400': game.status === 'Pick Up Later',
                         })}>
-                          {game.status}
+                          {game.status === 'Abandoned' ? 'DNF' : game.status}
                         </span>
                       </div>
                       {game.playLogs && game.playLogs.length > 0 && (

--- a/app/apps/game-analytics/components/TimelineView.tsx
+++ b/app/apps/game-analytics/components/TimelineView.tsx
@@ -293,7 +293,7 @@ export function TimelineView({ games, gamesWithMetrics, updateGame, onLogTime, o
         const totalH = getTotalHours(event.game);
         return `Completed — ${totalH}h total`;
       }
-      case 'abandon': return 'Abandoned';
+      case 'abandon': return 'DNF';
       case 'milestone': return event.milestoneDescription || '';
     }
   };

--- a/app/apps/game-analytics/components/UpNextTab.tsx
+++ b/app/apps/game-analytics/components/UpNextTab.tsx
@@ -636,9 +636,10 @@ export function UpNextTab({
                         game.status === 'In Progress' && 'bg-blue-500/20 text-blue-400',
                         game.status === 'Not Started' && 'bg-white/10 text-white/50',
                         game.status === 'Wishlist' && 'bg-purple-500/20 text-purple-400',
-                        game.status === 'Abandoned' && 'bg-red-500/20 text-red-400'
+                        game.status === 'Abandoned' && 'bg-red-500/20 text-red-400',
+                        game.status === 'Pick Up Later' && 'bg-cyan-500/20 text-cyan-400'
                       )}>
-                        {game.status === 'Not Started' ? 'Backlog' : game.status}
+                        {game.status === 'Not Started' ? 'Backlog' : game.status === 'Abandoned' ? 'DNF' : game.status}
                       </span>
                     </div>
                   </div>

--- a/app/apps/game-analytics/components/YearAwardsModal.tsx
+++ b/app/apps/game-analytics/components/YearAwardsModal.tsx
@@ -101,9 +101,9 @@ export function YearAwardsModal({ year, allGames, rawGames, updateGame, onClose 
     .filter(g => bestSessionInYear(g, year) > 0)
     .sort((a, b) => bestSessionInYear(b, year) - bestSessionInYear(a, year));
 
-  // "One That Got Away" — abandoned or high-playtime neglected games
+  // "One That Got Away" — abandoned/paused or high-playtime neglected games
   const gotAway = allGames
-    .filter(g => g.status === 'Abandoned' || (g.status === 'In Progress' && hoursInYear(g, year) === 0 && (g.playLogs || []).length > 0))
+    .filter(g => g.status === 'Abandoned' || g.status === 'Pick Up Later' || (g.status === 'In Progress' && hoursInYear(g, year) === 0 && (g.playLogs || []).length > 0))
     .sort((a, b) => (b.playLogs || []).reduce((s, l) => s + l.hours, 0) - (a.playLogs || []).reduce((s, l) => s + l.hours, 0));
 
   const categories: AwardCategoryDef[] = [
@@ -162,7 +162,7 @@ export function YearAwardsModal({ year, allGames, rawGames, updateGame, onClose 
       icon: '👻',
       description: 'A game you wish you\'d spent more time on. The one that haunts you.',
       nominees: (gotAway.length > 0 ? gotAway : allGames.filter(g => g.status === 'In Progress')).slice(0, 6)
-        .map(g => toNominee(g, g.status === 'Abandoned' ? `Abandoned after ${(g.playLogs || []).reduce((s, l) => s + l.hours, 0).toFixed(1)}h` : `Still unfinished · ${hoursInYear(g, year).toFixed(1)}h this year`)),
+        .map(g => toNominee(g, g.status === 'Abandoned' ? `DNF after ${(g.playLogs || []).reduce((s, l) => s + l.hours, 0).toFixed(1)}h` : g.status === 'Pick Up Later' ? `Paused after ${(g.playLogs || []).reduce((s, l) => s + l.hours, 0).toFixed(1)}h` : `Still unfinished · ${hoursInYear(g, year).toFixed(1)}h this year`)),
     },
     {
       id: 'legacy',

--- a/app/apps/game-analytics/components/story-screens/QuarterInNumbersScreen.tsx
+++ b/app/apps/game-analytics/components/story-screens/QuarterInNumbersScreen.tsx
@@ -14,7 +14,7 @@ export function QuarterInNumbersScreen({ data }: Props) {
     { label: 'Days Active', value: `${data.daysActive}`, icon: <Zap size={24} />, color: 'text-yellow-400', bg: 'from-yellow-500/25 to-yellow-600/10', delay: 0.4 },
     { label: 'Total Spent', value: `$${data.totalSpent.toFixed(0)}`, icon: <DollarSign size={24} />, color: 'text-emerald-400', bg: 'from-emerald-500/25 to-emerald-600/10', delay: 0.5 },
     { label: 'Completed', value: `${data.completedGames.length}`, icon: <Trophy size={24} />, color: 'text-orange-400', bg: 'from-orange-500/25 to-orange-600/10', delay: 0.6 },
-    { label: 'Abandoned', value: `${data.abandonedGames.length}`, icon: <XCircle size={24} />, color: 'text-red-400', bg: 'from-red-500/25 to-red-600/10', delay: 0.7 },
+    { label: 'DNF', value: `${data.abandonedGames.length}`, icon: <XCircle size={24} />, color: 'text-red-400', bg: 'from-red-500/25 to-red-600/10', delay: 0.7 },
     { label: 'Avg Session', value: `${data.avgSessionLength.toFixed(1)}h`, icon: <Star size={24} />, color: 'text-pink-400', bg: 'from-pink-500/25 to-pink-600/10', delay: 0.8 },
   ];
 

--- a/app/apps/game-analytics/lib/ai-actions.ts
+++ b/app/apps/game-analytics/lib/ai-actions.ts
@@ -31,7 +31,7 @@ import {
 // ── Constants shared with the schema ─────────────────────────────────────────
 
 export const GAME_STATUSES: GameStatus[] = [
-  'Not Started', 'In Progress', 'Completed', 'Wishlist', 'Abandoned',
+  'Not Started', 'In Progress', 'Completed', 'Wishlist', 'Abandoned', 'Pick Up Later',
 ];
 const SESSION_MOODS: SessionMood[] = ['great', 'good', 'meh', 'grind'];
 const SESSION_VIBES: SessionVibe[] = [

--- a/app/apps/game-analytics/lib/ai-service.ts
+++ b/app/apps/game-analytics/lib/ai-service.ts
@@ -842,7 +842,7 @@ const READ_FUNCTION_DECLARATIONS: FunctionDeclaration[] = [
       properties: {
         query: Schema.string({ description: 'Partial or full game name to match. Omit to list everything.' }),
         status: Schema.enumString({
-          enum: ['Not Started', 'In Progress', 'Completed', 'Wishlist', 'Abandoned'],
+          enum: ['Not Started', 'In Progress', 'Completed', 'Wishlist', 'Abandoned', 'Pick Up Later'],
           description: 'Optional status filter',
         }),
       },

--- a/app/apps/game-analytics/lib/award-categories.ts
+++ b/app/apps/game-analytics/lib/award-categories.ts
@@ -324,7 +324,7 @@ export function buildYearCategories(
 
   // One that got away
   const gotAway = allGames
-    .filter(g => g.status === 'Abandoned' || (g.status === 'In Progress' && hoursInYear(g, year) === 0 && (g.playLogs || []).length > 0))
+    .filter(g => g.status === 'Abandoned' || g.status === 'Pick Up Later' || (g.status === 'In Progress' && hoursInYear(g, year) === 0 && (g.playLogs || []).length > 0))
     .sort((a, b) => (b.playLogs || []).reduce((s, l) => s + l.hours, 0) - (a.playLogs || []).reduce((s, l) => s + l.hours, 0));
 
   return [
@@ -334,7 +334,7 @@ export function buildYearCategories(
     { id: 'endurance', label: 'The Endurance Award', icon: '⏳', description: 'Most committed. Most hours. The long haul game.', nominees: byHours.slice(0, 6).map(g => toNominee(g, `${hoursInYear(g, year).toFixed(1)}h in ${year}`)) },
     { id: 'best_investment', label: 'Best Investment', icon: '💰', description: 'Best value for money — the most per dollar.', nominees: (bestValue.length > 0 ? bestValue : byHours).slice(0, 6).map(g => { const cph = g.price > 0 ? g.price / hoursInYear(g, year) : 0; return toNominee(g, cph > 0 ? `$${cph.toFixed(2)}/hr · $${g.price} for ${hoursInYear(g, year).toFixed(1)}h` : `${hoursInYear(g, year).toFixed(1)}h · free`); }) },
     { id: 'session_of_year', label: 'Session of the Year', icon: '⚡', description: 'The game that hosted your single greatest gaming moment.', nominees: (sessionChamps.length > 0 ? sessionChamps : byHours).slice(0, 6).map(g => toNominee(g, `Best session: ${bestSessionInYear(g, year).toFixed(1)}h`)) },
-    { id: 'one_that_got_away', label: 'The One That Got Away', icon: '👻', description: "A game you wish you'd spent more time on.", nominees: (gotAway.length > 0 ? gotAway : allGames.filter(g => g.status === 'In Progress')).slice(0, 6).map(g => toNominee(g, g.status === 'Abandoned' ? `Abandoned after ${(g.playLogs || []).reduce((s, l) => s + l.hours, 0).toFixed(1)}h` : `Still unfinished`)) },
+    { id: 'one_that_got_away', label: 'The One That Got Away', icon: '👻', description: "A game you wish you'd spent more time on.", nominees: (gotAway.length > 0 ? gotAway : allGames.filter(g => g.status === 'In Progress')).slice(0, 6).map(g => toNominee(g, g.status === 'Abandoned' ? `Abandoned after ${(g.playLogs || []).reduce((s, l) => s + l.hours, 0).toFixed(1)}h` : g.status === 'Pick Up Later' ? `Paused after ${(g.playLogs || []).reduce((s, l) => s + l.hours, 0).toFixed(1)}h` : `Still unfinished`)) },
     { id: 'legacy', label: 'The Legacy', icon: '🌟', description: 'The game that changed how you think about gaming.', nominees: byHours.slice(0, 8).map(g => toNominee(g)) },
     { id: 'ai_choice', label: 'AI Choice Award', icon: '🤖', description: "The AI's surprising pick you might not have expected.", nominees: byHours.slice(0, 6).map(g => toNominee(g)), isAICategory: true },
   ];

--- a/app/apps/game-analytics/lib/calculations.ts
+++ b/app/apps/game-analytics/lib/calculations.ts
@@ -113,6 +113,7 @@ export function calculateSummary(games: Game[]): AnalyticsSummary {
   const inProgressGames = ownedGames.filter(g => g.status === 'In Progress');
   const notStartedGames = ownedGames.filter(g => g.status === 'Not Started');
   const abandonedGames = ownedGames.filter(g => g.status === 'Abandoned');
+  const pickUpLaterGames = ownedGames.filter(g => g.status === 'Pick Up Later');
   const playedGames = ownedGames.filter(g => getTotalHours(g) > 0);
 
   // Financial calculations
@@ -271,6 +272,7 @@ export function calculateSummary(games: Game[]): AnalyticsSummary {
     inProgressCount: inProgressGames.length,
     notStartedCount: notStartedGames.length,
     abandonedCount: abandonedGames.length,
+    pickUpLaterCount: pickUpLaterGames.length,
 
     // Financial
     totalSpent,
@@ -4950,7 +4952,10 @@ export function getGameHealthDot(game: Game): GameHealthDot {
     return { level: 'none', color: '#10b981', label: 'Completed', daysSinceLastPlay: -1 };
   }
   if (game.status === 'Abandoned') {
-    return { level: 'cold', color: '#ef4444', label: 'Abandoned', daysSinceLastPlay: -1 };
+    return { level: 'cold', color: '#ef4444', label: 'DNF', daysSinceLastPlay: -1 };
+  }
+  if (game.status === 'Pick Up Later') {
+    return { level: 'dormant', color: '#22d3ee', label: 'Paused', daysSinceLastPlay: -1 };
   }
 
   const logs = game.playLogs || [];
@@ -5030,6 +5035,18 @@ export function getDaysContext(game: Game): string {
       return `Playing for ${days} days`;
     }
     return 'In Progress';
+  }
+
+  if (game.status === 'Pick Up Later') {
+    const logs = game.playLogs || [];
+    if (logs.length > 0) {
+      const sorted = [...logs].sort((a, b) => parseLocalDate(b.date).getTime() - parseLocalDate(a.date).getTime());
+      const days = Math.floor((now - parseLocalDate(sorted[0].date).getTime()) / (24 * 60 * 60 * 1000));
+      if (days === 0) return 'Paused today';
+      if (days === 1) return 'Paused since yesterday';
+      return `Paused for ${days} days`;
+    }
+    return 'Pick up later';
   }
 
   if (game.status === 'Not Started') {
@@ -5218,6 +5235,9 @@ export function getGameSmartOneLiner(game: Game, allGames: Game[]): string {
   }
   if (game.status === 'Not Started') {
     return 'Waiting patiently in the backlog';
+  }
+  if (game.status === 'Pick Up Later' && totalHours > 0) {
+    return `${totalHours}h in, paused on purpose — pick it back up whenever`;
   }
 
   return '';
@@ -6743,6 +6763,7 @@ export function getCardRarity(game: Game): CardRarity {
   let completionScore = 0;
   if (game.status === 'Completed') completionScore = 10;
   else if (game.status === 'In Progress') completionScore = 5;
+  else if (game.status === 'Pick Up Later') completionScore = 3;
 
   const score = Math.round(ratingScore + valueScore + hoursScore + completionScore);
 
@@ -6872,6 +6893,16 @@ export function getRelationshipStatus(game: Game, allGames: Game[]): Relationshi
     return { label: "It's Complicated", color: '#a855f7', bgColor: 'rgba(168,85,247,0.15)', cardTint: 'rgba(168,85,247,0.03)' };
   }
 
+  // The Long Pause: paused for 60+ days
+  if (game.status === 'Pick Up Later' && daysSinceLastPlay >= 60) {
+    return { label: 'The Long Pause', color: '#0891b2', bgColor: 'rgba(8,145,178,0.15)', cardTint: 'rgba(8,145,178,0.03)' };
+  }
+
+  // On Hold (generic Pick Up Later)
+  if (game.status === 'Pick Up Later') {
+    return { label: 'On Hold', color: '#22d3ee', bgColor: 'rgba(34,211,238,0.15)', cardTint: 'rgba(34,211,238,0.03)' };
+  }
+
   // Buyer's Remorse: paid $40+, under 2 hours, no session in 30+ days
   if (game.price >= 40 && totalHours < 2 && (daysSinceLastPlay > 30 || (logs.length === 0 && daysSincePurchase > 30)) && game.status !== 'Wishlist') {
     return { label: "Buyer's Remorse", color: '#ef4444', bgColor: 'rgba(239,68,68,0.15)', cardTint: 'rgba(239,68,68,0.03)' };
@@ -6882,9 +6913,9 @@ export function getRelationshipStatus(game: Game, allGames: Game[]): Relationshi
     return { label: 'Ghosted', color: '#6b7280', bgColor: 'rgba(107,114,128,0.15)', cardTint: 'rgba(107,114,128,0.03)' };
   }
 
-  // Abandoned (generic)
+  // Abandoned/DNF (generic)
   if (game.status === 'Abandoned') {
-    return { label: 'Abandoned', color: '#ef4444', bgColor: 'rgba(239,68,68,0.15)', cardTint: 'rgba(239,68,68,0.02)' };
+    return { label: 'DNF', color: '#ef4444', bgColor: 'rgba(239,68,68,0.15)', cardTint: 'rgba(239,68,68,0.02)' };
   }
 
   // The One That Got Away: wishlist 60+ days
@@ -7033,6 +7064,21 @@ export function getHeroNumber(game: Game): HeroNumber {
     };
   }
 
+  if (game.status === 'Pick Up Later') {
+    const logs = game.playLogs || [];
+    const sorted = logs.length > 0
+      ? [...logs].sort((a, b) => parseLocalDate(b.date).getTime() - parseLocalDate(a.date).getTime())
+      : [];
+    const daysSince = sorted.length > 0
+      ? Math.floor((Date.now() - parseLocalDate(sorted[0].date).getTime()) / (24 * 60 * 60 * 1000))
+      : 0;
+    return {
+      value: `${daysSince}d`,
+      label: 'paused',
+      color: '#22d3ee',
+    };
+  }
+
   return { value: '-', label: '', color: '#6b7280' };
 }
 
@@ -7121,6 +7167,17 @@ export function getGameSections(games: Game[]): GameSection[] {
       label: 'Cooling Off',
       insight: `${coolingFiltered.length} game${coolingFiltered.length > 1 ? 's' : ''} losing momentum`,
       gameIds: coolingFiltered.map(g => g.id),
+    });
+  }
+
+  // Paused: intentionally on hold (Pick Up Later)
+  const paused = games.filter(g => g.status === 'Pick Up Later');
+  if (paused.length > 0) {
+    sections.push({
+      id: 'paused',
+      label: 'Paused',
+      insight: `${paused.length} game${paused.length > 1 ? 's' : ''} on hold, waiting to be picked back up`,
+      gameIds: paused.map(g => g.id),
     });
   }
 
@@ -7258,6 +7315,8 @@ export function generateGameBiography(game: Game, allGames: Game[]): string {
     } else {
       parts.push(`Shelved after ${totalHours}h. Sometimes things just don't click.`);
     }
+  } else if (game.status === 'Pick Up Later') {
+    parts.push(`Currently on an intermission after ${totalHours}h — paused on purpose, not given up on.`);
   }
 
   // Value context
@@ -11399,7 +11458,7 @@ export interface QueueShameData {
 export function getQueueShameData(game: Game, allGames: Game[]): QueueShameData | null {
   // Only applies to queued (Not Started / Wishlist) games with a queue position
   if (game.queuePosition == null) return null;
-  if (game.status === 'In Progress' || game.status === 'Completed' || game.status === 'Abandoned') return null;
+  if (game.status === 'In Progress' || game.status === 'Completed' || game.status === 'Abandoned' || game.status === 'Pick Up Later') return null;
 
   // Use datePurchased or createdAt as when it was added
   const addedDate = parseLocalDate(game.datePurchased || game.createdAt);

--- a/app/apps/game-analytics/lib/coop-match.ts
+++ b/app/apps/game-analytics/lib/coop-match.ts
@@ -33,7 +33,7 @@ export interface CoOpLibrarySnapshot {
   generatedAt: string;
 }
 
-const PLAYABLE_STATUSES: Game['status'][] = ['Not Started', 'In Progress', 'Completed'];
+const PLAYABLE_STATUSES: Game['status'][] = ['Not Started', 'In Progress', 'Completed', 'Pick Up Later'];
 
 export function buildCoOpSnapshot(games: Game[], name: string): CoOpLibrarySnapshot {
   const entries: CoOpGameEntry[] = games
@@ -127,10 +127,12 @@ function normalize(name: string): string {
 
 function classifyRelation(myStatus: Game['status'], theirStatus: Game['status']): MatchRelation {
   const finished = (s: Game['status']) => s === 'Completed';
+  // 'Pick Up Later' is a paused-but-not-finished game — still counts as "playing" for match purposes.
+  const playing = (s: Game['status']) => s === 'In Progress' || s === 'Pick Up Later';
   if (finished(myStatus) && finished(theirStatus)) return 'both-finished';
   if (finished(myStatus) || finished(theirStatus)) return 'one-finished';
   if (myStatus === 'Not Started' && theirStatus === 'Not Started') return 'both-unplayed';
-  if (myStatus === 'In Progress' && theirStatus === 'In Progress') return 'both-playing';
+  if (playing(myStatus) && playing(theirStatus)) return 'both-playing';
   return 'mismatched-progress';
 }
 

--- a/app/apps/game-analytics/lib/import-service.ts
+++ b/app/apps/game-analytics/lib/import-service.ts
@@ -16,7 +16,13 @@ export interface ImportParseResult {
   format: 'csv' | 'json';
 }
 
-const VALID_STATUSES: GameStatus[] = ['Not Started', 'In Progress', 'Completed', 'Wishlist', 'Abandoned'];
+const VALID_STATUSES: GameStatus[] = ['Not Started', 'In Progress', 'Completed', 'Wishlist', 'Abandoned', 'Pick Up Later'];
+// Lenient aliases for values that mean an existing GameStatus but are spelled differently
+// (e.g. "DNF" is just the display name for the 'Abandoned' status, not a separate value).
+const STATUS_ALIASES: Record<string, GameStatus> = {
+  dnf: 'Abandoned', 'did not finish': 'Abandoned', dropped: 'Abandoned',
+  'pick up later': 'Pick Up Later', paused: 'Pick Up Later', 'on hold': 'Pick Up Later',
+};
 const VALID_SOURCES: PurchaseSource[] = ['Steam', 'PlayStation', 'Xbox', 'Nintendo', 'Epic', 'GOG', 'Physical', 'Other'];
 const VALID_SUBSCRIPTIONS: SubscriptionSource[] = ['PS Plus', 'Game Pass', 'Epic Free', 'Prime Gaming', 'Humble Choice', 'Other'];
 
@@ -45,9 +51,9 @@ function normalizeHeader(h: string): string {
 
 function normalizeStatus(value: string | undefined): GameStatus {
   if (!value) return 'Not Started';
-  const trimmed = value.trim();
-  const match = VALID_STATUSES.find(s => s.toLowerCase() === trimmed.toLowerCase());
-  return match ?? 'Not Started';
+  const trimmed = value.trim().toLowerCase();
+  const match = VALID_STATUSES.find(s => s.toLowerCase() === trimmed);
+  return match ?? STATUS_ALIASES[trimmed] ?? 'Not Started';
 }
 
 function normalizeSource(value: string | undefined): PurchaseSource | undefined {

--- a/app/apps/game-analytics/lib/trophy-calculations.ts
+++ b/app/apps/game-analytics/lib/trophy-calculations.ts
@@ -754,7 +754,8 @@ function calcBacklogZero(games: Game[]): number {
   const owned = games.filter(g => g.status !== 'Wishlist');
   const notStarted = owned.filter(g => g.status === 'Not Started').length;
   const inProgress = owned.filter(g => g.status === 'In Progress').length;
-  return (notStarted === 0 && inProgress === 0 && owned.length > 0) ? 1 : 0;
+  const pickUpLater = owned.filter(g => g.status === 'Pick Up Later').length;
+  return (notStarted === 0 && inProgress === 0 && pickUpLater === 0 && owned.length > 0) ? 1 : 0;
 }
 
 function calcTripleThreat(games: Game[]): number {

--- a/app/apps/game-analytics/lib/types.ts
+++ b/app/apps/game-analytics/lib/types.ts
@@ -1,4 +1,6 @@
-export type GameStatus = 'Not Started' | 'In Progress' | 'Completed' | 'Wishlist' | 'Abandoned';
+// 'Abandoned' = DNF (Did Not Finish) — you gave up on it, whether you drifted away or made a deliberate call.
+// 'Pick Up Later' = an intentional pause, distinct from actively 'In Progress'. You plan to resume.
+export type GameStatus = 'Not Started' | 'In Progress' | 'Completed' | 'Wishlist' | 'Abandoned' | 'Pick Up Later';
 
 // ── Gaming Awards ──────────────────────────────────────────────
 
@@ -99,6 +101,7 @@ export interface AnalyticsSummary {
   inProgressCount: number;
   notStartedCount: number;
   abandonedCount: number;
+  pickUpLaterCount: number;
 
   // Financial
   totalSpent: number;

--- a/app/apps/game-analytics/page.tsx
+++ b/app/apps/game-analytics/page.tsx
@@ -1880,7 +1880,17 @@ export default function GameAnalyticsPage() {
             await updateGame(gameId, { status: 'Abandoned' });
             if (before) {
               showUndo({
-                message: `"${before.name}" marked Abandoned`,
+                message: `"${before.name}" marked DNF`,
+                onUndo: async () => { await updateGame(gameId, { status: before.status }); },
+              });
+            }
+          }}
+          onPickUpLater={async (gameId) => {
+            const before = games.find(g => g.id === gameId);
+            await updateGame(gameId, { status: 'Pick Up Later' });
+            if (before) {
+              showUndo({
+                message: `"${before.name}" set to Pick Up Later`,
                 onUndo: async () => { await updateGame(gameId, { status: before.status }); },
               });
             }

--- a/app/apps/game-analytics/page.tsx
+++ b/app/apps/game-analytics/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useMemo, useEffect, useCallback, useRef } from 'react';
-import { Plus, Sparkles, Gamepad2, Clock, DollarSign, Star, TrendingUp, Eye, Trophy, Flame, BarChart3, Calendar, CalendarClock, CalendarPlus, List, MessageCircle, ListOrdered, ListPlus, Check, Heart, ChevronUp, ChevronDown, ChevronLeft, ChevronRight, Compass, Zap, Target, ArrowUpRight, ArrowDownRight, Minus, Shield, MoreVertical, Download, Upload, Gift, ShoppingCart, Search, X, Moon, CreditCard, Swords, Inbox, History, RefreshCw, Crown, Users, Users2, PiggyBank, Radar, Home } from 'lucide-react';
+import { Plus, Sparkles, Gamepad2, Clock, DollarSign, Star, TrendingUp, Eye, Trophy, Flame, BarChart3, Calendar, CalendarClock, CalendarPlus, List, MessageCircle, ListOrdered, ListPlus, Check, Heart, ChevronUp, ChevronDown, ChevronLeft, ChevronRight, Compass, Zap, Target, ArrowUpRight, ArrowDownRight, Minus, Shield, MoreVertical, Download, Upload, Gift, ShoppingCart, Search, X, Moon, CreditCard, Swords, Inbox, History, RefreshCw, Crown, Users, Users2, PiggyBank, Radar, Home, Play } from 'lucide-react';
 import { useGames } from './hooks/useGames';
 import { useAnalytics, GameWithMetrics } from './hooks/useAnalytics';
 import { useBudget } from './hooks/useBudget';
@@ -1608,6 +1608,14 @@ export default function GameAnalyticsPage() {
                     }
                   }}
                   onDelete={(game) => handleDelete(game.id, game.name)}
+                  onStartGame={async (game) => {
+                    const today = new Date().toISOString().split('T')[0];
+                    await updateGame(game.id, { status: 'In Progress', startDate: game.startDate || today });
+                    showUndo({
+                      message: `"${game.name}" set to In Progress`,
+                      onUndo: async () => { await updateGame(game.id, { status: game.status }); },
+                    });
+                  }}
                   isInQueue={isInQueue}
                   sortBy={sortBy}
                   gameColors={gameColors}
@@ -2323,6 +2331,7 @@ interface GameCardListProps {
   onToggleQueue: (game: GameWithMetrics) => void;
   onToggleSpecial: (game: GameWithMetrics) => void;
   onDelete: (game: GameWithMetrics) => void;
+  onStartGame: (game: GameWithMetrics) => void;
   isInQueue: (id: string) => boolean;
   sortBy?: string;
   gameColors: Map<string, string>;
@@ -2343,6 +2352,7 @@ function GameCardList({
   onToggleQueue,
   onToggleSpecial,
   onDelete,
+  onStartGame,
   isInQueue,
   sortBy = 'hours',
   gameColors,
@@ -2401,13 +2411,13 @@ function GameCardList({
     if (cardViewMode === 'poster') {
       return (
         <div key={game.id} className={animClass}>
-          <PosterCard game={game} allGames={allGames} idx={idx} onClick={() => onCardClick(game)} onQuickLog={(h, d) => onQuickLog(game, h, d)} isInQueue={isInQueue(game.id)} sortBy={sortBy} tintColor={gameColors.get(game.id)} aiQuip={gameQuips[game.id]?.quip} eloRanking={eloRanking} gameTier={gameTier} eloTierRank={eloTierRank} />
+          <PosterCard game={game} allGames={allGames} idx={idx} onClick={() => onCardClick(game)} onQuickLog={(h, d) => onQuickLog(game, h, d)} onStartGame={() => onStartGame(game)} isInQueue={isInQueue(game.id)} sortBy={sortBy} tintColor={gameColors.get(game.id)} aiQuip={gameQuips[game.id]?.quip} eloRanking={eloRanking} gameTier={gameTier} eloTierRank={eloTierRank} />
         </div>
       );
     }
     return (
       <div key={game.id} className={animClass}>
-        <CompactCard game={game} allGames={allGames} idx={idx} onClick={() => onCardClick(game)} onLogTime={(d) => onLogTime(game, d)} onToggleQueue={() => onToggleQueue(game)} onDelete={() => onDelete(game)} isInQueue={isInQueue(game.id)} sortBy={sortBy} tintColor={gameColors.get(game.id)} aiQuip={gameQuips[game.id]?.quip} eloRanking={eloRanking} gameTier={gameTier} eloTierRank={eloTierRank} />
+        <CompactCard game={game} allGames={allGames} idx={idx} onClick={() => onCardClick(game)} onLogTime={(d) => onLogTime(game, d)} onToggleQueue={() => onToggleQueue(game)} onDelete={() => onDelete(game)} onStartGame={() => onStartGame(game)} isInQueue={isInQueue(game.id)} sortBy={sortBy} tintColor={gameColors.get(game.id)} aiQuip={gameQuips[game.id]?.quip} eloRanking={eloRanking} gameTier={gameTier} eloTierRank={eloTierRank} />
       </div>
     );
   };
@@ -2817,12 +2827,13 @@ function NowPlayingCard({ game, allGames, onClick, onQuickLog, sortBy = 'hours',
 
 // --- Poster Card ---
 
-function PosterCard({ game, allGames, idx, onClick, onQuickLog, isInQueue, sortBy = 'hours', tintColor, aiQuip, eloRanking, gameTier, eloTierRank }: {
+function PosterCard({ game, allGames, idx, onClick, onQuickLog, onStartGame, isInQueue, sortBy = 'hours', tintColor, aiQuip, eloRanking, gameTier, eloTierRank }: {
   game: GameWithMetrics;
   allGames: Game[];
   idx: number;
   onClick: () => void;
   onQuickLog: (hours: number, date?: string) => void;
+  onStartGame: () => void;
   isInQueue: boolean;
   sortBy?: string;
   tintColor?: string;
@@ -3019,6 +3030,15 @@ function PosterCard({ game, allGames, idx, onClick, onQuickLog, isInQueue, sortB
               </span>
             )}
             <div className="flex-1" />
+            {game.status !== 'In Progress' && (
+              <button
+                onClick={(e) => { e.stopPropagation(); onStartGame(); }}
+                title="Start playing"
+                className="flex items-center gap-1 px-1.5 h-6 rounded-lg text-[10px] font-medium text-white/30 active:text-emerald-400 active:bg-emerald-500/10 transition-all"
+              >
+                <Play size={11} /> Start
+              </button>
+            )}
             <CheckInDateNav size="xs" date={checkInDate} onChange={setCheckInDate} />
             <button
               onClick={(e) => {
@@ -3202,7 +3222,7 @@ function PosterCardBack({ game, allGames, onFlip, rarity, freshness, relationshi
 
 // --- Compact Card (original layout, fixed) ---
 
-function CompactCard({ game, allGames, idx, onClick, onLogTime, onToggleQueue, onDelete, isInQueue, sortBy = 'hours', tintColor, aiQuip, eloRanking, gameTier, eloTierRank }: {
+function CompactCard({ game, allGames, idx, onClick, onLogTime, onToggleQueue, onDelete, onStartGame, isInQueue, sortBy = 'hours', tintColor, aiQuip, eloRanking, gameTier, eloTierRank }: {
   game: GameWithMetrics;
   allGames: Game[];
   idx: number;
@@ -3210,6 +3230,7 @@ function CompactCard({ game, allGames, idx, onClick, onLogTime, onToggleQueue, o
   onLogTime: (date?: string) => void;
   onToggleQueue: () => void;
   onDelete: () => void;
+  onStartGame: () => void;
   isInQueue: boolean;
   sortBy?: string;
   tintColor?: string;
@@ -3474,6 +3495,14 @@ function CompactCard({ game, allGames, idx, onClick, onLogTime, onToggleQueue, o
               {isInQueue ? <Check size={12} /> : <ListPlus size={12} />}
               {isInQueue ? 'Queued' : 'Queue'}
             </button>
+            {game.status !== 'In Progress' && (
+              <button
+                onClick={(e) => { e.stopPropagation(); onStartGame(); }}
+                className="flex items-center gap-1 px-2.5 py-1.5 text-white/30 active:text-emerald-400 active:bg-emerald-500/10 rounded-lg transition-all text-xs"
+              >
+                <Play size={12} /> Start
+              </button>
+            )}
             <CheckInDateNav size="xs" date={checkInDate} onChange={setCheckInDate} />
             <div className="flex-1" />
             {/* Flip button */}


### PR DESCRIPTION
DNF relabels the existing 'Abandoned' status (same underlying value,
no migration needed) since they're the same concept. Pick Up Later is
a new, separate status for an intentional pause distinct from actively
In Progress. Wired into the status picker, badges/colors, rarity,
relationship status, hero numbers, card sections, biography/verdicts,
trophies, awards, and a new Backlog Triage "Pause it" quick action.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UZ5tLBe1s1hsyk1XLM718n