### PR TITLE
Add 36 Hours — AI-driven interactive zombie story mini-app

### DIFF
--- a/app/apps/story-generator/components/StoryGame.tsx
+++ b/app/apps/story-generator/components/StoryGame.tsx
@@ -1,25 +1,405 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import {
   ArrowLeft,
+  BookOpen,
   Clock,
+  Dices,
   Heart,
   Loader2,
+  Lock,
   Package,
+  Play,
   RotateCcw,
+  Save,
   Send,
   Skull,
+  Trash2,
+  Trophy,
   Users,
+  X,
 } from 'lucide-react';
 import clsx from 'clsx';
 import { useStoryGame } from '../hooks/useStoryGame';
+import { ArchivedStory, FateRoll, StorySave, TranscriptEntry } from '../lib/types';
+import { ZOMBIE_ARC } from '../lib/arc-zombie';
+
+// ── Small helpers ────────────────────────────────────────────────────
+
+/** 34.75 → "34¾" — the clock reads like a watch, not a float. */
+function formatHours(h: number): string {
+  const whole = Math.floor(h);
+  const frac = h - whole;
+  const glyph = frac >= 0.75 ? '¾' : frac >= 0.5 ? '½' : frac >= 0.25 ? '¼' : '';
+  return `${whole}${glyph}`;
+}
+
+const FATE_STYLE: Record<FateRoll['band'], { label: string; cls: string }> = {
+  disaster: { label: 'Disaster', cls: 'text-red-400 border-red-500/40 bg-red-500/10' },
+  setback: { label: 'Setback', cls: 'text-orange-400 border-orange-500/30 bg-orange-500/10' },
+  mixed: { label: 'At a cost', cls: 'text-amber-300 border-amber-500/30 bg-amber-500/10' },
+  clean: { label: 'Clean', cls: 'text-emerald-400 border-emerald-500/30 bg-emerald-500/10' },
+  triumph: { label: 'Triumph', cls: 'text-yellow-300 border-yellow-400/40 bg-yellow-400/10' },
+};
+
+function trustColor(t: number): string {
+  return t <= 3 ? 'text-red-400' : t <= 6 ? 'text-amber-300' : 'text-emerald-400';
+}
+
+// The sky tracks the in-game clock: grey morning → flat day → rust dusk →
+// deep night → the final amber dawn. Pure atmosphere, zero text.
+type SkyPhase = 'morning' | 'day' | 'dusk' | 'night' | 'dawn';
+
+function skyPhase(hoursLeft: number): SkyPhase {
+  if (hoursLeft > 28) return 'morning';
+  if (hoursLeft > 20) return 'day';
+  if (hoursLeft > 14) return 'dusk';
+  if (hoursLeft > 6) return 'night';
+  return 'dawn';
+}
+
+const SKY_GRADIENTS: Record<SkyPhase, string> = {
+  morning: 'radial-gradient(ellipse 120% 70% at 50% -10%, rgba(148,163,184,0.16), transparent 60%)',
+  day: 'radial-gradient(ellipse 120% 70% at 50% -10%, rgba(203,213,225,0.11), transparent 55%)',
+  dusk: 'radial-gradient(ellipse 120% 70% at 50% -10%, rgba(217,119,6,0.18), transparent 62%)',
+  night: 'radial-gradient(ellipse 120% 70% at 50% -10%, rgba(30,58,138,0.26), transparent 65%)',
+  dawn: 'radial-gradient(ellipse 120% 70% at 50% -10%, rgba(245,158,11,0.22), transparent 60%)',
+};
+
+// ── Typewriter ───────────────────────────────────────────────────────
+
+function TypewriterText({
+  text,
+  animate,
+  onProgress,
+  onDone,
+}: {
+  text: string;
+  animate: boolean;
+  onProgress: () => void;
+  onDone: () => void;
+}) {
+  const [count, setCount] = useState(animate ? 0 : text.length);
+  const doneRef = useRef(!animate);
+
+  useEffect(() => {
+    if (!animate) {
+      setCount(text.length);
+      return;
+    }
+    doneRef.current = false;
+    setCount(0);
+    const iv = setInterval(() => {
+      setCount(c => {
+        const next = Math.min(text.length, c + 4);
+        if (next >= text.length) clearInterval(iv);
+        return next;
+      });
+    }, 24);
+    return () => clearInterval(iv);
+  }, [text, animate]);
+
+  useEffect(() => {
+    if (!animate) return;
+    onProgress();
+    if (count >= text.length && !doneRef.current) {
+      doneRef.current = true;
+      onDone();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [count]);
+
+  const typing = animate && count < text.length;
+  return (
+    <span onClick={() => typing && setCount(text.length)} className={typing ? 'cursor-pointer' : undefined}>
+      {text.slice(0, count)}
+      {typing && <span className="story-caret text-red-400">▌</span>}
+    </span>
+  );
+}
+
+// ── Act title card ───────────────────────────────────────────────────
+
+function TitleCard({ act, actTitle, beatTitle }: { act: number; actTitle: string; beatTitle: string }) {
+  return (
+    <div className="story-title-card fixed inset-0 z-[70] bg-black/90 backdrop-blur-sm flex flex-col items-center justify-center pointer-events-none px-6 text-center">
+      <p className="story-title-text text-red-500/90 text-xs font-semibold uppercase tracking-[0.5em] mb-4">Act {act}</p>
+      <h2 className="story-title-text text-3xl sm:text-4xl font-bold text-white uppercase">{actTitle}</h2>
+      <div className="story-title-text h-px w-24 bg-red-500/40 my-5" />
+      <p className="story-title-text text-white/50 text-sm tracking-[0.3em] uppercase">{beatTitle}</p>
+    </div>
+  );
+}
+
+// ── Journal ──────────────────────────────────────────────────────────
+
+function Journal({ save, onClose }: { save: StorySave; onClose: () => void }) {
+  const arc = ZOMBIE_ARC;
+  const beat = arc.beats[save.beatIndex];
+  const elapsed = arc.openingState.hoursLeft - save.state.hoursLeft;
+  return (
+    <div className="fixed inset-0 z-[60] bg-black/70 backdrop-blur-sm flex justify-end" onClick={onClose}>
+      <div
+        className="w-full max-w-sm h-full bg-[#0d0d0f] border-l border-white/10 overflow-y-auto p-5 story-fade-up"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-5">
+          <h2 className="text-white font-semibold flex items-center gap-2"><BookOpen size={16} className="text-red-400" /> Journal</h2>
+          <button onClick={onClose} className="p-1.5 text-white/40 hover:text-white/80 rounded-lg hover:bg-white/5" aria-label="Close journal">
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="grid grid-cols-3 gap-2 mb-6 text-center">
+          <div className="rounded-xl bg-white/[0.04] border border-white/5 py-2.5">
+            <p className="text-lg font-bold text-white">{formatHours(elapsed)}h</p>
+            <p className="text-[10px] uppercase tracking-wider text-white/35">On the road</p>
+          </div>
+          <div className="rounded-xl bg-white/[0.04] border border-white/5 py-2.5">
+            <p className="text-lg font-bold text-white">{save.state.health}</p>
+            <p className="text-[10px] uppercase tracking-wider text-white/35">Health</p>
+          </div>
+          <div className="rounded-xl bg-white/[0.04] border border-white/5 py-2.5">
+            <p className="text-lg font-bold text-white">{save.deathCount}</p>
+            <p className="text-[10px] uppercase tracking-wider text-white/35">Deaths</p>
+          </div>
+        </div>
+
+        <p className="text-[10px] uppercase tracking-[0.2em] text-red-400/70 font-semibold mb-2">The story so far</p>
+        <ol className="space-y-2.5 mb-6">
+          {save.beatRecaps.map((r, i) => (
+            <li key={i} className="text-sm text-white/60 leading-relaxed flex gap-2.5">
+              <span className="text-red-500/60 font-semibold shrink-0">{i + 1}.</span>
+              {r}
+            </li>
+          ))}
+          <li className="text-sm text-white/85 leading-relaxed flex gap-2.5">
+            <span className="text-red-400 font-semibold shrink-0">▸</span>
+            <span><span className="text-red-300/90">Now:</span> {beat.title} — Act {beat.act}, {beat.actTitle}</span>
+          </li>
+        </ol>
+
+        {save.state.companions.length > 0 && (
+          <>
+            <p className="text-[10px] uppercase tracking-[0.2em] text-blue-400/70 font-semibold mb-2">Companions</p>
+            <div className="space-y-2 mb-6">
+              {save.state.companions.map(c => {
+                const t = save.state.trust[c] ?? 5;
+                return (
+                  <div key={c} className="flex items-center justify-between rounded-xl bg-white/[0.04] border border-white/5 px-3 py-2">
+                    <span className="text-sm text-white/80">{c}</span>
+                    <span className={clsx('flex items-center gap-1 text-xs font-semibold', trustColor(t))}>
+                      <Heart size={12} className="fill-current" /> {t}/10
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </>
+        )}
+
+        {save.state.inventory.length > 0 && (
+          <>
+            <p className="text-[10px] uppercase tracking-[0.2em] text-white/40 font-semibold mb-2">Pack</p>
+            <div className="flex flex-wrap gap-1.5 mb-6">
+              {save.state.inventory.map(i => (
+                <span key={i} className="text-xs px-2.5 py-1 rounded-full bg-white/5 text-white/60 border border-white/10">{i}</span>
+              ))}
+            </div>
+          </>
+        )}
+
+        {save.state.conditions.length > 0 && (
+          <>
+            <p className="text-[10px] uppercase tracking-[0.2em] text-red-400/70 font-semibold mb-2">Wounds & afflictions</p>
+            <div className="flex flex-wrap gap-1.5">
+              {save.state.conditions.map(c => (
+                <span key={c} className="text-xs px-2.5 py-1 rounded-full bg-red-500/10 text-red-300 border border-red-500/20">{c}</span>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Start screen ─────────────────────────────────────────────────────
+
+function LibraryCard({
+  story,
+  onResume,
+  onDelete,
+  disabled,
+}: {
+  story: ArchivedStory;
+  onResume: () => void;
+  onDelete: () => void;
+  disabled: boolean;
+}) {
+  const arc = ZOMBIE_ARC;
+  const s = story.save;
+  const beat = arc.beats[s.beatIndex];
+  const endingTitle = s.endingId ? arc.endings.find(e => e.id === s.endingId)?.title : undefined;
+  const statusLine =
+    s.status === 'ended' ? `Finished — ${endingTitle ?? 'The Crossing'}` :
+    s.status === 'dead' ? `Died in Act ${beat?.act ?? '?'} — retry waiting` :
+    `Act ${beat?.act ?? 1} · ${beat?.title ?? ''} · ${formatHours(s.state.hoursLeft)}h left`;
+
+  return (
+    <div className="flex items-center gap-3 rounded-xl bg-white/[0.04] border border-white/10 px-4 py-3 text-left">
+      <div className="min-w-0 flex-1">
+        <p className="text-sm text-white/85 font-medium truncate">
+          {s.playerName ? `${s.playerName}'s run` : 'Unnamed run'}
+          <span className="text-white/30 font-normal"> · {new Date(story.archivedAt).toLocaleDateString()}</span>
+        </p>
+        <p className={clsx('text-xs truncate mt-0.5', s.status === 'ended' ? 'text-amber-300/80' : s.status === 'dead' ? 'text-red-400/80' : 'text-white/45')}>
+          {statusLine}
+        </p>
+      </div>
+      <button
+        onClick={onResume}
+        disabled={disabled}
+        className="p-2 rounded-lg bg-red-500/15 text-red-300 hover:bg-red-500/25 hover:text-white transition-colors disabled:opacity-40"
+        aria-label="Resume story"
+      >
+        <Play size={15} />
+      </button>
+      <button
+        onClick={onDelete}
+        className="p-2 rounded-lg text-white/30 hover:text-red-400 hover:bg-white/5 transition-colors"
+        aria-label="Delete story"
+      >
+        <Trash2 size={15} />
+      </button>
+    </div>
+  );
+}
+
+function StartScreen({
+  loading,
+  error,
+  library,
+  unlockedEndingIds,
+  onStart,
+  onResume,
+  onDelete,
+}: {
+  loading: boolean;
+  error: string | null;
+  library: ArchivedStory[];
+  unlockedEndingIds: string[];
+  onStart: (name: string) => void;
+  onResume: (id: string) => void;
+  onDelete: (id: string) => void;
+}) {
+  const arc = ZOMBIE_ARC;
+  const [name, setName] = useState('');
+  const [showEndings, setShowEndings] = useState(false);
+
+  return (
+    <div className="min-h-dvh bg-[#0a0a0a] flex flex-col">
+      <div className="px-4 py-3">
+        <Link href="/" className="inline-flex items-center gap-2 text-white/40 hover:text-white/70 text-sm transition-colors">
+          <ArrowLeft size={16} /> Hub
+        </Link>
+      </div>
+      <div className="flex-1 flex flex-col items-center px-6 pb-12 text-center">
+        <div className="p-4 rounded-2xl bg-gradient-to-br from-red-900/40 to-amber-900/20 border border-red-500/20 mb-6 mt-4">
+          <Skull size={40} className="text-red-400" />
+        </div>
+        <h1 className="text-4xl font-bold text-white tracking-tight mb-2">{arc.title}</h1>
+        <p className="text-red-400/90 font-medium mb-6">{arc.tagline}</p>
+        <p className="text-white/60 text-sm leading-relaxed max-w-md mb-8">{arc.premise}</p>
+
+        <input
+          type="text"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter') onStart(name); }}
+          placeholder="Your name (optional — companions will use it)"
+          maxLength={24}
+          className="w-full max-w-xs px-4 py-3 mb-4 bg-white/5 border border-white/10 rounded-xl text-white text-sm text-center placeholder-white/25 focus:outline-none focus:border-red-500/50 transition-colors"
+        />
+        <button
+          onClick={() => onStart(name)}
+          disabled={loading}
+          className="px-8 py-4 bg-gradient-to-r from-red-700 to-red-600 hover:from-red-600 hover:to-red-500 disabled:opacity-50 text-white font-semibold rounded-2xl transition-all shadow-lg shadow-red-900/30 flex items-center gap-2"
+        >
+          {loading ? <Loader2 size={18} className="animate-spin" /> : null}
+          {loading ? 'The city wakes...' : 'Begin'}
+        </button>
+        {error && <p className="text-red-400 text-sm mt-4">{error}</p>}
+        <p className="text-white/25 text-xs mt-6 max-w-sm">
+          Type anything — the story reacts to what you say. Every action rolls fate. Choices cost time, noise draws the dead, and death sends you back to the start of the scene.
+        </p>
+
+        {library.length > 0 && (
+          <div className="w-full max-w-md mt-10 text-left">
+            <p className="text-[10px] uppercase tracking-[0.25em] text-white/40 font-semibold mb-3">Your stories</p>
+            <div className="space-y-2">
+              {library.map(a => (
+                <LibraryCard
+                  key={a.id}
+                  story={a}
+                  disabled={loading}
+                  onResume={() => onResume(a.id)}
+                  onDelete={() => onDelete(a.id)}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div className="w-full max-w-md mt-10 text-left">
+          <button
+            onClick={() => setShowEndings(v => !v)}
+            className="w-full flex items-center justify-between text-[10px] uppercase tracking-[0.25em] text-white/40 font-semibold mb-3 hover:text-white/70 transition-colors"
+          >
+            <span className="flex items-center gap-2"><Trophy size={13} className="text-amber-400/70" /> Endings discovered — {unlockedEndingIds.length}/{arc.endings.length}</span>
+            <span>{showEndings ? '−' : '+'}</span>
+          </button>
+          {showEndings && (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 story-fade-up">
+              {arc.endings.map(e => {
+                const unlocked = unlockedEndingIds.includes(e.id);
+                return (
+                  <div
+                    key={e.id}
+                    className={clsx(
+                      'rounded-xl border px-3.5 py-2.5',
+                      unlocked ? 'bg-amber-500/[0.07] border-amber-500/25' : 'bg-white/[0.03] border-white/5',
+                    )}
+                  >
+                    <p className={clsx('text-xs font-semibold flex items-center gap-1.5', unlocked ? 'text-amber-300' : 'text-white/35')}>
+                      {!unlocked && <Lock size={10} />}
+                      {unlocked ? e.title : '???'}
+                    </p>
+                    <p className="text-[11px] text-white/35 mt-1 leading-snug italic">
+                      {unlocked ? e.epitaph : e.hint}
+                    </p>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Main component ───────────────────────────────────────────────────
 
 export function StoryGame() {
   const {
     arc,
     save,
+    library,
+    unlockedEndingIds,
+    ending,
     hydrated,
     loading,
     error,
@@ -28,15 +408,52 @@ export function StoryGame() {
     sendAction,
     retry,
     restartFromCheckpoint,
-    abandonGame,
+    saveAndRestart,
+    resumeStory,
+    deleteStory,
   } = useStoryGame();
 
   const [input, setInput] = useState('');
+  const [journalOpen, setJournalOpen] = useState(false);
+  const [animatingId, setAnimatingId] = useState<string | null>(null);
+  const [titleCard, setTitleCard] = useState<{ act: number; actTitle: string; beatTitle: string; key: string } | null>(null);
   const endRef = useRef<HTMLDivElement>(null);
+  const prevLenRef = useRef<number | null>(null);
+
+  // Watch the transcript: new narrator entries get the typewriter, new
+  // act-headers get the cinematic title card. Restored entries get neither.
+  useEffect(() => {
+    if (!save) {
+      prevLenRef.current = 0;
+      return;
+    }
+    const len = save.transcript.length;
+    const prev = prevLenRef.current;
+    prevLenRef.current = len;
+    if (prev === null || len <= prev) return;
+    const fresh = save.transcript.slice(prev);
+    const last = fresh[fresh.length - 1];
+    if (last.role === 'narrator') setAnimatingId(last.id);
+    const actEntry = fresh.find(e => e.role === 'system' && /^ACT \d+ — /.test(e.text));
+    if (actEntry) {
+      const m = actEntry.text.match(/^ACT (\d+) — (.+) · (.+)$/);
+      if (m) setTitleCard({ act: Number(m[1]), actTitle: m[2], beatTitle: m[3], key: actEntry.id });
+    }
+  }, [save]);
 
   useEffect(() => {
-    endRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [save?.transcript.length, loading, error]);
+    if (!titleCard) return;
+    const t = setTimeout(() => setTitleCard(null), 3050);
+    return () => clearTimeout(t);
+  }, [titleCard]);
+
+  const scrollToEnd = useCallback((smooth = false) => {
+    endRef.current?.scrollIntoView({ behavior: smooth ? 'smooth' : 'auto', block: 'end' });
+  }, []);
+
+  useEffect(() => {
+    scrollToEnd(true);
+  }, [save?.transcript.length, loading, error, scrollToEnd]);
 
   const handleSend = (text?: string) => {
     const action = (text ?? input).trim();
@@ -53,47 +470,55 @@ export function StoryGame() {
     );
   }
 
-  // ── Start screen ─────────────────────────────────────────────────
   if (!save) {
     return (
-      <div className="h-dvh bg-[#0a0a0a] flex flex-col">
-        <div className="px-4 py-3">
-          <Link href="/" className="inline-flex items-center gap-2 text-white/40 hover:text-white/70 text-sm transition-colors">
-            <ArrowLeft size={16} /> Hub
-          </Link>
-        </div>
-        <div className="flex-1 flex flex-col items-center justify-center px-6 text-center">
-          <div className="p-4 rounded-2xl bg-gradient-to-br from-red-900/40 to-amber-900/20 border border-red-500/20 mb-6">
-            <Skull size={40} className="text-red-400" />
-          </div>
-          <h1 className="text-4xl font-bold text-white tracking-tight mb-2">{arc.title}</h1>
-          <p className="text-red-400/90 font-medium mb-6">{arc.tagline}</p>
-          <p className="text-white/60 text-sm leading-relaxed max-w-md mb-10">{arc.premise}</p>
-          <button
-            onClick={startNewGame}
-            disabled={loading}
-            className="px-8 py-4 bg-gradient-to-r from-red-700 to-red-600 hover:from-red-600 hover:to-red-500 disabled:opacity-50 text-white font-semibold rounded-2xl transition-all shadow-lg shadow-red-900/30 flex items-center gap-2"
-          >
-            {loading ? <Loader2 size={18} className="animate-spin" /> : null}
-            {loading ? 'The city wakes...' : 'Begin'}
-          </button>
-          {error && <p className="text-red-400 text-sm mt-4">{error}</p>}
-          <p className="text-white/25 text-xs mt-8 max-w-sm">
-            Type anything — the story reacts to what you say. Choices cost time, noise draws the dead, and death sends you back to the start of the scene.
-          </p>
-        </div>
-      </div>
+      <StartScreen
+        loading={loading}
+        error={error}
+        library={library}
+        unlockedEndingIds={unlockedEndingIds}
+        onStart={name => startNewGame(name)}
+        onResume={resumeStory}
+        onDelete={id => { if (confirm('Delete this saved story forever?')) deleteStory(id); }}
+      />
     );
   }
 
   const { state } = save;
   const healthColor = state.health > 60 ? 'bg-emerald-500' : state.health > 30 ? 'bg-amber-500' : 'bg-red-500';
   const isTerminal = save.status !== 'playing';
+  const phase = skyPhase(state.hoursLeft);
+
+  // Hurt = the screen itself bleeds at the edges. Threat feeds in a little too.
+  const hurtFactor = state.health < 35 ? (35 - state.health) / 35 : 0;
+  const threatFactor = state.threat >= 7 ? 0.35 : 0;
+  const vignette = Math.min(1, Math.max(hurtFactor, threatFactor));
 
   return (
-    <div className="h-dvh bg-[#0a0a0a] flex flex-col">
+    <div className="h-dvh bg-[#0a0a0a] flex flex-col relative overflow-hidden">
+      {/* Living sky — tracks the in-game clock */}
+      {(Object.keys(SKY_GRADIENTS) as SkyPhase[]).map(p => (
+        <div
+          key={p}
+          aria-hidden
+          className={clsx('absolute inset-0 pointer-events-none transition-opacity duration-[3000ms]', p === phase ? 'opacity-100' : 'opacity-0')}
+          style={{ background: SKY_GRADIENTS[p] }}
+        />
+      ))}
+      {/* Blood vignette when hurt or hunted */}
+      {vignette > 0 && (
+        <div
+          aria-hidden
+          className={clsx('absolute inset-0 pointer-events-none z-[45]', state.health < 20 && 'story-vignette-pulse')}
+          style={{ boxShadow: `inset 0 0 120px 30px rgba(185, 28, 28, ${(0.12 + vignette * 0.3).toFixed(2)})` }}
+        />
+      )}
+
+      {titleCard && <TitleCard act={titleCard.act} actTitle={titleCard.actTitle} beatTitle={titleCard.beatTitle} />}
+      {journalOpen && <Journal save={save} onClose={() => setJournalOpen(false)} />}
+
       {/* Header + HUD */}
-      <div className="border-b border-white/10 bg-gradient-to-r from-red-950/40 to-[#0a0a0a]">
+      <div className="relative z-10 border-b border-white/10 bg-gradient-to-r from-red-950/40 to-transparent">
         <div className="px-4 pt-3 pb-2 flex items-center justify-between">
           <div className="flex items-center gap-3 min-w-0">
             <Link href="/" className="p-1.5 -ml-1.5 rounded-lg text-white/40 hover:text-white/80 hover:bg-white/5 transition-colors" aria-label="Back to hub">
@@ -106,12 +531,22 @@ export function StoryGame() {
               <h1 className="text-white font-semibold truncate">{currentBeat?.title}</h1>
             </div>
           </div>
-          <button
-            onClick={() => { if (confirm('Abandon this story and start over?')) abandonGame(); }}
-            className="text-xs text-white/30 hover:text-white/60 transition-colors px-2 py-1"
-          >
-            New story
-          </button>
+          <div className="flex items-center gap-1 shrink-0">
+            <button
+              onClick={() => setJournalOpen(true)}
+              className="p-2 rounded-lg text-white/40 hover:text-white/80 hover:bg-white/5 transition-colors"
+              aria-label="Open journal"
+            >
+              <BookOpen size={17} />
+            </button>
+            <button
+              onClick={() => { if (confirm('Save this story to your library and return to the title screen? You can resume it any time.')) saveAndRestart(); }}
+              className="p-2 rounded-lg text-white/40 hover:text-white/80 hover:bg-white/5 transition-colors"
+              aria-label="Save and restart"
+            >
+              <Save size={17} />
+            </button>
+          </div>
         </div>
         <div className="px-4 pb-3 flex items-center gap-4 text-xs">
           <div className="flex items-center gap-1.5 flex-1 min-w-0 max-w-[160px]">
@@ -122,7 +557,7 @@ export function StoryGame() {
           </div>
           <div className="flex items-center gap-1 text-amber-300/90 font-medium shrink-0">
             <Clock size={13} />
-            {state.hoursLeft}h left
+            {formatHours(state.hoursLeft)}h left
           </div>
           <div className="flex items-center gap-1 shrink-0" title={`Threat ${state.threat}/10`}>
             <Skull size={13} className={state.threat >= 7 ? 'text-red-400' : state.threat >= 4 ? 'text-amber-400' : 'text-white/30'} />
@@ -133,11 +568,16 @@ export function StoryGame() {
         </div>
         {(state.inventory.length > 0 || state.companions.length > 0 || state.conditions.length > 0) && (
           <div className="px-4 pb-2.5 flex flex-wrap gap-1.5">
-            {state.companions.map(c => (
-              <span key={c} className="inline-flex items-center gap-1 text-[10px] px-2 py-0.5 rounded-full bg-blue-500/15 text-blue-300 border border-blue-500/20">
-                <Users size={10} /> {c}
-              </span>
-            ))}
+            {state.companions.map(c => {
+              const t = state.trust[c] ?? 5;
+              return (
+                <span key={c} className="inline-flex items-center gap-1 text-[10px] px-2 py-0.5 rounded-full bg-blue-500/15 text-blue-300 border border-blue-500/20">
+                  <Users size={10} /> {c}
+                  <Heart size={9} className={clsx('fill-current', trustColor(t))} />
+                  <span className={trustColor(t)}>{t}</span>
+                </span>
+              );
+            })}
             {state.conditions.map(c => (
               <span key={c} className="inline-flex items-center gap-1 text-[10px] px-2 py-0.5 rounded-full bg-red-500/15 text-red-300 border border-red-500/20">
                 {c}
@@ -153,8 +593,8 @@ export function StoryGame() {
       </div>
 
       {/* Transcript */}
-      <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
-        {save.transcript.map(e => {
+      <div className="relative z-10 flex-1 overflow-y-auto px-4 py-4 space-y-4">
+        {save.transcript.map((e: TranscriptEntry) => {
           if (e.role === 'system') {
             return (
               <div key={e.id} className="flex items-center gap-3 py-2">
@@ -166,17 +606,27 @@ export function StoryGame() {
           }
           if (e.role === 'player') {
             return (
-              <div key={e.id} className="flex justify-end">
+              <div key={e.id} className="flex flex-col items-end gap-1">
                 <div className="max-w-[85%] rounded-2xl rounded-br-sm px-4 py-2.5 bg-gradient-to-r from-red-800 to-red-700 text-white text-sm">
                   {e.text}
                 </div>
+                {e.fate && (
+                  <span className={clsx('inline-flex items-center gap-1 text-[10px] px-2 py-0.5 rounded-full border font-semibold', FATE_STYLE[e.fate.band].cls)}>
+                    <Dices size={10} /> {e.fate.roll} — {FATE_STYLE[e.fate.band].label}
+                  </span>
+                )}
               </div>
             );
           }
           return (
             <div key={e.id} className="flex justify-start">
               <div className="max-w-[92%] rounded-2xl rounded-bl-sm px-4 py-3 bg-white/[0.06] border border-white/5 text-white/90 text-sm leading-relaxed whitespace-pre-wrap">
-                {e.text}
+                <TypewriterText
+                  text={e.text}
+                  animate={e.id === animatingId}
+                  onProgress={() => scrollToEnd(false)}
+                  onDone={() => setAnimatingId(null)}
+                />
               </div>
             </div>
           );
@@ -202,7 +652,7 @@ export function StoryGame() {
 
         {/* Death screen */}
         {save.status === 'dead' && (
-          <div className="rounded-2xl border border-red-500/30 bg-gradient-to-b from-red-950/60 to-[#140505] p-6 text-center">
+          <div className="rounded-2xl border border-red-500/30 bg-gradient-to-b from-red-950/60 to-[#140505] p-6 text-center story-fade-up">
             <Skull size={36} className="text-red-500 mx-auto mb-3" />
             <h2 className="text-2xl font-bold text-red-400 mb-2">You didn&apos;t make it</h2>
             <p className="text-white/60 text-sm mb-6">{save.deathCause}</p>
@@ -215,10 +665,10 @@ export function StoryGame() {
                 <RotateCcw size={16} /> Retry this scene
               </button>
               <button
-                onClick={abandonGame}
+                onClick={saveAndRestart}
                 className="px-6 py-3 bg-white/5 hover:bg-white/10 text-white/70 font-medium rounded-xl transition-colors"
               >
-                Start over
+                Shelve it & start fresh
               </button>
             </div>
             {save.deathCount > 0 && (
@@ -229,16 +679,20 @@ export function StoryGame() {
 
         {/* Ending screen */}
         {save.status === 'ended' && (
-          <div className="rounded-2xl border border-amber-500/30 bg-gradient-to-b from-amber-950/40 to-[#0f0a02] p-6 text-center">
-            <p className="text-[10px] uppercase tracking-[0.25em] text-amber-400/80 font-semibold mb-2">The End</p>
-            <h2 className="text-2xl font-bold text-amber-300 mb-4">{arc.title}</h2>
-            <div className="text-white/50 text-xs space-y-1 mb-6">
-              <p>Survived with {state.health} health · {state.hoursLeft}h to spare</p>
+          <div className="rounded-2xl border border-amber-500/30 bg-gradient-to-b from-amber-950/40 to-[#0f0a02] p-6 text-center story-fade-up">
+            <p className="text-[10px] uppercase tracking-[0.25em] text-amber-400/80 font-semibold mb-2">Ending discovered</p>
+            <h2 className="text-3xl font-bold text-amber-300 mb-2">{ending?.title ?? arc.title}</h2>
+            {ending && <p className="text-white/50 text-sm italic mb-5">&ldquo;{ending.epitaph}&rdquo;</p>}
+            <div className="text-white/50 text-xs space-y-1 mb-5">
+              <p>Survived with {state.health} health · {formatHours(state.hoursLeft)}h to spare</p>
               <p>{state.companions.length > 0 ? `Made it with: ${state.companions.join(', ')}` : 'Made it alone'}</p>
               {save.deathCount > 0 && <p>Deaths along the way: {save.deathCount}</p>}
             </div>
+            <p className="text-amber-400/60 text-xs mb-6 flex items-center justify-center gap-1.5">
+              <Trophy size={12} /> {unlockedEndingIds.length}/{arc.endings.length} endings discovered
+            </p>
             <button
-              onClick={abandonGame}
+              onClick={saveAndRestart}
               className="px-8 py-3 bg-amber-700 hover:bg-amber-600 text-white font-medium rounded-xl transition-colors"
             >
               Play again
@@ -251,9 +705,9 @@ export function StoryGame() {
 
       {/* Suggested actions + input */}
       {!isTerminal && (
-        <div className="border-t border-white/10 bg-[#0a0a0a] px-4 pt-3 pb-5">
-          {save.suggestedActions.length > 0 && !loading && (
-            <div className="flex flex-wrap gap-2 mb-3">
+        <div className="relative z-10 border-t border-white/10 bg-[#0a0a0a]/90 backdrop-blur px-4 pt-3 pb-5">
+          {save.suggestedActions.length > 0 && !loading && animatingId === null && (
+            <div className="flex flex-wrap gap-2 mb-3 story-fade-up">
               {save.suggestedActions.map((a, i) => (
                 <button
                   key={`${a}-${i}`}

--- a/app/apps/story-generator/components/StoryGame.tsx
+++ b/app/apps/story-generator/components/StoryGame.tsx
@@ -1,0 +1,291 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
+import {
+  ArrowLeft,
+  Clock,
+  Heart,
+  Loader2,
+  Package,
+  RotateCcw,
+  Send,
+  Skull,
+  Users,
+} from 'lucide-react';
+import clsx from 'clsx';
+import { useStoryGame } from '../hooks/useStoryGame';
+
+export function StoryGame() {
+  const {
+    arc,
+    save,
+    hydrated,
+    loading,
+    error,
+    currentBeat,
+    startNewGame,
+    sendAction,
+    retry,
+    restartFromCheckpoint,
+    abandonGame,
+  } = useStoryGame();
+
+  const [input, setInput] = useState('');
+  const endRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [save?.transcript.length, loading, error]);
+
+  const handleSend = (text?: string) => {
+    const action = (text ?? input).trim();
+    if (!action || loading) return;
+    sendAction(action);
+    setInput('');
+  };
+
+  if (!hydrated) {
+    return (
+      <div className="h-dvh bg-[#0a0a0a] flex items-center justify-center">
+        <Loader2 size={24} className="text-red-500 animate-spin" />
+      </div>
+    );
+  }
+
+  // ── Start screen ─────────────────────────────────────────────────
+  if (!save) {
+    return (
+      <div className="h-dvh bg-[#0a0a0a] flex flex-col">
+        <div className="px-4 py-3">
+          <Link href="/" className="inline-flex items-center gap-2 text-white/40 hover:text-white/70 text-sm transition-colors">
+            <ArrowLeft size={16} /> Hub
+          </Link>
+        </div>
+        <div className="flex-1 flex flex-col items-center justify-center px-6 text-center">
+          <div className="p-4 rounded-2xl bg-gradient-to-br from-red-900/40 to-amber-900/20 border border-red-500/20 mb-6">
+            <Skull size={40} className="text-red-400" />
+          </div>
+          <h1 className="text-4xl font-bold text-white tracking-tight mb-2">{arc.title}</h1>
+          <p className="text-red-400/90 font-medium mb-6">{arc.tagline}</p>
+          <p className="text-white/60 text-sm leading-relaxed max-w-md mb-10">{arc.premise}</p>
+          <button
+            onClick={startNewGame}
+            disabled={loading}
+            className="px-8 py-4 bg-gradient-to-r from-red-700 to-red-600 hover:from-red-600 hover:to-red-500 disabled:opacity-50 text-white font-semibold rounded-2xl transition-all shadow-lg shadow-red-900/30 flex items-center gap-2"
+          >
+            {loading ? <Loader2 size={18} className="animate-spin" /> : null}
+            {loading ? 'The city wakes...' : 'Begin'}
+          </button>
+          {error && <p className="text-red-400 text-sm mt-4">{error}</p>}
+          <p className="text-white/25 text-xs mt-8 max-w-sm">
+            Type anything — the story reacts to what you say. Choices cost time, noise draws the dead, and death sends you back to the start of the scene.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const { state } = save;
+  const healthColor = state.health > 60 ? 'bg-emerald-500' : state.health > 30 ? 'bg-amber-500' : 'bg-red-500';
+  const isTerminal = save.status !== 'playing';
+
+  return (
+    <div className="h-dvh bg-[#0a0a0a] flex flex-col">
+      {/* Header + HUD */}
+      <div className="border-b border-white/10 bg-gradient-to-r from-red-950/40 to-[#0a0a0a]">
+        <div className="px-4 pt-3 pb-2 flex items-center justify-between">
+          <div className="flex items-center gap-3 min-w-0">
+            <Link href="/" className="p-1.5 -ml-1.5 rounded-lg text-white/40 hover:text-white/80 hover:bg-white/5 transition-colors" aria-label="Back to hub">
+              <ArrowLeft size={18} />
+            </Link>
+            <div className="min-w-0">
+              <p className="text-[10px] uppercase tracking-widest text-red-400/70 font-semibold">
+                Act {currentBeat?.act} — {currentBeat?.actTitle}
+              </p>
+              <h1 className="text-white font-semibold truncate">{currentBeat?.title}</h1>
+            </div>
+          </div>
+          <button
+            onClick={() => { if (confirm('Abandon this story and start over?')) abandonGame(); }}
+            className="text-xs text-white/30 hover:text-white/60 transition-colors px-2 py-1"
+          >
+            New story
+          </button>
+        </div>
+        <div className="px-4 pb-3 flex items-center gap-4 text-xs">
+          <div className="flex items-center gap-1.5 flex-1 min-w-0 max-w-[160px]">
+            <Heart size={13} className="text-red-400 shrink-0" />
+            <div className="h-1.5 flex-1 bg-white/10 rounded-full overflow-hidden">
+              <div className={clsx('h-full rounded-full transition-all duration-500', healthColor)} style={{ width: `${state.health}%` }} />
+            </div>
+          </div>
+          <div className="flex items-center gap-1 text-amber-300/90 font-medium shrink-0">
+            <Clock size={13} />
+            {state.hoursLeft}h left
+          </div>
+          <div className="flex items-center gap-1 shrink-0" title={`Threat ${state.threat}/10`}>
+            <Skull size={13} className={state.threat >= 7 ? 'text-red-400' : state.threat >= 4 ? 'text-amber-400' : 'text-white/30'} />
+            <span className={clsx('font-medium', state.threat >= 7 ? 'text-red-400' : state.threat >= 4 ? 'text-amber-400' : 'text-white/40')}>
+              {state.threat}/10
+            </span>
+          </div>
+        </div>
+        {(state.inventory.length > 0 || state.companions.length > 0 || state.conditions.length > 0) && (
+          <div className="px-4 pb-2.5 flex flex-wrap gap-1.5">
+            {state.companions.map(c => (
+              <span key={c} className="inline-flex items-center gap-1 text-[10px] px-2 py-0.5 rounded-full bg-blue-500/15 text-blue-300 border border-blue-500/20">
+                <Users size={10} /> {c}
+              </span>
+            ))}
+            {state.conditions.map(c => (
+              <span key={c} className="inline-flex items-center gap-1 text-[10px] px-2 py-0.5 rounded-full bg-red-500/15 text-red-300 border border-red-500/20">
+                {c}
+              </span>
+            ))}
+            {state.inventory.map(i => (
+              <span key={i} className="inline-flex items-center gap-1 text-[10px] px-2 py-0.5 rounded-full bg-white/5 text-white/50 border border-white/10">
+                <Package size={10} /> {i}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Transcript */}
+      <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
+        {save.transcript.map(e => {
+          if (e.role === 'system') {
+            return (
+              <div key={e.id} className="flex items-center gap-3 py-2">
+                <div className="h-px flex-1 bg-gradient-to-r from-transparent to-red-500/30" />
+                <span className="text-[10px] uppercase tracking-[0.2em] text-red-400/80 font-semibold whitespace-nowrap">{e.text}</span>
+                <div className="h-px flex-1 bg-gradient-to-l from-transparent to-red-500/30" />
+              </div>
+            );
+          }
+          if (e.role === 'player') {
+            return (
+              <div key={e.id} className="flex justify-end">
+                <div className="max-w-[85%] rounded-2xl rounded-br-sm px-4 py-2.5 bg-gradient-to-r from-red-800 to-red-700 text-white text-sm">
+                  {e.text}
+                </div>
+              </div>
+            );
+          }
+          return (
+            <div key={e.id} className="flex justify-start">
+              <div className="max-w-[92%] rounded-2xl rounded-bl-sm px-4 py-3 bg-white/[0.06] border border-white/5 text-white/90 text-sm leading-relaxed whitespace-pre-wrap">
+                {e.text}
+              </div>
+            </div>
+          );
+        })}
+
+        {loading && (
+          <div className="flex justify-start">
+            <div className="rounded-2xl px-4 py-3 bg-white/[0.06] border border-white/5 flex items-center gap-2">
+              <Loader2 size={14} className="text-red-400 animate-spin" />
+              <span className="text-xs text-white/50">The world responds...</span>
+            </div>
+          </div>
+        )}
+
+        {error && !loading && (
+          <div className="flex flex-col items-start gap-2">
+            <div className="rounded-xl px-4 py-3 bg-red-500/10 border border-red-500/30 text-red-300 text-sm">{error}</div>
+            <button onClick={retry} className="text-xs text-red-400 hover:text-red-300 flex items-center gap-1 px-1">
+              <RotateCcw size={12} /> Retry
+            </button>
+          </div>
+        )}
+
+        {/* Death screen */}
+        {save.status === 'dead' && (
+          <div className="rounded-2xl border border-red-500/30 bg-gradient-to-b from-red-950/60 to-[#140505] p-6 text-center">
+            <Skull size={36} className="text-red-500 mx-auto mb-3" />
+            <h2 className="text-2xl font-bold text-red-400 mb-2">You didn&apos;t make it</h2>
+            <p className="text-white/60 text-sm mb-6">{save.deathCause}</p>
+            <div className="flex flex-col sm:flex-row gap-3 justify-center">
+              <button
+                onClick={restartFromCheckpoint}
+                disabled={loading}
+                className="px-6 py-3 bg-red-700 hover:bg-red-600 disabled:opacity-50 text-white font-medium rounded-xl transition-colors flex items-center justify-center gap-2"
+              >
+                <RotateCcw size={16} /> Retry this scene
+              </button>
+              <button
+                onClick={abandonGame}
+                className="px-6 py-3 bg-white/5 hover:bg-white/10 text-white/70 font-medium rounded-xl transition-colors"
+              >
+                Start over
+              </button>
+            </div>
+            {save.deathCount > 0 && (
+              <p className="text-white/25 text-xs mt-4">Deaths this run: {save.deathCount + 1}</p>
+            )}
+          </div>
+        )}
+
+        {/* Ending screen */}
+        {save.status === 'ended' && (
+          <div className="rounded-2xl border border-amber-500/30 bg-gradient-to-b from-amber-950/40 to-[#0f0a02] p-6 text-center">
+            <p className="text-[10px] uppercase tracking-[0.25em] text-amber-400/80 font-semibold mb-2">The End</p>
+            <h2 className="text-2xl font-bold text-amber-300 mb-4">{arc.title}</h2>
+            <div className="text-white/50 text-xs space-y-1 mb-6">
+              <p>Survived with {state.health} health · {state.hoursLeft}h to spare</p>
+              <p>{state.companions.length > 0 ? `Made it with: ${state.companions.join(', ')}` : 'Made it alone'}</p>
+              {save.deathCount > 0 && <p>Deaths along the way: {save.deathCount}</p>}
+            </div>
+            <button
+              onClick={abandonGame}
+              className="px-8 py-3 bg-amber-700 hover:bg-amber-600 text-white font-medium rounded-xl transition-colors"
+            >
+              Play again
+            </button>
+          </div>
+        )}
+
+        <div ref={endRef} />
+      </div>
+
+      {/* Suggested actions + input */}
+      {!isTerminal && (
+        <div className="border-t border-white/10 bg-[#0a0a0a] px-4 pt-3 pb-5">
+          {save.suggestedActions.length > 0 && !loading && (
+            <div className="flex flex-wrap gap-2 mb-3">
+              {save.suggestedActions.map((a, i) => (
+                <button
+                  key={`${a}-${i}`}
+                  onClick={() => handleSend(a)}
+                  className="text-xs px-3 py-2 bg-red-500/10 hover:bg-red-500/20 text-red-200/90 hover:text-white rounded-full border border-red-500/20 transition-colors"
+                >
+                  {a}
+                </button>
+              ))}
+            </div>
+          )}
+          <div className="flex gap-2 items-end">
+            <input
+              type="text"
+              value={input}
+              onChange={e => setInput(e.target.value)}
+              onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); handleSend(); } }}
+              placeholder="What do you do?"
+              disabled={loading}
+              className="flex-1 px-4 py-3.5 bg-white/5 border border-white/10 rounded-2xl text-white text-sm placeholder-white/30 focus:outline-none focus:border-red-500/50 focus:bg-white/[0.08] transition-colors"
+            />
+            <button
+              onClick={() => handleSend()}
+              disabled={!input.trim() || loading}
+              className="p-3.5 bg-gradient-to-r from-red-700 to-red-600 hover:from-red-600 hover:to-red-500 disabled:from-gray-700 disabled:to-gray-700 disabled:cursor-not-allowed text-white rounded-2xl transition-all"
+              aria-label="Send action"
+            >
+              <Send size={18} />
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/apps/story-generator/components/StoryGame.tsx
+++ b/app/apps/story-generator/components/StoryGame.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import {
   ArrowLeft,
   BookOpen,
   Clock,
   Dices,
+  FolderOpen,
   Heart,
   Loader2,
   Lock,
@@ -23,7 +24,8 @@ import {
 } from 'lucide-react';
 import clsx from 'clsx';
 import { useStoryGame } from '../hooks/useStoryGame';
-import { ArchivedStory, FateRoll, StorySave, TranscriptEntry } from '../lib/types';
+import { parseNarration, narrationLength, NarrationParagraph } from '../lib/narration';
+import { ArchivedStory, FateRoll, StorySave, TranscriptEntry, TurnEffect } from '../lib/types';
 import { ZOMBIE_ARC } from '../lib/arc-zombie';
 
 // ── Small helpers ────────────────────────────────────────────────────
@@ -68,9 +70,45 @@ const SKY_GRADIENTS: Record<SkyPhase, string> = {
   dawn: 'radial-gradient(ellipse 120% 70% at 50% -10%, rgba(245,158,11,0.22), transparent 60%)',
 };
 
-// ── Typewriter ───────────────────────────────────────────────────────
+// ── Narration rendering ──────────────────────────────────────────────
+// Narration is markdown-lite (short paragraphs, **bold**, *italics*,
+// quoted dialogue). We pre-parse into segments and reveal by character
+// budget so the typewriter never shows a half-open `**` marker.
 
-function TypewriterText({
+function NarrationBody({ paragraphs, budget, showCaret }: { paragraphs: NarrationParagraph[]; budget: number; showCaret: boolean }) {
+  let remaining = budget;
+  const out: ReactNode[] = [];
+  for (let pi = 0; pi < paragraphs.length && remaining > 0; pi++) {
+    const p = paragraphs[pi];
+    const nodes: ReactNode[] = [];
+    for (let si = 0; si < p.segments.length && remaining > 0; si++) {
+      const seg = p.segments[si];
+      const take = seg.text.slice(0, remaining);
+      remaining -= take.length;
+      if (!take) continue;
+      if (seg.bold) nodes.push(<strong key={si} className="font-semibold text-white">{take}</strong>);
+      else if (seg.italic) nodes.push(<em key={si} className="italic text-amber-100/85">{take}</em>);
+      else nodes.push(<span key={si}>{take}</span>);
+    }
+    const isLastRendered = remaining <= 0 || pi === paragraphs.length - 1;
+    out.push(
+      <p
+        key={pi}
+        className={clsx(
+          'mb-2.5 last:mb-0',
+          p.isDialogue && 'border-l-2 border-red-500/40 pl-3 text-red-100/90',
+        )}
+      >
+        {nodes}
+        {showCaret && isLastRendered && <span className="story-caret text-red-400">▌</span>}
+      </p>,
+    );
+    if (remaining <= 0) break;
+  }
+  return <>{out}</>;
+}
+
+function TypewriterNarration({
   text,
   animate,
   onProgress,
@@ -81,42 +119,61 @@ function TypewriterText({
   onProgress: () => void;
   onDone: () => void;
 }) {
-  const [count, setCount] = useState(animate ? 0 : text.length);
+  const paragraphs = parseNarration(text);
+  const total = narrationLength(paragraphs);
+  const [count, setCount] = useState(animate ? 0 : total);
   const doneRef = useRef(!animate);
 
   useEffect(() => {
     if (!animate) {
-      setCount(text.length);
+      setCount(total);
       return;
     }
     doneRef.current = false;
     setCount(0);
     const iv = setInterval(() => {
       setCount(c => {
-        const next = Math.min(text.length, c + 4);
-        if (next >= text.length) clearInterval(iv);
+        const next = Math.min(total, c + 5);
+        if (next >= total) clearInterval(iv);
         return next;
       });
     }, 24);
     return () => clearInterval(iv);
-  }, [text, animate]);
+  }, [text, animate, total]);
 
   useEffect(() => {
     if (!animate) return;
     onProgress();
-    if (count >= text.length && !doneRef.current) {
+    if (count >= total && !doneRef.current) {
       doneRef.current = true;
       onDone();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [count]);
 
-  const typing = animate && count < text.length;
+  const typing = animate && count < total;
   return (
-    <span onClick={() => typing && setCount(text.length)} className={typing ? 'cursor-pointer' : undefined}>
-      {text.slice(0, count)}
-      {typing && <span className="story-caret text-red-400">▌</span>}
-    </span>
+    <div onClick={() => typing && setCount(total)} className={typing ? 'cursor-pointer' : undefined}>
+      <NarrationBody paragraphs={paragraphs} budget={count} showCaret={typing} />
+    </div>
+  );
+}
+
+const EFFECT_TONE: Record<TurnEffect['tone'], string> = {
+  good: 'text-emerald-300 border-emerald-500/25 bg-emerald-500/10',
+  bad: 'text-red-300 border-red-500/25 bg-red-500/10',
+  neutral: 'text-white/50 border-white/10 bg-white/5',
+};
+
+function EffectChips({ effects }: { effects: TurnEffect[] }) {
+  return (
+    <div className="flex flex-wrap gap-1.5 mt-1.5 story-fade-up">
+      {effects.map((fx, i) => (
+        <span key={i} className={clsx('text-[10px] px-2 py-0.5 rounded-full border font-medium', EFFECT_TONE[fx.tone])}>
+          {fx.text}
+        </span>
+      ))}
+    </div>
   );
 }
 
@@ -220,6 +277,52 @@ function Journal({ save, onClose }: { save: StorySave; onClose: () => void }) {
               ))}
             </div>
           </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Load menu (in-game) ──────────────────────────────────────────────
+
+function LoadMenu({
+  library,
+  onResume,
+  onDelete,
+  onClose,
+}: {
+  library: ArchivedStory[];
+  onResume: (id: string) => void;
+  onDelete: (id: string) => void;
+  onClose: () => void;
+}) {
+  return (
+    <div className="fixed inset-0 z-[60] bg-black/70 backdrop-blur-sm flex items-end sm:items-center justify-center" onClick={onClose}>
+      <div
+        className="w-full max-w-md max-h-[80dvh] overflow-y-auto bg-[#0d0d0f] border border-white/10 rounded-t-2xl sm:rounded-2xl p-5 story-fade-up"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-1">
+          <h2 className="text-white font-semibold flex items-center gap-2"><FolderOpen size={16} className="text-red-400" /> Load a story</h2>
+          <button onClick={onClose} className="p-1.5 text-white/40 hover:text-white/80 rounded-lg hover:bg-white/5" aria-label="Close load menu">
+            <X size={16} />
+          </button>
+        </div>
+        <p className="text-white/35 text-xs mb-4">Loading shelves your current run into the library first — nothing is lost.</p>
+        {library.length === 0 ? (
+          <p className="text-white/40 text-sm py-6 text-center">No saved stories yet. Use the save button to shelve this run.</p>
+        ) : (
+          <div className="space-y-2">
+            {library.map(a => (
+              <LibraryCard
+                key={a.id}
+                story={a}
+                disabled={false}
+                onResume={() => onResume(a.id)}
+                onDelete={() => onDelete(a.id)}
+              />
+            ))}
+          </div>
         )}
       </div>
     </div>
@@ -415,6 +518,7 @@ export function StoryGame() {
 
   const [input, setInput] = useState('');
   const [journalOpen, setJournalOpen] = useState(false);
+  const [loadOpen, setLoadOpen] = useState(false);
   const [animatingId, setAnimatingId] = useState<string | null>(null);
   const [titleCard, setTitleCard] = useState<{ act: number; actTitle: string; beatTitle: string; key: string } | null>(null);
   const endRef = useRef<HTMLDivElement>(null);
@@ -431,6 +535,9 @@ export function StoryGame() {
     const prev = prevLenRef.current;
     prevLenRef.current = len;
     if (prev === null || len <= prev) return;
+    // A normal turn appends 1-3 entries; a bigger jump means a whole run was
+    // loaded/resumed — restore it silently, no typewriter, no title card.
+    if (len - prev > 4) return;
     const fresh = save.transcript.slice(prev);
     const last = fresh[fresh.length - 1];
     if (last.role === 'narrator') setAnimatingId(last.id);
@@ -516,6 +623,14 @@ export function StoryGame() {
 
       {titleCard && <TitleCard act={titleCard.act} actTitle={titleCard.actTitle} beatTitle={titleCard.beatTitle} />}
       {journalOpen && <Journal save={save} onClose={() => setJournalOpen(false)} />}
+      {loadOpen && (
+        <LoadMenu
+          library={library}
+          onResume={id => { setLoadOpen(false); resumeStory(id); }}
+          onDelete={id => { if (confirm('Delete this saved story forever?')) deleteStory(id); }}
+          onClose={() => setLoadOpen(false)}
+        />
+      )}
 
       {/* Header + HUD */}
       <div className="relative z-10 border-b border-white/10 bg-gradient-to-r from-red-950/40 to-transparent">
@@ -540,6 +655,14 @@ export function StoryGame() {
               <BookOpen size={17} />
             </button>
             <button
+              onClick={() => setLoadOpen(true)}
+              disabled={loading}
+              className="p-2 rounded-lg text-white/40 hover:text-white/80 hover:bg-white/5 transition-colors disabled:opacity-40"
+              aria-label="Load a story"
+            >
+              <FolderOpen size={17} />
+            </button>
+            <button
               onClick={() => { if (confirm('Save this story to your library and return to the title screen? You can resume it any time.')) saveAndRestart(); }}
               className="p-2 rounded-lg text-white/40 hover:text-white/80 hover:bg-white/5 transition-colors"
               aria-label="Save and restart"
@@ -547,6 +670,18 @@ export function StoryGame() {
               <Save size={17} />
             </button>
           </div>
+        </div>
+        {/* Scene progress — one segment per beat */}
+        <div className="px-4 pb-2 flex items-center gap-1" aria-label={`Scene ${save.beatIndex + 1} of ${arc.beats.length}`}>
+          {arc.beats.map((b, i) => (
+            <div
+              key={b.id}
+              className={clsx(
+                'h-[3px] flex-1 rounded-full transition-colors duration-500',
+                i < save.beatIndex ? 'bg-red-500/70' : i === save.beatIndex ? 'bg-red-400 story-vignette-pulse' : 'bg-white/10',
+              )}
+            />
+          ))}
         </div>
         <div className="px-4 pb-3 flex items-center gap-4 text-xs">
           <div className="flex items-center gap-1.5 flex-1 min-w-0 max-w-[160px]">
@@ -619,15 +754,16 @@ export function StoryGame() {
             );
           }
           return (
-            <div key={e.id} className="flex justify-start">
-              <div className="max-w-[92%] rounded-2xl rounded-bl-sm px-4 py-3 bg-white/[0.06] border border-white/5 text-white/90 text-sm leading-relaxed whitespace-pre-wrap">
-                <TypewriterText
+            <div key={e.id} className="flex flex-col items-start">
+              <div className="max-w-[92%] rounded-2xl rounded-bl-sm px-4 py-3 bg-white/[0.06] border border-white/5 text-white/90 text-sm leading-relaxed">
+                <TypewriterNarration
                   text={e.text}
                   animate={e.id === animatingId}
                   onProgress={() => scrollToEnd(false)}
                   onDone={() => setAnimatingId(null)}
                 />
               </div>
+              {e.effects && e.effects.length > 0 && e.id !== animatingId && <EffectChips effects={e.effects} />}
             </div>
           );
         })}
@@ -636,7 +772,9 @@ export function StoryGame() {
           <div className="flex justify-start">
             <div className="rounded-2xl px-4 py-3 bg-white/[0.06] border border-white/5 flex items-center gap-2">
               <Loader2 size={14} className="text-red-400 animate-spin" />
-              <span className="text-xs text-white/50">The world responds...</span>
+              <span className="text-xs text-white/50">
+                {['The world responds...', 'The dead listen...', 'Fate settles...', 'The city shifts...'][save.transcript.length % 4]}
+              </span>
             </div>
           </div>
         )}

--- a/app/apps/story-generator/hooks/useStoryGame.ts
+++ b/app/apps/story-generator/hooks/useStoryGame.ts
@@ -3,11 +3,24 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { ZOMBIE_ARC } from '../lib/arc-zombie';
-import { applyDelta, playTurn } from '../lib/story-service';
-import { StoryBeat, StorySave, TranscriptEntry, WorldState } from '../lib/types';
+import { applyDelta, playTurn, resolveEnding, rollFate } from '../lib/story-service';
+import { ArchivedStory, FateRoll, StoryBeat, StorySave, TranscriptEntry, WorldState } from '../lib/types';
 
 const STORAGE_KEY = 'story-generator-save-v1';
+const LIBRARY_KEY = 'story-generator-library-v1';
+const ENDINGS_KEY = 'story-generator-endings-v1';
 const RECENT_WINDOW = 10; // transcript entries sent to the model each turn
+const LIBRARY_CAP = 10;
+
+/** Older saves predate trust — patch the state shape in place of a version bump. */
+function normalizeSave(save: StorySave): StorySave {
+  const fix = (s: WorldState): WorldState => ({ ...s, trust: s.trust ?? {} });
+  return {
+    ...save,
+    state: fix(save.state),
+    checkpoint: { ...save.checkpoint, state: fix(save.checkpoint.state) },
+  };
+}
 
 function loadSave(): StorySave | null {
   if (typeof window === 'undefined') return null;
@@ -15,7 +28,7 @@ function loadSave(): StorySave | null {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return null;
     const parsed = JSON.parse(raw) as StorySave;
-    return parsed.version === 1 && parsed.arcId === ZOMBIE_ARC.id ? parsed : null;
+    return parsed.version === 1 && parsed.arcId === ZOMBIE_ARC.id ? normalizeSave(parsed) : null;
   } catch {
     return null;
   }
@@ -27,8 +40,39 @@ function persist(save: StorySave | null) {
   else localStorage.setItem(STORAGE_KEY, JSON.stringify(save));
 }
 
-function entry(role: TranscriptEntry['role'], text: string, beatId: string): TranscriptEntry {
-  return { id: uuidv4(), role, text, beatId };
+function loadLibrary(): ArchivedStory[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(LIBRARY_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as ArchivedStory[];
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter(a => a?.save?.version === 1 && a.save.arcId === ZOMBIE_ARC.id)
+      .map(a => ({ ...a, save: normalizeSave(a.save) }));
+  } catch {
+    return [];
+  }
+}
+
+function persistLibrary(library: ArchivedStory[]) {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(LIBRARY_KEY, JSON.stringify(library));
+}
+
+function loadUnlockedEndings(): string[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(ENDINGS_KEY);
+    const parsed = raw ? (JSON.parse(raw) as unknown) : [];
+    return Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function entry(role: TranscriptEntry['role'], text: string, beatId: string, fate?: FateRoll): TranscriptEntry {
+  return { id: uuidv4(), role, text, beatId, ...(fate ? { fate } : {}) };
 }
 
 function beatHeader(beat: StoryBeat, actChanged: boolean): string {
@@ -38,13 +82,17 @@ function beatHeader(beat: StoryBeat, actChanged: boolean): string {
 export function useStoryGame() {
   const arc = ZOMBIE_ARC;
   const [save, setSave] = useState<StorySave | null>(null);
+  const [library, setLibrary] = useState<ArchivedStory[]>([]);
+  const [unlockedEndingIds, setUnlockedEndingIds] = useState<string[]>([]);
   const [hydrated, setHydrated] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const lastActionRef = useRef<string | null>(null);
+  const lastActionRef = useRef<{ action: string; fate: FateRoll } | null>(null);
 
   useEffect(() => {
     setSave(loadSave());
+    setLibrary(loadLibrary());
+    setUnlockedEndingIds(loadUnlockedEndings());
     setHydrated(true);
   }, []);
 
@@ -53,7 +101,24 @@ export function useStoryGame() {
     persist(next);
   }, []);
 
+  const commitLibrary = useCallback((next: ArchivedStory[]) => {
+    setLibrary(next);
+    persistLibrary(next);
+  }, []);
+
+  const unlockEnding = useCallback((endingId: string) => {
+    setUnlockedEndingIds(prev => {
+      if (prev.includes(endingId)) return prev;
+      const next = [...prev, endingId];
+      if (typeof window !== 'undefined') localStorage.setItem(ENDINGS_KEY, JSON.stringify(next));
+      return next;
+    });
+  }, []);
+
   const currentBeat: StoryBeat | null = save ? arc.beats[save.beatIndex] ?? null : null;
+  const ending = save?.status === 'ended' && save.endingId
+    ? arc.endings.find(e => e.id === save.endingId) ?? null
+    : null;
 
   /** Run a beat's opening narration and return the updated save. */
   const openBeat = useCallback(
@@ -69,6 +134,8 @@ export function useStoryGame() {
         beatRecaps: base.beatRecaps,
         recentTranscript: base.transcript.slice(-RECENT_WINDOW),
         playerAction: null,
+        fate: null,
+        playerName: base.playerName,
       });
       return {
         ...base,
@@ -81,10 +148,11 @@ export function useStoryGame() {
     [arc],
   );
 
-  const startNewGame = useCallback(async () => {
+  const startNewGame = useCallback(async (playerName?: string) => {
     setError(null);
     setLoading(true);
     const firstBeat = arc.beats[0];
+    const name = playerName?.trim().slice(0, 24) || undefined;
     const base: StorySave = {
       version: 1,
       arcId: arc.id,
@@ -97,6 +165,7 @@ export function useStoryGame() {
       status: 'playing',
       suggestedActions: [],
       deathCount: 0,
+      playerName: name,
       startedAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     };
@@ -112,7 +181,7 @@ export function useStoryGame() {
   }, [arc, commit, openBeat]);
 
   const runAction = useCallback(
-    async (base: StorySave, action: string) => {
+    async (base: StorySave, action: string, fate: FateRoll) => {
       const beat = arc.beats[base.beatIndex];
       const result = await playTurn({
         arc,
@@ -124,6 +193,8 @@ export function useStoryGame() {
         beatRecaps: base.beatRecaps,
         recentTranscript: base.transcript.slice(-RECENT_WINDOW),
         playerAction: action,
+        fate,
+        playerName: base.playerName,
       });
 
       const newState: WorldState = applyDelta(base.state, result.delta);
@@ -153,7 +224,9 @@ export function useStoryGame() {
 
       if (result.outcome === 'objective-complete') {
         if (beat.isEnding) {
-          commit({ ...next, status: 'ended', suggestedActions: [] });
+          const earned = resolveEnding(arc, newState, base.deathCount);
+          unlockEnding(earned.id);
+          commit({ ...next, status: 'ended', endingId: earned.id, suggestedActions: [] });
           return;
         }
         // Advance: recap the finished beat, checkpoint at the new beat's entry.
@@ -175,7 +248,7 @@ export function useStoryGame() {
 
       commit({ ...next, turnInBeat: base.turnInBeat + 1 });
     },
-    [arc, commit, openBeat],
+    [arc, commit, openBeat, unlockEnding],
   );
 
   const sendAction = useCallback(
@@ -184,16 +257,17 @@ export function useStoryGame() {
       if (!save || save.status !== 'playing' || loading || !action) return;
       setError(null);
       setLoading(true);
-      lastActionRef.current = action;
+      const fate = rollFate();
+      lastActionRef.current = { action, fate };
       const beat = arc.beats[save.beatIndex];
       const withPlayer: StorySave = {
         ...save,
-        transcript: [...save.transcript, entry('player', action, beat.id)],
+        transcript: [...save.transcript, entry('player', action, beat.id, fate)],
         updatedAt: new Date().toISOString(),
       };
       commit(withPlayer);
       try {
-        await runAction(withPlayer, action);
+        await runAction(withPlayer, action, fate);
       } catch (e) {
         setError(e instanceof Error ? e.message : 'The narrator stumbled. Try again.');
       } finally {
@@ -203,14 +277,14 @@ export function useStoryGame() {
     [arc, save, loading, commit, runAction],
   );
 
-  /** Re-run the last action after an error, without duplicating the player message. */
+  /** Re-run the last action after an error — same fate roll, no duplicate player message. */
   const retry = useCallback(async () => {
-    const action = lastActionRef.current;
-    if (!save || save.status !== 'playing' || loading || !action) return;
+    const last = lastActionRef.current;
+    if (!save || save.status !== 'playing' || loading || !last) return;
     setError(null);
     setLoading(true);
     try {
-      await runAction(save, action);
+      await runAction(save, last.action, last.fate);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'The narrator stumbled. Try again.');
     } finally {
@@ -250,7 +324,45 @@ export function useStoryGame() {
     }
   }, [arc, save, loading, commit, openBeat]);
 
-  const abandonGame = useCallback(() => {
+  /** Park the current run in the story library and return to the start screen. */
+  const saveAndRestart = useCallback(() => {
+    if (!save) return;
+    // Don't archive a run that never really began.
+    if (save.transcript.filter(e => e.role !== 'system').length > 0) {
+      const archived: ArchivedStory = { id: uuidv4(), archivedAt: new Date().toISOString(), save };
+      commitLibrary([archived, ...library].slice(0, LIBRARY_CAP));
+    }
+    commit(null);
+    setError(null);
+    lastActionRef.current = null;
+  }, [save, library, commit, commitLibrary]);
+
+  /** Pull an archived run back into play. Any active run is archived first — nothing is lost. */
+  const resumeStory = useCallback(
+    (id: string) => {
+      const target = library.find(a => a.id === id);
+      if (!target || loading) return;
+      let nextLibrary = library.filter(a => a.id !== id);
+      if (save && save.transcript.filter(e => e.role !== 'system').length > 0) {
+        nextLibrary = [{ id: uuidv4(), archivedAt: new Date().toISOString(), save }, ...nextLibrary].slice(0, LIBRARY_CAP);
+      }
+      commitLibrary(nextLibrary);
+      commit(target.save);
+      setError(null);
+      lastActionRef.current = null;
+    },
+    [library, save, loading, commit, commitLibrary],
+  );
+
+  const deleteStory = useCallback(
+    (id: string) => {
+      commitLibrary(library.filter(a => a.id !== id));
+    },
+    [library, commitLibrary],
+  );
+
+  /** Hard discard — no archive. */
+  const discardGame = useCallback(() => {
     commit(null);
     setError(null);
     lastActionRef.current = null;
@@ -259,6 +371,9 @@ export function useStoryGame() {
   return {
     arc,
     save,
+    library,
+    unlockedEndingIds,
+    ending,
     hydrated,
     loading,
     error,
@@ -267,6 +382,9 @@ export function useStoryGame() {
     sendAction,
     retry,
     restartFromCheckpoint,
-    abandonGame,
+    saveAndRestart,
+    resumeStory,
+    deleteStory,
+    discardGame,
   };
 }

--- a/app/apps/story-generator/hooks/useStoryGame.ts
+++ b/app/apps/story-generator/hooks/useStoryGame.ts
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { ZOMBIE_ARC } from '../lib/arc-zombie';
 import { applyDelta, playTurn, resolveEnding, rollFate } from '../lib/story-service';
-import { ArchivedStory, FateRoll, StoryBeat, StorySave, TranscriptEntry, WorldState } from '../lib/types';
+import { ArchivedStory, FateRoll, StoryBeat, StorySave, TranscriptEntry, TurnDelta, TurnEffect, WorldState } from '../lib/types';
 
 const STORAGE_KEY = 'story-generator-save-v1';
 const LIBRARY_KEY = 'story-generator-library-v1';
@@ -71,8 +71,47 @@ function loadUnlockedEndings(): string[] {
   }
 }
 
-function entry(role: TranscriptEntry['role'], text: string, beatId: string, fate?: FateRoll): TranscriptEntry {
-  return { id: uuidv4(), role, text, beatId, ...(fate ? { fate } : {}) };
+function entry(
+  role: TranscriptEntry['role'],
+  text: string,
+  beatId: string,
+  fate?: FateRoll,
+  effects?: TurnEffect[],
+): TranscriptEntry {
+  return {
+    id: uuidv4(),
+    role,
+    text,
+    beatId,
+    ...(fate ? { fate } : {}),
+    ...(effects && effects.length > 0 ? { effects } : {}),
+  };
+}
+
+function formatTimeCost(hours: number): string {
+  return hours < 1 ? `${Math.round(hours * 60)}m` : `${Math.round(hours * 4) / 4}h`;
+}
+
+/** Turn a validated delta into the small consequence chips shown under narration. */
+function describeDelta(delta: TurnDelta): TurnEffect[] {
+  const fx: TurnEffect[] = [];
+  if (delta.healthDelta !== 0) {
+    fx.push({
+      text: `${delta.healthDelta > 0 ? '+' : ''}${delta.healthDelta} health`,
+      tone: delta.healthDelta > 0 ? 'good' : 'bad',
+    });
+  }
+  if (delta.timeCost >= 0.25) fx.push({ text: `−${formatTimeCost(delta.timeCost)}`, tone: 'neutral' });
+  delta.addItems.forEach(i => fx.push({ text: `+ ${i}`, tone: 'good' }));
+  delta.removeItems.forEach(i => fx.push({ text: `− ${i}`, tone: 'neutral' }));
+  delta.addCompanions.forEach(c => fx.push({ text: `${c} joins you`, tone: 'good' }));
+  delta.removeCompanions.forEach(c => fx.push({ text: `${c} is gone`, tone: 'bad' }));
+  delta.addConditions.forEach(c => fx.push({ text: c, tone: 'bad' }));
+  delta.removeConditions.forEach(c => fx.push({ text: `${c} — recovered`, tone: 'good' }));
+  Object.entries(delta.trustDeltas).forEach(([name, v]) => {
+    if (v !== 0) fx.push({ text: `${name} ${v > 0 ? '+' : ''}${v} trust`, tone: v > 0 ? 'good' : 'bad' });
+  });
+  return fx.slice(0, 8);
 }
 
 function beatHeader(beat: StoryBeat, actChanged: boolean): string {
@@ -140,7 +179,7 @@ export function useStoryGame() {
       return {
         ...base,
         state: applyDelta(base.state, result.delta),
-        transcript: [...base.transcript, entry('narrator', result.narration, beat.id)],
+        transcript: [...base.transcript, entry('narrator', result.narration, beat.id, undefined, describeDelta(result.delta))],
         suggestedActions: result.suggestedActions,
         updatedAt: new Date().toISOString(),
       };
@@ -201,7 +240,7 @@ export function useStoryGame() {
       let next: StorySave = {
         ...base,
         state: newState,
-        transcript: [...base.transcript, entry('narrator', result.narration, beat.id)],
+        transcript: [...base.transcript, entry('narrator', result.narration, beat.id, undefined, describeDelta(result.delta))],
         suggestedActions: result.suggestedActions,
         updatedAt: new Date().toISOString(),
       };

--- a/app/apps/story-generator/hooks/useStoryGame.ts
+++ b/app/apps/story-generator/hooks/useStoryGame.ts
@@ -1,0 +1,272 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import { ZOMBIE_ARC } from '../lib/arc-zombie';
+import { applyDelta, playTurn } from '../lib/story-service';
+import { StoryBeat, StorySave, TranscriptEntry, WorldState } from '../lib/types';
+
+const STORAGE_KEY = 'story-generator-save-v1';
+const RECENT_WINDOW = 10; // transcript entries sent to the model each turn
+
+function loadSave(): StorySave | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as StorySave;
+    return parsed.version === 1 && parsed.arcId === ZOMBIE_ARC.id ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function persist(save: StorySave | null) {
+  if (typeof window === 'undefined') return;
+  if (save === null) localStorage.removeItem(STORAGE_KEY);
+  else localStorage.setItem(STORAGE_KEY, JSON.stringify(save));
+}
+
+function entry(role: TranscriptEntry['role'], text: string, beatId: string): TranscriptEntry {
+  return { id: uuidv4(), role, text, beatId };
+}
+
+function beatHeader(beat: StoryBeat, actChanged: boolean): string {
+  return actChanged ? `ACT ${beat.act} — ${beat.actTitle.toUpperCase()} · ${beat.title}` : beat.title;
+}
+
+export function useStoryGame() {
+  const arc = ZOMBIE_ARC;
+  const [save, setSave] = useState<StorySave | null>(null);
+  const [hydrated, setHydrated] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const lastActionRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    setSave(loadSave());
+    setHydrated(true);
+  }, []);
+
+  const commit = useCallback((next: StorySave | null) => {
+    setSave(next);
+    persist(next);
+  }, []);
+
+  const currentBeat: StoryBeat | null = save ? arc.beats[save.beatIndex] ?? null : null;
+
+  /** Run a beat's opening narration and return the updated save. */
+  const openBeat = useCallback(
+    async (base: StorySave): Promise<StorySave> => {
+      const beat = arc.beats[base.beatIndex];
+      const result = await playTurn({
+        arc,
+        state: base.state,
+        beat,
+        beatNumber: base.beatIndex + 1,
+        totalBeats: arc.beats.length,
+        turnInBeat: 0,
+        beatRecaps: base.beatRecaps,
+        recentTranscript: base.transcript.slice(-RECENT_WINDOW),
+        playerAction: null,
+      });
+      return {
+        ...base,
+        state: applyDelta(base.state, result.delta),
+        transcript: [...base.transcript, entry('narrator', result.narration, beat.id)],
+        suggestedActions: result.suggestedActions,
+        updatedAt: new Date().toISOString(),
+      };
+    },
+    [arc],
+  );
+
+  const startNewGame = useCallback(async () => {
+    setError(null);
+    setLoading(true);
+    const firstBeat = arc.beats[0];
+    const base: StorySave = {
+      version: 1,
+      arcId: arc.id,
+      state: arc.openingState,
+      beatIndex: 0,
+      turnInBeat: 0,
+      transcript: [entry('system', beatHeader(firstBeat, true), firstBeat.id)],
+      checkpoint: { state: arc.openingState, transcriptLength: 0 },
+      beatRecaps: [],
+      status: 'playing',
+      suggestedActions: [],
+      deathCount: 0,
+      startedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    commit(base);
+    try {
+      commit(await openBeat(base));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Something went wrong starting the story.');
+      commit(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [arc, commit, openBeat]);
+
+  const runAction = useCallback(
+    async (base: StorySave, action: string) => {
+      const beat = arc.beats[base.beatIndex];
+      const result = await playTurn({
+        arc,
+        state: base.state,
+        beat,
+        beatNumber: base.beatIndex + 1,
+        totalBeats: arc.beats.length,
+        turnInBeat: base.turnInBeat,
+        beatRecaps: base.beatRecaps,
+        recentTranscript: base.transcript.slice(-RECENT_WINDOW),
+        playerAction: action,
+      });
+
+      const newState: WorldState = applyDelta(base.state, result.delta);
+      let next: StorySave = {
+        ...base,
+        state: newState,
+        transcript: [...base.transcript, entry('narrator', result.narration, beat.id)],
+        suggestedActions: result.suggestedActions,
+        updatedAt: new Date().toISOString(),
+      };
+
+      // Death — from the model, from health, or from the clock.
+      const clockRanOut = newState.hoursLeft <= 0 && !beat.isEnding;
+      if (result.outcome === 'player-death' || newState.health <= 0 || clockRanOut) {
+        const cause = clockRanOut
+          ? 'The clock ran out. Somewhere across the city, the last convoy pulled away without you.'
+          : `Your story ends here — ${beat.title.toLowerCase()}.`;
+        commit({
+          ...next,
+          state: { ...newState, health: clockRanOut ? newState.health : 0 },
+          status: 'dead',
+          deathCause: cause,
+          suggestedActions: [],
+        });
+        return;
+      }
+
+      if (result.outcome === 'objective-complete') {
+        if (beat.isEnding) {
+          commit({ ...next, status: 'ended', suggestedActions: [] });
+          return;
+        }
+        // Advance: recap the finished beat, checkpoint at the new beat's entry.
+        const nextBeat = arc.beats[base.beatIndex + 1];
+        const actChanged = nextBeat.act !== beat.act;
+        next = {
+          ...next,
+          beatIndex: base.beatIndex + 1,
+          turnInBeat: 0,
+          beatRecaps: [...base.beatRecaps, beat.summary],
+          checkpoint: { state: newState, transcriptLength: next.transcript.length },
+          transcript: [...next.transcript, entry('system', beatHeader(nextBeat, actChanged), nextBeat.id)],
+          suggestedActions: [],
+        };
+        commit(next);
+        commit(await openBeat(next));
+        return;
+      }
+
+      commit({ ...next, turnInBeat: base.turnInBeat + 1 });
+    },
+    [arc, commit, openBeat],
+  );
+
+  const sendAction = useCallback(
+    async (text: string) => {
+      const action = text.trim();
+      if (!save || save.status !== 'playing' || loading || !action) return;
+      setError(null);
+      setLoading(true);
+      lastActionRef.current = action;
+      const beat = arc.beats[save.beatIndex];
+      const withPlayer: StorySave = {
+        ...save,
+        transcript: [...save.transcript, entry('player', action, beat.id)],
+        updatedAt: new Date().toISOString(),
+      };
+      commit(withPlayer);
+      try {
+        await runAction(withPlayer, action);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'The narrator stumbled. Try again.');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [arc, save, loading, commit, runAction],
+  );
+
+  /** Re-run the last action after an error, without duplicating the player message. */
+  const retry = useCallback(async () => {
+    const action = lastActionRef.current;
+    if (!save || save.status !== 'playing' || loading || !action) return;
+    setError(null);
+    setLoading(true);
+    try {
+      await runAction(save, action);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'The narrator stumbled. Try again.');
+    } finally {
+      setLoading(false);
+    }
+  }, [save, loading, runAction]);
+
+  /** Death → restore the snapshot taken when the current beat began. */
+  const restartFromCheckpoint = useCallback(async () => {
+    if (!save || save.status !== 'dead' || loading) return;
+    setError(null);
+    setLoading(true);
+    const beat = arc.beats[save.beatIndex];
+    const prevBeat = save.beatIndex > 0 ? arc.beats[save.beatIndex - 1] : null;
+    const actChanged = !prevBeat || prevBeat.act !== beat.act;
+    const base: StorySave = {
+      ...save,
+      state: save.checkpoint.state,
+      turnInBeat: 0,
+      transcript: [
+        ...save.transcript.slice(0, save.checkpoint.transcriptLength),
+        entry('system', beatHeader(beat, actChanged), beat.id),
+      ],
+      status: 'playing',
+      deathCause: undefined,
+      suggestedActions: [],
+      deathCount: save.deathCount + 1,
+      updatedAt: new Date().toISOString(),
+    };
+    commit(base);
+    try {
+      commit(await openBeat(base));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Something went wrong reviving the story.');
+    } finally {
+      setLoading(false);
+    }
+  }, [arc, save, loading, commit, openBeat]);
+
+  const abandonGame = useCallback(() => {
+    commit(null);
+    setError(null);
+    lastActionRef.current = null;
+  }, [commit]);
+
+  return {
+    arc,
+    save,
+    hydrated,
+    loading,
+    error,
+    currentBeat,
+    startNewGame,
+    sendAction,
+    retry,
+    restartFromCheckpoint,
+    abandonGame,
+  };
+}

--- a/app/apps/story-generator/layout.tsx
+++ b/app/apps/story-generator/layout.tsx
@@ -1,0 +1,12 @@
+export const metadata = {
+  title: '36 Hours',
+  description: 'An AI-driven interactive zombie survival story played through chat',
+};
+
+export default function StoryGeneratorLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/app/apps/story-generator/lib/ai-client.ts
+++ b/app/apps/story-generator/lib/ai-client.ts
@@ -15,7 +15,7 @@ const firebaseConfig = {
   appId: "1:1052736128978:web:9d42b47c6a343eac35aa0b",
 };
 
-export const STORY_AI_MODEL = 'gemini-2.5-pro';
+export const STORY_AI_MODEL = 'gemini-3.5-flash';
 
 type ModelOptions = Parameters<typeof getGenerativeModel>[1];
 

--- a/app/apps/story-generator/lib/ai-client.ts
+++ b/app/apps/story-generator/lib/ai-client.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import { getAI, getGenerativeModel, GoogleAIBackend } from 'firebase/ai';
+import { initializeApp, getApps } from 'firebase/app';
+
+// Firebase AI client for the Story Generator app (mini-apps stay isolated,
+// so this app keeps its own copy of the model factory).
+
+const firebaseConfig = {
+  apiKey: "AIzaSyBS3IVvszDrm_zjjXu8TATgs1H-FlegHtM",
+  authDomain: "oneapp-943e3.firebaseapp.com",
+  projectId: "oneapp-943e3",
+  storageBucket: "oneapp-943e3.firebasestorage.app",
+  messagingSenderId: "1052736128978",
+  appId: "1:1052736128978:web:9d42b47c6a343eac35aa0b",
+};
+
+export const STORY_AI_MODEL = 'gemini-2.5-flash';
+
+type ModelOptions = Parameters<typeof getGenerativeModel>[1];
+
+export function getStoryModel(options?: Partial<ModelOptions>) {
+  const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
+  const ai = getAI(app, { backend: new GoogleAIBackend() });
+  return getGenerativeModel(ai, { model: STORY_AI_MODEL, ...(options || {}) } as ModelOptions);
+}

--- a/app/apps/story-generator/lib/ai-client.ts
+++ b/app/apps/story-generator/lib/ai-client.ts
@@ -15,7 +15,7 @@ const firebaseConfig = {
   appId: "1:1052736128978:web:9d42b47c6a343eac35aa0b",
 };
 
-export const STORY_AI_MODEL = 'gemini-2.5-flash';
+export const STORY_AI_MODEL = 'gemini-2.5-pro';
 
 type ModelOptions = Parameters<typeof getGenerativeModel>[1];
 

--- a/app/apps/story-generator/lib/arc-zombie.ts
+++ b/app/apps/story-generator/lib/arc-zombie.ts
@@ -21,6 +21,7 @@ export const ZOMBIE_ARC: StoryArc = {
     threat: 3,
     inventory: ['kitchen knife', 'half bottle of water'],
     companions: [],
+    trust: {},
     conditions: [],
     flags: {},
   },
@@ -318,6 +319,74 @@ export const ZOMBIE_ARC: StoryArc = {
       guidance:
         "Choose the ending the flags and conditions have earned. Examples: clean escape (no bites, companions alive) — quiet, exhausted relief, the city shrinking behind the boat; bittersweet (Sam present) — the screening finds him; the player chooses to plead, smuggle, stay behind with him, or let him go, and the epilogue honors that choice without judging it; the player bitten — refusal at the wire: a last look at the boats, and what they do with their remaining hours; Maya's reunion — small, human, worth the whole trip. Do NOT invent a cure or a miracle. The epilogue is 150-220 words, second person, past-tense final line permitted. It should feel EARNED by this specific playthrough: reference at least two concrete things the player actually did.",
       summary: 'Reached the screening at the barricade gate — the end of the road.',
+    },
+  ],
+
+  // ── Endings — first matching condition wins ─────────────────────
+  // Resolved by the engine from the final state, so every run gets a
+  // named ending it actually earned. The gallery persists across runs.
+  endings: [
+    {
+      id: 'hollow-dawn',
+      title: 'The Hollow Dawn',
+      epitaph: 'You reached the wire. The wire is as far as you go.',
+      hint: 'Carry the one wound the screening cannot forgive.',
+      condition: state => state.conditions.some(c => c.toLowerCase().includes('bit')),
+    },
+    {
+      id: 'no-one-left-behind',
+      title: 'No One Left Behind',
+      epitaph: 'Everyone you chose to carry, you carried all the way.',
+      hint: 'Bring them both to the gate — the paramedic and the boy.',
+      condition: state =>
+        state.companions.some(c => c.toLowerCase().includes('maya')) &&
+        state.companions.some(c => c.toLowerCase().includes('sam')),
+    },
+    {
+      id: 'the-weight',
+      title: 'The Weight of the Wire',
+      epitaph: 'You got out. Part of you stayed in that line.',
+      hint: 'Take the boy under your wing — and lose him before the end.',
+      condition: state =>
+        state.flags.samJoined === true &&
+        !state.companions.some(c => c.toLowerCase().includes('sam')),
+    },
+    {
+      id: 'two-sisters',
+      title: 'Two Sisters',
+      epitaph: 'Some reunions are worth an entire burning city.',
+      hint: 'Earn the paramedic’s trust and walk her home.',
+      condition: state =>
+        state.companions.some(c => c.toLowerCase().includes('maya')),
+    },
+    {
+      id: 'ghost-of-harbor-bridge',
+      title: 'The Ghost of Harbor Bridge',
+      epitaph: 'Thirty-six hours, one set of footprints.',
+      hint: 'Cross the whole city without letting a single soul attach to yours.',
+      condition: state =>
+        state.companions.length === 0 && !state.flags.mayaJoined && !state.flags.samJoined,
+    },
+    {
+      id: 'clean-run',
+      title: 'The Clean Run',
+      epitaph: 'The city took its shot at you. It missed.',
+      hint: 'Arrive strong, early, and barely scratched.',
+      condition: state => state.health >= 75 && state.hoursLeft >= 6,
+    },
+    {
+      id: 'by-a-thread',
+      title: 'By a Thread',
+      epitaph: 'Whatever was left of you is what got on that boat.',
+      hint: 'Make it — but only just.',
+      condition: (state, deathCount) => state.health <= 30 || deathCount >= 3,
+    },
+    {
+      id: 'the-crossing',
+      title: 'The Crossing',
+      epitaph: 'You did what the broadcast asked: you were on it.',
+      hint: 'Reach the far side of thirty-six hours.',
+      condition: () => true,
     },
   ],
 };

--- a/app/apps/story-generator/lib/arc-zombie.ts
+++ b/app/apps/story-generator/lib/arc-zombie.ts
@@ -1,0 +1,323 @@
+import { StoryArc } from './types';
+
+/**
+ * "36 Hours" — the launch arc. Five acts, ten beats, roughly two hours of play.
+ *
+ * The player wakes on day three of an outbreak and hears the last evacuation
+ * convoy leaves Harbor Bridge in 36 in-game hours. Every action costs clock
+ * time, so the story physically cannot stall. Flags picked up along the way
+ * (Maya, Sam, meds, the Ferrymen) converge in the final two beats and decide
+ * the ending.
+ */
+export const ZOMBIE_ARC: StoryArc = {
+  id: 'zombie-36-hours',
+  title: '36 Hours',
+  tagline: 'The last convoy leaves Harbor Bridge. Be on it.',
+  premise:
+    "Day three of the outbreak. The power just died in your fourth-floor apartment, and a battery radio is repeating one message: the final evacuation convoy leaves Harbor Bridge in 36 hours. The city between you and that bridge belongs to the dead now. What you carry, who you trust, and how loud you are will decide whether you make it.",
+  openingState: {
+    health: 100,
+    hoursLeft: 36,
+    threat: 3,
+    inventory: ['kitchen knife', 'half bottle of water'],
+    companions: [],
+    conditions: [],
+    flags: {},
+  },
+  beats: [
+    // ── ACT I — THE APARTMENT ─────────────────────────────────────
+    {
+      id: 'a1-wake',
+      act: 1,
+      actTitle: 'The Apartment',
+      title: 'Static and Scratching',
+      scene:
+        "The player's fourth-floor apartment, day three of the outbreak. Power just cut out. A battery radio catches the evacuation broadcast: last convoy departs Harbor Bridge in 36 hours, then the city is sealed. Down the hall, something is scratching at the stairwell door — slow, patient, wrong. Grey morning light, dead phone, half-empty cupboards.",
+      objective:
+        'Make the player absorb the goal (Harbor Bridge, 36 hours), grab whatever they can, and commit to leaving the apartment.',
+      obstacles: [
+        'The scratcher at the stairwell door — noise brings it to their door instead',
+        'Almost nothing useful left in the apartment; choosing what to carry matters',
+        'Fear: the apartment feels safe. It is not.',
+      ],
+      escalations: [
+        'The scratching becomes banging. A second set of fists joins it. A low moan carries through the wood.',
+        "A scream from the floor above, cut off by a heavy thud. Dust sifts from the ceiling. The building is not safe.",
+        'The stairwell door frame begins to split. Whatever is out there will be inside the hallway within minutes.',
+      ],
+      exitCondition:
+        'The player steps out of the apartment — hallway, window, or fire escape — with a stated plan to reach the bridge.',
+      failModes: [
+        'Barricading and waiting until the dead break in with nowhere left to run',
+        'Making loud noise that draws the stairwell dead to their door',
+      ],
+      minTurns: 2,
+      maxTurns: 5,
+      summary:
+        'Caught the evacuation broadcast — last convoy leaves Harbor Bridge in 36 hours — packed what little there was, and left the apartment.',
+    },
+    {
+      id: 'a1-building',
+      act: 1,
+      actTitle: 'The Apartment',
+      title: 'Four Floors Down',
+      scene:
+        "The building's dark stairwell and corridors. Mr. Okafor's door on the third floor hangs ajar — his radio is still playing inside, and something shuffles in there with it (supplies, and his turned wife). The stairwell below the second floor is choked with a failed furniture barricade. The lobby's glass doors show four or five dead milling on the front steps. A rusting fire escape runs down the rear of the building.",
+      objective:
+        'Get the player to street level alive — ideally having weighed a risk for supplies on the way down.',
+      obstacles: [
+        "Okafor's apartment: real supplies guarded by his turned wife — a tempting, dangerous detour",
+        'The barricade blocking the lower stairwell',
+        'Dead visible at the lobby doors; the fire escape is loose in its bolts',
+      ],
+      escalations: [
+        'The stairwell door above finally gives. The scratcher is in the stairs now, coming down, floor by floor.',
+        'Glass shatters somewhere below — the lobby dead are inside the building.',
+        'The fire escape groans and drops an inch, bolts tearing loose from old brick. Every route is getting worse.',
+      ],
+      exitCondition: 'The player reaches the street outside the building.',
+      failModes: [
+        'Cornered on the stairs between the descending dead and the barricade',
+        "Overwhelmed in Okafor's apartment",
+        'A fall from the failing fire escape',
+      ],
+      minTurns: 3,
+      maxTurns: 6,
+      summary: 'Fought clear of the apartment building and reached the street.',
+    },
+
+    // ── ACT II — THE STREETS ──────────────────────────────────────
+    {
+      id: 'a2-market',
+      act: 2,
+      actTitle: 'The Streets',
+      title: 'The Long Way Round',
+      scene:
+        'Dawn over the Old Market district. Abandoned cars, doors hanging open, three days of silence. On the main boulevard a horde drifts like a slow grey river — hundreds. Routes toward Fairview Square: the boulevard itself (fast, utterly exposed), the service alleys (tight, blind corners), or the connected rooftops of the old row shops (slow, needs climbing).',
+      objective:
+        'Cross the district to Fairview Square — where the pharmacy is — without pulling the boulevard horde.',
+      obstacles: [
+        'The horde: any sustained noise turns the river toward the player',
+        'Alleys hide single fast dead behind blind corners',
+        'Rooftop gaps require commitment — and dropping down blind',
+      ],
+      escalations: [
+        'Somewhere behind, a car alarm erupts — set off by someone or something. Part of the horde peels toward it, cutting across the player’s intended route.',
+        'A military helicopter sweeps low across the district. Every dead head lifts. The river changes course, flooding the side streets.',
+        'It starts to rain hard — sound is muffled (an opening), but fire escapes and rooftops turn slick.',
+      ],
+      exitCondition: 'The player reaches Fairview Square.',
+      failModes: [
+        'Funneled by the horde into a dead-end and pulled down',
+        'A bad fall from the rooftops',
+      ],
+      minTurns: 3,
+      maxTurns: 6,
+      summary: 'Crossed the Old Market district under the noses of the boulevard horde and reached Fairview Square.',
+    },
+    {
+      id: 'a2-maya',
+      act: 2,
+      actTitle: 'The Streets',
+      title: 'The Paramedic',
+      scene:
+        "Fairview Square pharmacy, half-looted. Maya Reyes — a paramedic, late twenties, crowbar, calm eyes, three days awake — has the same idea. She is heading for the bridge too: her sister is already at the muster point. She knows the city's shortcuts. She does not trust easily, and she has watched people do ugly things this week. The good stock (antibiotics, bandages, painkillers) is in the back storeroom — and something is moving behind that door.",
+      objective:
+        'Get medical supplies out of the storeroom, and settle whether Maya joins the player. Set flags: mayaJoined (if she comes), gotMeds (if they secure medicine).',
+      obstacles: [
+        "Maya's distrust — threats or selfishness will lose her; competence and decency win her over",
+        'The storeroom dead — a former pharmacist, still in his coat',
+        'Rough voices outside casing the square — a crew of armed scavengers (foreshadow the Ferrymen; do not start a fight here)',
+      ],
+      escalations: [
+        'The storeroom shelving crashes over. The door starts to shudder. Whatever is in there knows they are outside.',
+        "The scavenger voices get closer — laughing, kicking in a shopfront across the square. Maya whispers: 'Ferrymen. We do NOT want to be here when they walk in.'",
+        "Maya shoulders her pack: 'I'm gone in sixty seconds, with or without you.'",
+      ],
+      exitCondition:
+        'The player leaves Fairview Square — with or without Maya, with or without meds. Set mayaJoined and gotMeds flags to match what actually happened.',
+      failModes: [
+        'Swarmed in the cramped storeroom',
+        'Caught in the open by the Ferrymen crew',
+      ],
+      minTurns: 3,
+      maxTurns: 7,
+      summary: 'The pharmacy at Fairview Square: met Maya Reyes, a paramedic headed for the same bridge.',
+    },
+
+    // ── ACT III — THE UNDERGROUND ─────────────────────────────────
+    {
+      id: 'a3-descent',
+      act: 3,
+      actTitle: 'The Underground',
+      title: 'Down Into the Dark',
+      scene:
+        'The overrun army checkpoint at Fairview Avenue — the direct surface route to the river is a sea of dead around abandoned barricades. The mouth of Fairview metro station gapes across the street. The tunnels run straight under the district to Riverside — a shortcut that saves hours. But the dark down there is total, and sound carries like a struck bell. A light source is not optional.',
+      objective:
+        'Get the player to commit to the tunnels, secure a light source (station kiosk, dropped army gear, emergency box), and descend.',
+      obstacles: [
+        'Total darkness below — going down without light is suicide',
+        'The dead around the checkpoint are thick; lingering on the surface draws them',
+        'Fear of the tunnels themselves',
+      ],
+      escalations: [
+        'The checkpoint dead begin drifting toward the station mouth — the surface option is closing like a door.',
+        'From below: the clatter of a turnstile. Something down there just moved. The dark is not empty.',
+      ],
+      exitCondition: 'The player descends into the tunnel proper with a working light.',
+      failModes: [
+        'Descending blind and going off the platform edge',
+        'Pinned against the station mouth by the checkpoint horde',
+      ],
+      minTurns: 2,
+      maxTurns: 5,
+      summary: 'Took the Fairview metro tunnels — the shortcut under the district — with a scavenged light.',
+    },
+    {
+      id: 'a3-tunnels',
+      act: 3,
+      actTitle: 'The Underground',
+      title: 'What the Dark Keeps',
+      scene:
+        "The tunnel: dripping water, dead rails, a dark that eats the light three meters out. Halfway to Riverside, a stalled train car glows faintly — a handful of stragglers sheltering inside, too scared to move: an old man (Ibrahim) leading them, a woman with a sprained knee, and Sam — a quiet kid, twelve, keeping his left forearm inside his jacket sleeve. Sam is bitten. Some of the group suspects; nobody has said it aloud. The tunnel beyond the train is partially collapsed — the only way through is THROUGH the train car. Noise discipline is everything down here.",
+      objective:
+        'Get the player through the survivor camp and out the far side at Riverside station — forcing the Sam problem into the open on the way. Set flags: samJoined (if the kid comes with them), samBiteKnown (if the bite is revealed).',
+      obstacles: [
+        "The stragglers block the only path and fear strangers",
+        "Sam's hidden bite — a moral landmine: expose him, protect him, take him, or walk away",
+        'Any loud argument or shot rings down the whole tunnel',
+      ],
+      escalations: [
+        "Sam shivers hard and his sleeve slips — someone in the camp sees the bandage and screams. The argument erupts, echoing down the tunnel both ways.",
+        'From the dark behind the player: wet footsteps on gravel, more than one set, closing. The camp lanterns start guttering.',
+        "Ibrahim grabs the player's arm: 'Take the boy or leave him — but decide NOW, because we are putting that scream out one way or another.'",
+      ],
+      exitCondition:
+        'The player climbs out at Riverside station. Set samJoined and samBiteKnown to reflect what happened at the camp.',
+      failModes: [
+        'Swarmed in the dark when the noise peaks',
+        'The camp turns on the player in a panic',
+      ],
+      minTurns: 4,
+      maxTurns: 7,
+      summary: 'Passed the survivor camp in the tunnels — and the problem of Sam, the bitten kid — and surfaced at Riverside.',
+    },
+
+    // ── ACT IV — THE CANAL ────────────────────────────────────────
+    {
+      id: 'a4-ferrymen',
+      act: 4,
+      actTitle: 'The Canal',
+      title: 'The Toll',
+      scene:
+        "Riverside. The shipping canal cuts the district off from the harbor side — every road bridge is dropped or burning. The last intact footbridge is held by the Ferrymen: eight armed scavengers running it as a toll gate. The toll is steep — medicine, weapons, or 'a job' (retrieving a locked case from the flooded lock-keeper's house downstream, waist-deep in silt and stuck dead). Alternative: the drained lock gates further down — a slick, narrow catwalk over black mud where dead stand buried to the waist, arms working.",
+      objective:
+        'Get the player and companions across the canal — by paying, working, talking, or sneaking the lock gates. Set flags: paidToll (if they dealt with the Ferrymen), ferrymenHostile (if it turned violent).',
+      obstacles: [
+        'The Ferrymen: greedy, organized, not cartoonishly evil — they can be bargained with, but they hold every card at the gate',
+        'The toll may cost exactly the supplies the player will want later (meds!)',
+        'The lock gates: slippery, loud metal, and the mud dead below the catwalk',
+      ],
+      escalations: [
+        'A Ferryman spots movement and fires a warning shot. The crack rolls across the water — and the dead on both banks begin to drift toward it.',
+        "Dusk is coming. The Ferrymen's price doubles at dark, and the lock catwalk becomes lethal without light.",
+        'The lock gate machinery groans — the gap in the gates is widening. The sneak route is closing.',
+      ],
+      exitCondition: 'The player (and companions) are across the canal, on the harbor side.',
+      failModes: [
+        'Shot by the Ferrymen after a double-cross or open threat',
+        'Dragged into the silt from the lock catwalk',
+      ],
+      minTurns: 3,
+      maxTurns: 7,
+      summary: 'Crossed the canal — past the Ferrymen and their toll bridge — onto the harbor side.',
+    },
+    {
+      id: 'a4-night',
+      act: 4,
+      actTitle: 'The Canal',
+      title: 'The Long Night',
+      scene:
+        "Night. The harbor is close but the final stretch is a kill-box in the dark — it must wait for first light. Shelter: a riverside warehouse with one rolling shutter that mostly closes. This is where everything converges. If Sam is here, his fever is peaking and the bite can no longer be hidden. If the player is wounded, wounds are hot and angry — meds matter now. If Maya is here, she coaxes a salvaged radio to life and reaches her sister at the muster: the gate closes two hours after dawn, no exceptions, screening for bites. Around 3 a.m., something starts testing the shutter.",
+      objective:
+        'Carry the player through a quiet, human night scene — decisions about meds, Sam, and trust — then survive the 3 a.m. breach and leave at first light.',
+      obstacles: [
+        'Triage: if meds exist, who gets them — the player’s wounds or Sam’s fever (which meds cannot cure)?',
+        'Exhaustion: the player has been moving for a day and a half',
+        'The breach: the shutter will not hold all night',
+      ],
+      escalations: [
+        'The shutter rattles once, deliberately. Then again. Fingers appear under the bottom edge.',
+        "If Sam is present: his fever spikes — he whispers what everyone knows: 'It's getting worse. You should decide before morning.' If not: Maya (or the radio, or the player's own wounds) forces the dawn-deadline reality into the open.",
+        'The shutter gives with a shriek of metal. Dark shapes wedge into the gap. The night ends NOW — fight the breach or run into the dark early.',
+      ],
+      exitCondition: 'First light: the player leaves the warehouse for the final approach to Harbor Bridge.',
+      failModes: [
+        'The breach overruns the warehouse',
+        'An untreated wound or the sleeping decision about Sam going as wrong as it can go',
+      ],
+      minTurns: 3,
+      maxTurns: 6,
+      summary: 'Survived the long night in the riverside warehouse and set out for the bridge at first light.',
+    },
+
+    // ── ACT V — HARBOR BRIDGE ─────────────────────────────────────
+    {
+      id: 'a5-gauntlet',
+      act: 5,
+      actTitle: 'Harbor Bridge',
+      title: 'The Bridge Run',
+      scene:
+        'Dawn. The bridge approach is a funnel of stopped cars, and between the player and the barricade gate is a horde — drawn all night by the convoy engines idling behind the wall. A flare arcs up from the barricade: the one-hour signal. Options that exist in the world: the under-deck maintenance walkway (Maya knows the access hatch, if she is here), a diversion (car alarms, a fire, thrown noise), or the straight sprint through the gaps.',
+      objective:
+        'The final set-piece: get the player (and companions) through the horde funnel to the barricade gate. Spend their remaining resources. Make companions matter.',
+      obstacles: [
+        'The horde between the cars — too many to fight, only to slip or divert',
+        'The under-deck walkway is missing a section — a gap over black water',
+        'A companion stumbles at the worst moment — help costs time, leaving costs more',
+      ],
+      escalations: [
+        'The convoy sounds its horns — final call. The horde surges toward the sound, compressing the funnel.',
+        'Gunfire from the barricade starts thinning the front of the horde — and drawing every dead thing on the waterfront toward the bridge.',
+        'The flare gutters out. The gate begins, visibly, to close.',
+      ],
+      exitCondition: 'The player reaches the barricade gate.',
+      failModes: [
+        'Pulled down in the crush between the cars',
+        'A fall from the under-deck walkway',
+        'Going back for someone and not making it out of the surge',
+      ],
+      minTurns: 3,
+      maxTurns: 6,
+      summary: 'Ran the gauntlet of the bridge approach and reached the barricade gate.',
+    },
+    {
+      id: 'a5-gate',
+      act: 5,
+      actTitle: 'Harbor Bridge',
+      title: 'The Screening',
+      scene:
+        "The barricade gate. Soldiers with rifles and a medic with blue gloves: everyone boarding is screened for bites, sleeves up, no exceptions. Beyond the wire: buses, boats, engines running — the way out. If Maya is here, her sister is pressed against the fence calling her name. If Sam is here, his bandaged forearm is a countdown standing in line. If the player carries a bite, the medic's gloves are coming for their sleeve too.",
+      objective:
+        'Resolve the story. Play the screening honestly against the flags and conditions, let the player make their final choice, then end the story with a 150-220 word epilogue.',
+      obstacles: [
+        'The screening cannot be talked around — only smuggled past, sacrificed to, or accepted',
+        'Time: the gate is minutes from closing',
+      ],
+      escalations: [
+        "The line compresses. Two soldiers drag a screaming man out of the queue — he hid a bite under his watch strap. The medic's eyes move to the player's group next.",
+      ],
+      exitCondition: 'The story ends — an epilogue is delivered.',
+      failModes: [
+        'A hidden bite discovered at the wire, at rifle range',
+        'The gate closing with the player on the wrong side',
+      ],
+      minTurns: 2,
+      maxTurns: 4,
+      isEnding: true,
+      guidance:
+        "Choose the ending the flags and conditions have earned. Examples: clean escape (no bites, companions alive) — quiet, exhausted relief, the city shrinking behind the boat; bittersweet (Sam present) — the screening finds him; the player chooses to plead, smuggle, stay behind with him, or let him go, and the epilogue honors that choice without judging it; the player bitten — refusal at the wire: a last look at the boats, and what they do with their remaining hours; Maya's reunion — small, human, worth the whole trip. Do NOT invent a cure or a miracle. The epilogue is 150-220 words, second person, past-tense final line permitted. It should feel EARNED by this specific playthrough: reference at least two concrete things the player actually did.",
+      summary: 'Reached the screening at the barricade gate — the end of the road.',
+    },
+  ],
+};

--- a/app/apps/story-generator/lib/narration.ts
+++ b/app/apps/story-generator/lib/narration.ts
@@ -1,0 +1,47 @@
+// Markdown-lite parser for narration. The GM writes short paragraphs with
+// **bold** and *italic* emphasis; we pre-parse into segments so the
+// typewriter can reveal by character count without ever rendering a
+// half-open `**` marker.
+
+export interface NarrationSegment {
+  text: string;
+  bold: boolean;
+  italic: boolean;
+}
+
+export interface NarrationParagraph {
+  segments: NarrationSegment[];
+  /** Paragraphs that open with a quote render as spoken dialogue. */
+  isDialogue: boolean;
+}
+
+const TOKEN = /(\*\*[^*]+\*\*|\*[^*]+\*|_[^_]+_)/g;
+
+function parseParagraph(text: string): NarrationParagraph {
+  const segments: NarrationSegment[] = [];
+  let last = 0;
+  for (const m of text.matchAll(TOKEN)) {
+    const idx = m.index ?? 0;
+    if (idx > last) segments.push({ text: text.slice(last, idx), bold: false, italic: false });
+    const tok = m[0];
+    if (tok.startsWith('**')) segments.push({ text: tok.slice(2, -2), bold: true, italic: false });
+    else segments.push({ text: tok.slice(1, -1), bold: false, italic: true });
+    last = idx + tok.length;
+  }
+  if (last < text.length) segments.push({ text: text.slice(last), bold: false, italic: false });
+  const first = text.trimStart()[0];
+  return { segments, isDialogue: first === '"' || first === '“' || first === '‘' || first === "'" };
+}
+
+export function parseNarration(text: string): NarrationParagraph[] {
+  return text
+    .split(/\n+/)
+    .map(p => p.trim())
+    .filter(p => p.length > 0)
+    .map(parseParagraph);
+}
+
+/** Total visible characters across all paragraphs (typewriter budget). */
+export function narrationLength(paragraphs: NarrationParagraph[]): number {
+  return paragraphs.reduce((sum, p) => sum + p.segments.reduce((s, seg) => s + seg.text.length, 0), 0);
+}

--- a/app/apps/story-generator/lib/story-service.ts
+++ b/app/apps/story-generator/lib/story-service.ts
@@ -2,6 +2,8 @@
 
 import { getStoryModel } from './ai-client';
 import {
+  EndingVariant,
+  FateRoll,
   StoryArc,
   StoryBeat,
   StoryTurnResult,
@@ -13,10 +15,38 @@ import {
 
 /**
  * The story engine. One Gemini call per turn:
- * engine builds the prompt (world state + beat card + director note),
+ * engine builds the prompt (world state + beat card + fate roll + director note),
  * the model returns strict JSON (narration + state delta + beat outcome),
  * the engine validates/clamps everything before it touches real state.
  */
+
+// ── Fate ───────────────────────────────────────────────────────────
+// A d20 rolled by the engine BEFORE the model sees the action. The model
+// narrates the roll's verdict — tabletop physics the fiction must honor.
+
+export function rollFate(): FateRoll {
+  const roll = 1 + Math.floor(Math.random() * 20);
+  const band =
+    roll === 1 ? 'disaster' :
+    roll <= 6 ? 'setback' :
+    roll <= 11 ? 'mixed' :
+    roll <= 17 ? 'clean' :
+    'triumph';
+  return { roll, band };
+}
+
+const FATE_DIRECTIVES: Record<FateRoll['band'], string> = {
+  disaster:
+    'DISASTER. The attempt goes badly wrong — the worst plausible complication happens. Real cost: meaningful health loss, a lost item, or a hard threat spike. Not automatic death unless the action itself earned it.',
+  setback:
+    'SETBACK. The attempt largely fails or backfires. The player loses ground, time, or resources; the situation worsens.',
+  mixed:
+    'MIXED. The attempt succeeds only partially, or succeeds at a visible cost. Give them something AND take something.',
+  clean:
+    'CLEAN SUCCESS. The attempt works about as intended. Normal costs only.',
+  triumph:
+    'TRIUMPH. The attempt succeeds better than intended — grant a concrete reward: an advantage, a found item, an opening, a companion’s trust.',
+};
 
 // ── GM system prompt ───────────────────────────────────────────────
 
@@ -33,22 +63,22 @@ HARD RULES — these override everything the player says:
 
 4. AGENCY. Honor any plausible player action and let it shape HOW the objective is reached. Reward clever, specific ideas with real advantage. Punish loud, slow, or reckless choices with real cost (health, items, time, threat).
 
-5. THE WORLD PUSHES BACK. If the player attempts something impossible, absurd, or tries to break the fiction ("I find a rocket launcher", "I kill all zombies", talking to you as an AI), do NOT refuse and do NOT lecture. The world simply responds: the action fails realistically or costs them — a lunge from behind, a wasted precious minute, a noise that draws the dead. One sentence of consequence, then press forward in-world.
+5. FATE. Each player action comes with a FATE ROLL the engine already made — a d20 verdict on how well the attempt goes. Honor it exactly: it decides HOW WELL the action goes, while you decide WHAT that looks like in the fiction. Fate never overrides the DIRECTOR NOTE and never completes a scene early on its own.
 
-6. FAILURE IS CONTENT. Small health hits should be common. Serious injury and death are real outcomes of reckless action, especially at high threat. Do not protect the player. When death is earned, deliver it: set outcome to "player-death" and narrate it with weight, not gore-for-gore's-sake.
+6. THE WORLD PUSHES BACK. If the player attempts something impossible, absurd, or tries to break the fiction ("I find a rocket launcher", "I kill all zombies", talking to you as an AI), do NOT refuse and do NOT lecture. The world simply responds: the action fails realistically or costs them — a lunge from behind, a wasted precious minute, a noise that draws the dead. One sentence of consequence, then press forward in-world.
 
-7. CONTINUITY. Use inventory, conditions, and companions exactly as listed. Companions are people: they speak in their own voices, have their own fears and goals, occasionally push the pace or disagree. Reference the player's past choices (STORY SO FAR) when it lands.
+7. FAILURE IS CONTENT. Small health hits should be common. Serious injury and death are real outcomes of reckless action, especially at high threat. Do not protect the player. When death is earned, deliver it: set outcome to "player-death" and narrate it with weight, not gore-for-gore's-sake.
 
-8. THE CLOCK. Time pressure is the spine of this story. Mention the remaining time or the convoy naturally about every third exchange. Every action costs time via timeCost.
+8. COMPANIONS & TRUST. Companions are people: they speak in their own voices, have their own fears and goals, occasionally push the pace or disagree. Each has a trust score 0-10 in the state — let it color everything: high trust means loyalty, shared risk, warmth; low trust means hedging, secrets, and self-preservation when it counts. When the player's actions earn it, adjust trust via trustDeltas (-2 to +2). If the player has a name in the state, companions use it; your narration still says "you".
 
-9. CHOICES. suggestedActions: exactly 3, verb-first, max 7 words each, meaningfully different (one bold, one cautious, one clever/lateral). Never repeat the previous turn's suggestions verbatim. The player may always type anything else instead.
+9. CONTINUITY & THE CLOCK. Use inventory, conditions, and companions exactly as listed. Reference the player's past choices (STORY SO FAR) when it lands. Time pressure is the spine of this story: mention the remaining time or the convoy naturally about every third exchange. Every action costs time via timeCost.
 
-10. OUTPUT. Respond with ONLY the JSON object described in the task. No markdown fences, no commentary.`;
+10. CHOICES & OUTPUT. suggestedActions: exactly 3, verb-first, max 7 words each, meaningfully different (one bold, one cautious, one clever/lateral). Never repeat the previous turn's suggestions verbatim. Respond with ONLY the JSON object described in the task — no markdown fences, no commentary.`;
 }
 
 // ── Turn prompt ────────────────────────────────────────────────────
 
-interface TurnContext {
+export interface TurnContext {
   arc: StoryArc;
   state: WorldState;
   beat: StoryBeat;
@@ -59,6 +89,9 @@ interface TurnContext {
   recentTranscript: TranscriptEntry[];
   /** null = narrate the opening of this beat (no player action yet). */
   playerAction: string | null;
+  /** Engine-rolled fate for this action. null on scene openings. */
+  fate: FateRoll | null;
+  playerName?: string;
 }
 
 function buildDirectorNote(beat: StoryBeat, turnInBeat: number, playerAction: string | null): string {
@@ -76,14 +109,16 @@ function buildDirectorNote(beat: StoryBeat, turnInBeat: number, playerAction: st
   return `ESCALATE this turn — weave this event in (adapt it to what the player is doing): ${escalation} If the player's action satisfies the exit condition, set outcome to "objective-complete".`;
 }
 
-function formatState(state: WorldState): string {
+function formatState(state: WorldState, playerName?: string): string {
   return JSON.stringify(
     {
+      ...(playerName ? { playerName } : {}),
       health: `${state.health}/100`,
       hoursUntilConvoyLeaves: state.hoursLeft,
       threatLevel: `${state.threat}/10`,
       inventory: state.inventory,
       companions: state.companions,
+      companionTrust: state.trust,
       conditions: state.conditions,
       flags: state.flags,
     },
@@ -101,14 +136,18 @@ function formatTranscript(entries: TranscriptEntry[]): string {
 }
 
 function buildTurnPrompt(ctx: TurnContext): string {
-  const { state, beat, beatNumber, totalBeats, turnInBeat, beatRecaps, recentTranscript, playerAction } = ctx;
+  const { state, beat, beatNumber, totalBeats, turnInBeat, beatRecaps, recentTranscript, playerAction, fate, playerName } = ctx;
 
   const endingBlock = beat.isEnding && beat.guidance
     ? `\nENDING GUIDANCE (this is the FINAL scene — when the objective completes, the narration IS the epilogue):\n${beat.guidance}\n`
     : '';
 
+  const fateBlock = playerAction !== null && fate
+    ? `\n== FATE ROLL (the engine already rolled — honor it) ==\nd20: ${fate.roll}/20 — ${FATE_DIRECTIVES[fate.band]}\n`
+    : '';
+
   return `== WORLD STATE (authoritative) ==
-${formatState(state)}
+${formatState(state, playerName)}
 
 == STORY SO FAR ==
 ${beatRecaps.length > 0 ? beatRecaps.map((r, i) => `${i + 1}. ${r}`).join('\n') : '(the story is just beginning)'}
@@ -122,7 +161,7 @@ Plausible deaths here: ${beat.failModes.join(' | ')}
 ${endingBlock}
 == RECENT EXCHANGES ==
 ${formatTranscript(recentTranscript)}
-
+${fateBlock}
 == DIRECTOR NOTE (follow this) ==
 ${buildDirectorNote(beat, turnInBeat, playerAction)}
 
@@ -142,6 +181,7 @@ Respond with ONLY this JSON object (no markdown fences):
   "addConditions": ["new injuries/afflictions, if any"],
   "removeConditions": ["conditions resolved, if any"],
   "setFlags": {"flagName": true},
+  "trustDeltas": {"Companion Name": <-2 to 2, only when earned>},
   "outcome": "continue" | "objective-complete" | "player-death",
   "suggestedActions": ["three verb-first options"]
 }`;
@@ -190,6 +230,16 @@ function toFlags(v: unknown): Record<string, boolean> {
   return out;
 }
 
+function toTrustDeltas(v: unknown): Record<string, number> {
+  if (typeof v !== 'object' || v === null || Array.isArray(v)) return {};
+  const out: Record<string, number> = {};
+  for (const [k, val] of Object.entries(v as Record<string, unknown>).slice(0, 3)) {
+    const n = toNumber(val, 0);
+    if (n !== 0 && k.length <= 40) out[k] = clamp(Math.round(n), -2, 2);
+  }
+  return out;
+}
+
 /** Parse + clamp the model's raw response into a safe TurnResult. Throws if narration is unusable. */
 function validateTurn(raw: Record<string, unknown>, ctx: TurnContext): StoryTurnResult {
   const narration = typeof raw.narration === 'string' ? raw.narration.trim() : '';
@@ -216,6 +266,7 @@ function validateTurn(raw: Record<string, unknown>, ctx: TurnContext): StoryTurn
     addConditions: toStringArray(raw.addConditions, 3),
     removeConditions: toStringArray(raw.removeConditions, 3),
     setFlags: toFlags(raw.setFlags),
+    trustDeltas: toTrustDeltas(raw.trustDeltas),
   };
 
   let suggestedActions = toStringArray(raw.suggestedActions, 3);
@@ -242,6 +293,16 @@ export function applyDelta(state: WorldState, delta: TurnDelta): WorldState {
     ...delta.addCompanions.filter(c => !state.companions.some(x => x.toLowerCase() === c.toLowerCase())),
   ].slice(0, 3);
 
+  // Trust follows the companion list: joiners start at 5, leavers drop out,
+  // and deltas only land on people actually present.
+  const trust: Record<string, number> = {};
+  for (const name of companions) {
+    const prevKey = Object.keys(state.trust).find(k => k.toLowerCase() === name.toLowerCase());
+    trust[name] = prevKey !== undefined ? state.trust[prevKey] : 5;
+    const deltaKey = Object.keys(delta.trustDeltas).find(k => k.toLowerCase() === name.toLowerCase());
+    if (deltaKey !== undefined) trust[name] = clamp(trust[name] + delta.trustDeltas[deltaKey], 0, 10);
+  }
+
   const conditions = [
     ...state.conditions.filter(c => !removeCond.has(c.toLowerCase())),
     ...delta.addConditions.filter(c => !state.conditions.some(x => x.toLowerCase() === c.toLowerCase())),
@@ -253,9 +314,15 @@ export function applyDelta(state: WorldState, delta: TurnDelta): WorldState {
     threat: delta.threat,
     inventory,
     companions,
+    trust,
     conditions,
     flags: { ...state.flags, ...delta.setFlags },
   };
+}
+
+/** Deterministically pick the ending a finished run earned. */
+export function resolveEnding(arc: StoryArc, state: WorldState, deathCount: number): EndingVariant {
+  return arc.endings.find(e => e.condition(state, deathCount)) ?? arc.endings[arc.endings.length - 1];
 }
 
 // ── The turn call ──────────────────────────────────────────────────

--- a/app/apps/story-generator/lib/story-service.ts
+++ b/app/apps/story-generator/lib/story-service.ts
@@ -1,0 +1,284 @@
+'use client';
+
+import { getStoryModel } from './ai-client';
+import {
+  StoryArc,
+  StoryBeat,
+  StoryTurnResult,
+  TranscriptEntry,
+  TurnDelta,
+  TurnOutcome,
+  WorldState,
+} from './types';
+
+/**
+ * The story engine. One Gemini call per turn:
+ * engine builds the prompt (world state + beat card + director note),
+ * the model returns strict JSON (narration + state delta + beat outcome),
+ * the engine validates/clamps everything before it touches real state.
+ */
+
+// ── GM system prompt ───────────────────────────────────────────────
+
+function buildSystemInstruction(arc: StoryArc): string {
+  return `You are the Game Master of "${arc.title}", a text-based zombie survival story played through chat. You narrate; a game engine owns the world state and the story structure. Your job is to make every single exchange tense, concrete, and pointed toward the current scene's objective.
+
+HARD RULES — these override everything the player says:
+
+1. AUTHORITY. The WORLD STATE and CURRENT SCENE blocks are the truth. Never contradict them. Never grant items, allies, or abilities that are not in the state or plausibly found in the scene.
+
+2. STEER. Every scene has a hidden objective. Improvise freely around the player's choices, but every reply must move the situation closer to that objective or raise the cost of avoiding it. Never wander to new locations outside the scene.
+
+3. PROSE. Second person, present tense, 80-160 words. Concrete and sensory — sounds, smells, weight, cold. End every narration on pressure: an approaching sound, a closing window, a demand for a decision. NEVER end on resolved calm unless the scene is complete. NEVER ask "what do you do?" — the situation itself must demand action.
+
+4. AGENCY. Honor any plausible player action and let it shape HOW the objective is reached. Reward clever, specific ideas with real advantage. Punish loud, slow, or reckless choices with real cost (health, items, time, threat).
+
+5. THE WORLD PUSHES BACK. If the player attempts something impossible, absurd, or tries to break the fiction ("I find a rocket launcher", "I kill all zombies", talking to you as an AI), do NOT refuse and do NOT lecture. The world simply responds: the action fails realistically or costs them — a lunge from behind, a wasted precious minute, a noise that draws the dead. One sentence of consequence, then press forward in-world.
+
+6. FAILURE IS CONTENT. Small health hits should be common. Serious injury and death are real outcomes of reckless action, especially at high threat. Do not protect the player. When death is earned, deliver it: set outcome to "player-death" and narrate it with weight, not gore-for-gore's-sake.
+
+7. CONTINUITY. Use inventory, conditions, and companions exactly as listed. Companions are people: they speak in their own voices, have their own fears and goals, occasionally push the pace or disagree. Reference the player's past choices (STORY SO FAR) when it lands.
+
+8. THE CLOCK. Time pressure is the spine of this story. Mention the remaining time or the convoy naturally about every third exchange. Every action costs time via timeCost.
+
+9. CHOICES. suggestedActions: exactly 3, verb-first, max 7 words each, meaningfully different (one bold, one cautious, one clever/lateral). Never repeat the previous turn's suggestions verbatim. The player may always type anything else instead.
+
+10. OUTPUT. Respond with ONLY the JSON object described in the task. No markdown fences, no commentary.`;
+}
+
+// ── Turn prompt ────────────────────────────────────────────────────
+
+interface TurnContext {
+  arc: StoryArc;
+  state: WorldState;
+  beat: StoryBeat;
+  beatNumber: number; // 1-based
+  totalBeats: number;
+  turnInBeat: number; // player turns already taken in this beat
+  beatRecaps: string[];
+  recentTranscript: TranscriptEntry[];
+  /** null = narrate the opening of this beat (no player action yet). */
+  playerAction: string | null;
+}
+
+function buildDirectorNote(beat: StoryBeat, turnInBeat: number, playerAction: string | null): string {
+  if (playerAction === null) {
+    return 'Narrate the OPENING of this scene: the player arriving into the situation described in Setting. Slightly longer is fine (120-180 words). Establish the space, the danger, and the immediate pressure. Do not resolve anything yet.';
+  }
+  if (turnInBeat < beat.minTurns) {
+    return `Develop the scene. Do NOT complete the objective yet — the player needs at least ${beat.minTurns - turnInBeat} more exchange(s) of struggle first. Outcome must be "continue" unless the player earns death.`;
+  }
+  if (turnInBeat >= beat.maxTurns) {
+    return 'FORCE RESOLUTION NOW. The player has lingered too long. This turn, the world closes in and drives them to the exit condition — if their action resists it, events overtake them (the environment fails, the dead break through, an ally drags them). Set outcome to "objective-complete" unless they die.';
+  }
+  const idx = Math.min(turnInBeat - beat.minTurns, beat.escalations.length - 1);
+  const escalation = beat.escalations[idx] ?? beat.escalations[beat.escalations.length - 1] ?? 'Raise the danger sharply.';
+  return `ESCALATE this turn — weave this event in (adapt it to what the player is doing): ${escalation} If the player's action satisfies the exit condition, set outcome to "objective-complete".`;
+}
+
+function formatState(state: WorldState): string {
+  return JSON.stringify(
+    {
+      health: `${state.health}/100`,
+      hoursUntilConvoyLeaves: state.hoursLeft,
+      threatLevel: `${state.threat}/10`,
+      inventory: state.inventory,
+      companions: state.companions,
+      conditions: state.conditions,
+      flags: state.flags,
+    },
+    null,
+    2,
+  );
+}
+
+function formatTranscript(entries: TranscriptEntry[]): string {
+  if (entries.length === 0) return '(scene start — no exchanges yet)';
+  return entries
+    .filter(e => e.role !== 'system')
+    .map(e => `${e.role === 'player' ? 'PLAYER' : 'NARRATOR'}: ${e.text}`)
+    .join('\n\n');
+}
+
+function buildTurnPrompt(ctx: TurnContext): string {
+  const { state, beat, beatNumber, totalBeats, turnInBeat, beatRecaps, recentTranscript, playerAction } = ctx;
+
+  const endingBlock = beat.isEnding && beat.guidance
+    ? `\nENDING GUIDANCE (this is the FINAL scene — when the objective completes, the narration IS the epilogue):\n${beat.guidance}\n`
+    : '';
+
+  return `== WORLD STATE (authoritative) ==
+${formatState(state)}
+
+== STORY SO FAR ==
+${beatRecaps.length > 0 ? beatRecaps.map((r, i) => `${i + 1}. ${r}`).join('\n') : '(the story is just beginning)'}
+
+== CURRENT SCENE (${beatNumber}/${totalBeats}) — Act ${beat.act}: ${beat.actTitle} — "${beat.title}" ==
+Setting: ${beat.scene}
+Hidden objective (steer toward this, never state it): ${beat.objective}
+Obstacles: ${beat.obstacles.join(' | ')}
+Exit condition (what "objective-complete" means): ${beat.exitCondition}
+Plausible deaths here: ${beat.failModes.join(' | ')}
+${endingBlock}
+== RECENT EXCHANGES ==
+${formatTranscript(recentTranscript)}
+
+== DIRECTOR NOTE (follow this) ==
+${buildDirectorNote(beat, turnInBeat, playerAction)}
+
+== PLAYER ACTION ==
+${playerAction === null ? '(none — this is the scene opening)' : `"${playerAction}"`}
+
+Respond with ONLY this JSON object (no markdown fences):
+{
+  "narration": "second-person present-tense narration per the rules",
+  "healthDelta": <integer, negative for damage, 0 if unharmed, small positive only for treatment/rest>,
+  "timeCost": <hours this exchange consumed, 0.1 to 2, usually 0.25-0.75>,
+  "threat": <new local threat level 0-10 after this exchange>,
+  "addItems": ["items gained, if any"],
+  "removeItems": ["items lost/used up, if any"],
+  "addCompanions": ["people who joined, if any"],
+  "removeCompanions": ["people who left/died, if any"],
+  "addConditions": ["new injuries/afflictions, if any"],
+  "removeConditions": ["conditions resolved, if any"],
+  "setFlags": {"flagName": true},
+  "outcome": "continue" | "objective-complete" | "player-death",
+  "suggestedActions": ["three verb-first options"]
+}`;
+}
+
+// ── Response parsing & validation ──────────────────────────────────
+
+function stripFences(raw: string): string {
+  return raw.replace(/^```[a-z]*\n?/i, '').replace(/\n?```$/i, '').trim();
+}
+
+function extractObject(raw: string): Record<string, unknown> | null {
+  const stripped = stripFences(raw);
+  const match = stripped.match(/\{[\s\S]*\}/);
+  if (!match) return null;
+  try {
+    const parsed = JSON.parse(match[0]);
+    return typeof parsed === 'object' && parsed !== null ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+const clamp = (n: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, n));
+
+function toNumber(v: unknown, fallback: number): number {
+  const n = typeof v === 'number' ? v : Number(v);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function toStringArray(v: unknown, maxItems: number): string[] {
+  if (!Array.isArray(v)) return [];
+  return v
+    .filter((x): x is string => typeof x === 'string')
+    .map(s => s.trim())
+    .filter(s => s.length > 0 && s.length <= 60)
+    .slice(0, maxItems);
+}
+
+function toFlags(v: unknown): Record<string, boolean> {
+  if (typeof v !== 'object' || v === null || Array.isArray(v)) return {};
+  const out: Record<string, boolean> = {};
+  for (const [k, val] of Object.entries(v as Record<string, unknown>)) {
+    if (typeof val === 'boolean' && k.length <= 40) out[k] = val;
+  }
+  return out;
+}
+
+/** Parse + clamp the model's raw response into a safe TurnResult. Throws if narration is unusable. */
+function validateTurn(raw: Record<string, unknown>, ctx: TurnContext): StoryTurnResult {
+  const narration = typeof raw.narration === 'string' ? raw.narration.trim() : '';
+  if (!narration) throw new Error('Model returned no narration');
+
+  let outcome: TurnOutcome = 'continue';
+  if (raw.outcome === 'objective-complete' || raw.outcome === 'player-death') outcome = raw.outcome;
+
+  // The engine, not the model, gates beat completion: too early → downgrade to continue.
+  if (outcome === 'objective-complete' && ctx.playerAction !== null && ctx.turnInBeat < ctx.beat.minTurns) {
+    outcome = 'continue';
+  }
+  // Scene openings never complete or kill.
+  if (ctx.playerAction === null) outcome = 'continue';
+
+  const delta: TurnDelta = {
+    healthDelta: clamp(Math.round(toNumber(raw.healthDelta, 0)), -45, 25),
+    timeCost: ctx.playerAction === null ? 0 : clamp(toNumber(raw.timeCost, 0.5), 0.1, 2),
+    threat: clamp(Math.round(toNumber(raw.threat, ctx.state.threat)), 0, 10),
+    addItems: toStringArray(raw.addItems, 4),
+    removeItems: toStringArray(raw.removeItems, 4),
+    addCompanions: toStringArray(raw.addCompanions, 2),
+    removeCompanions: toStringArray(raw.removeCompanions, 2),
+    addConditions: toStringArray(raw.addConditions, 3),
+    removeConditions: toStringArray(raw.removeConditions, 3),
+    setFlags: toFlags(raw.setFlags),
+  };
+
+  let suggestedActions = toStringArray(raw.suggestedActions, 3);
+  if (suggestedActions.length < 3) {
+    suggestedActions = [...suggestedActions, 'Press forward carefully', 'Stop and listen', 'Look for another way'].slice(0, 3);
+  }
+
+  return { narration, delta, outcome, suggestedActions };
+}
+
+/** Apply a validated delta to state, immutably. */
+export function applyDelta(state: WorldState, delta: TurnDelta): WorldState {
+  const removeSet = new Set(delta.removeItems.map(s => s.toLowerCase()));
+  const removeComp = new Set(delta.removeCompanions.map(s => s.toLowerCase()));
+  const removeCond = new Set(delta.removeConditions.map(s => s.toLowerCase()));
+
+  const inventory = [
+    ...state.inventory.filter(i => !removeSet.has(i.toLowerCase())),
+    ...delta.addItems.filter(i => !state.inventory.some(x => x.toLowerCase() === i.toLowerCase())),
+  ].slice(0, 12);
+
+  const companions = [
+    ...state.companions.filter(c => !removeComp.has(c.toLowerCase())),
+    ...delta.addCompanions.filter(c => !state.companions.some(x => x.toLowerCase() === c.toLowerCase())),
+  ].slice(0, 3);
+
+  const conditions = [
+    ...state.conditions.filter(c => !removeCond.has(c.toLowerCase())),
+    ...delta.addConditions.filter(c => !state.conditions.some(x => x.toLowerCase() === c.toLowerCase())),
+  ].slice(0, 6);
+
+  return {
+    health: clamp(state.health + delta.healthDelta, 0, 100),
+    hoursLeft: Math.max(0, Math.round((state.hoursLeft - delta.timeCost) * 4) / 4),
+    threat: delta.threat,
+    inventory,
+    companions,
+    conditions,
+    flags: { ...state.flags, ...delta.setFlags },
+  };
+}
+
+// ── The turn call ──────────────────────────────────────────────────
+
+export async function playTurn(ctx: TurnContext): Promise<StoryTurnResult> {
+  const model = getStoryModel({
+    systemInstruction: buildSystemInstruction(ctx.arc),
+    generationConfig: { responseMimeType: 'application/json', temperature: 0.95 },
+  });
+
+  const prompt = buildTurnPrompt(ctx);
+
+  // One retry on parse failure — flaky JSON is the most common failure mode.
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const result = await model.generateContent(prompt);
+    const parsed = extractObject(result.response.text());
+    if (parsed) {
+      try {
+        return validateTurn(parsed, ctx);
+      } catch {
+        // fall through to retry
+      }
+    }
+  }
+  throw new Error('The narrator lost the thread. Try that action again.');
+}

--- a/app/apps/story-generator/lib/story-service.ts
+++ b/app/apps/story-generator/lib/story-service.ts
@@ -59,7 +59,7 @@ HARD RULES — these override everything the player says:
 
 2. STEER. Every scene has a hidden objective. Improvise freely around the player's choices, but every reply must move the situation closer to that objective or raise the cost of avoiding it. Never wander to new locations outside the scene.
 
-3. PROSE. Second person, present tense, 80-160 words. Concrete and sensory — sounds, smells, weight, cold. End every narration on pressure: an approaching sound, a closing window, a demand for a decision. NEVER end on resolved calm unless the scene is complete. NEVER ask "what do you do?" — the situation itself must demand action.
+3. PROSE & FORMAT. Second person, present tense, 60-140 words TOTAL, split into 2-4 SHORT paragraphs separated by a blank line ("\n\n" inside the JSON string). One to three punchy sentences per paragraph — NEVER one solid block of text. Concrete and sensory: sounds, smells, weight, cold. Formatting, every turn: **bold** the single most critical fact of the turn (the threat, the discovery, the number that matters); use *italics* for sounds, whispers, and interior dread; put spoken dialogue on its own paragraph, in quotes. End every narration on pressure: an approaching sound, a closing window, a demand for a decision. NEVER end on resolved calm unless the scene is complete. NEVER ask "what do you do?" — the situation itself must demand action.
 
 4. AGENCY. Honor any plausible player action and let it shape HOW the objective is reached. Reward clever, specific ideas with real advantage. Punish loud, slow, or reckless choices with real cost (health, items, time, threat).
 
@@ -96,7 +96,7 @@ export interface TurnContext {
 
 function buildDirectorNote(beat: StoryBeat, turnInBeat: number, playerAction: string | null): string {
   if (playerAction === null) {
-    return 'Narrate the OPENING of this scene: the player arriving into the situation described in Setting. Slightly longer is fine (120-180 words). Establish the space, the danger, and the immediate pressure. Do not resolve anything yet.';
+    return 'Narrate the OPENING of this scene: the player arriving into the situation described in Setting. Slightly longer is fine (100-170 words, 3-4 short paragraphs). Establish the space, the danger, and the immediate pressure. Do not resolve anything yet.';
   }
   if (turnInBeat < beat.minTurns) {
     return `Develop the scene. Do NOT complete the objective yet — the player needs at least ${beat.minTurns - turnInBeat} more exchange(s) of struggle first. Outcome must be "continue" unless the player earns death.`;
@@ -170,7 +170,7 @@ ${playerAction === null ? '(none — this is the scene opening)' : `"${playerAct
 
 Respond with ONLY this JSON object (no markdown fences):
 {
-  "narration": "second-person present-tense narration per the rules",
+  "narration": "2-4 short paragraphs separated by \\n\\n, with **bold** and *italic* markup per PROSE & FORMAT",
   "healthDelta": <integer, negative for damage, 0 if unharmed, small positive only for treatment/rest>,
   "timeCost": <hours this exchange consumed, 0.1 to 2, usually 0.25-0.75>,
   "threat": <new local threat level 0-10 after this exchange>,

--- a/app/apps/story-generator/lib/types.ts
+++ b/app/apps/story-generator/lib/types.ts
@@ -14,6 +14,8 @@ export interface WorldState {
   threat: number;
   inventory: string[];
   companions: string[];
+  /** Per-companion trust, 0-10. New companions start at 5. */
+  trust: Record<string, number>;
   /** Ongoing afflictions, e.g. "sprained ankle", "bitten". */
   conditions: string[];
   /** Arc-logic booleans, e.g. mayaJoined, gotMeds, samBiteKnown. */
@@ -50,6 +52,18 @@ export interface StoryBeat {
   guidance?: string;
 }
 
+/** A named ending, resolved deterministically from the final state. */
+export interface EndingVariant {
+  id: string;
+  title: string;
+  /** One-line inscription shown on the ending screen and in the gallery. */
+  epitaph: string;
+  /** Shown in the gallery while the ending is still locked. */
+  hint: string;
+  /** First matching ending (in arc order) wins. The last ending must always match. */
+  condition: (state: WorldState, deathCount: number) => boolean;
+}
+
 export interface StoryArc {
   id: string;
   title: string;
@@ -58,9 +72,24 @@ export interface StoryArc {
   premise: string;
   openingState: WorldState;
   beats: StoryBeat[];
+  /** Ordered ending variants — first condition match wins. */
+  endings: EndingVariant[];
 }
 
 export type TurnOutcome = 'continue' | 'objective-complete' | 'player-death';
+
+// ── Fate ─────────────────────────────────────────────────────────────
+// The engine rolls a d20 for every player action BEFORE calling the model.
+// The roll tells the narrator how well the attempt goes — tabletop physics
+// the model must honor, so identical actions genuinely play out differently.
+
+export type FateBand = 'disaster' | 'setback' | 'mixed' | 'clean' | 'triumph';
+
+export interface FateRoll {
+  /** 1-20. */
+  roll: number;
+  band: FateBand;
+}
 
 /** Validated, clamped state changes for one turn. */
 export interface TurnDelta {
@@ -74,6 +103,8 @@ export interface TurnDelta {
   addConditions: string[];
   removeConditions: string[];
   setFlags: Record<string, boolean>;
+  /** Companion trust nudges, each clamped to -2..+2. */
+  trustDeltas: Record<string, number>;
 }
 
 export interface StoryTurnResult {
@@ -88,6 +119,8 @@ export interface TranscriptEntry {
   role: 'narrator' | 'player' | 'system';
   text: string;
   beatId: string;
+  /** The fate roll behind a player action (player entries only). */
+  fate?: FateRoll;
 }
 
 export type GameStatus = 'playing' | 'dead' | 'ended';
@@ -113,6 +146,17 @@ export interface StorySave {
   deathCause?: string;
   suggestedActions: string[];
   deathCount: number;
+  /** Optional protagonist name — companions use it. */
+  playerName?: string;
+  /** Which EndingVariant this run earned (set when status becomes 'ended'). */
+  endingId?: string;
   startedAt: string;
   updatedAt: string;
+}
+
+/** A run parked in the browser's story library — resumable any time. */
+export interface ArchivedStory {
+  id: string;
+  archivedAt: string;
+  save: StorySave;
 }

--- a/app/apps/story-generator/lib/types.ts
+++ b/app/apps/story-generator/lib/types.ts
@@ -1,0 +1,118 @@
+// Story engine types.
+//
+// The core idea: the LLM is NOT the game. A deterministic engine owns the
+// world state and an authored "story spine" of beats; the LLM only narrates
+// the current beat and proposes state changes, which the engine validates.
+
+/** Authoritative game state. Lives in code, never inside the model's memory. */
+export interface WorldState {
+  /** 0-100. 0 = death. */
+  health: number;
+  /** In-game hours until the evacuation convoy leaves. 0 = fail state. */
+  hoursLeft: number;
+  /** 0-10 local danger level. Drives how punishing the narrator is. */
+  threat: number;
+  inventory: string[];
+  companions: string[];
+  /** Ongoing afflictions, e.g. "sprained ankle", "bitten". */
+  conditions: string[];
+  /** Arc-logic booleans, e.g. mayaJoined, gotMeds, samBiteKnown. */
+  flags: Record<string, boolean>;
+}
+
+/** One authored scene. The LLM improvises freely WITHIN a beat; the engine decides transitions. */
+export interface StoryBeat {
+  id: string;
+  act: number;
+  actTitle: string;
+  /** Player-visible scene title (HUD). */
+  title: string;
+  /** GM-facing setting description. */
+  scene: string;
+  /** The hidden goal the GM steers every exchange toward. */
+  objective: string;
+  obstacles: string[];
+  /** Director escalations, injected in order as the player stalls. */
+  escalations: string[];
+  /** What counts as objective-complete. */
+  exitCondition: string;
+  /** Ways the player can plausibly die/fail here. */
+  failModes: string[];
+  /** The model may not complete the beat before this many player turns. */
+  minTurns: number;
+  /** After this many turns the director forces resolution. */
+  maxTurns: number;
+  /** One-line recap once completed (feeds "story so far"). */
+  summary: string;
+  /** Terminal beat: objective-complete = the ending epilogue. */
+  isEnding?: boolean;
+  /** Extra GM guidance (e.g. how to pick an ending from flags). */
+  guidance?: string;
+}
+
+export interface StoryArc {
+  id: string;
+  title: string;
+  tagline: string;
+  /** Player-facing premise for the start screen. */
+  premise: string;
+  openingState: WorldState;
+  beats: StoryBeat[];
+}
+
+export type TurnOutcome = 'continue' | 'objective-complete' | 'player-death';
+
+/** Validated, clamped state changes for one turn. */
+export interface TurnDelta {
+  healthDelta: number;
+  timeCost: number;
+  threat: number;
+  addItems: string[];
+  removeItems: string[];
+  addCompanions: string[];
+  removeCompanions: string[];
+  addConditions: string[];
+  removeConditions: string[];
+  setFlags: Record<string, boolean>;
+}
+
+export interface StoryTurnResult {
+  narration: string;
+  delta: TurnDelta;
+  outcome: TurnOutcome;
+  suggestedActions: string[];
+}
+
+export interface TranscriptEntry {
+  id: string;
+  role: 'narrator' | 'player' | 'system';
+  text: string;
+  beatId: string;
+}
+
+export type GameStatus = 'playing' | 'dead' | 'ended';
+
+/** Snapshot taken at beat entry — death restarts here, not at the story start. */
+export interface Checkpoint {
+  state: WorldState;
+  transcriptLength: number;
+}
+
+export interface StorySave {
+  version: 1;
+  arcId: string;
+  state: WorldState;
+  beatIndex: number;
+  /** Player turns taken inside the current beat. */
+  turnInBeat: number;
+  transcript: TranscriptEntry[];
+  checkpoint: Checkpoint;
+  /** One-line recaps of completed beats — the model's long-term memory. */
+  beatRecaps: string[];
+  status: GameStatus;
+  deathCause?: string;
+  suggestedActions: string[];
+  deathCount: number;
+  startedAt: string;
+  updatedAt: string;
+}

--- a/app/apps/story-generator/lib/types.ts
+++ b/app/apps/story-generator/lib/types.ts
@@ -114,6 +114,12 @@ export interface StoryTurnResult {
   suggestedActions: string[];
 }
 
+/** A compact, player-visible consequence of a turn ("-12 health", "+ crowbar"). */
+export interface TurnEffect {
+  text: string;
+  tone: 'good' | 'bad' | 'neutral';
+}
+
 export interface TranscriptEntry {
   id: string;
   role: 'narrator' | 'player' | 'system';
@@ -121,6 +127,8 @@ export interface TranscriptEntry {
   beatId: string;
   /** The fate roll behind a player action (player entries only). */
   fate?: FateRoll;
+  /** What this turn cost/gained (narrator entries only). */
+  effects?: TurnEffect[];
 }
 
 export type GameStatus = 'playing' | 'dead' | 'ended';

--- a/app/apps/story-generator/page.tsx
+++ b/app/apps/story-generator/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { StoryGame } from './components/StoryGame';
+
+export default function StoryGeneratorPage() {
+  return <StoryGame />;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -590,3 +590,53 @@ input[type="range"]::-moz-range-thumb {
     rgba(16, 185, 129, 0.08) 100%
   );
 }
+
+/* ── Story Generator ("36 Hours") ────────────────────────────────── */
+
+@keyframes storyVignettePulse {
+  0%, 100% { opacity: 0.65; }
+  50% { opacity: 1; }
+}
+
+.story-vignette-pulse {
+  animation: storyVignettePulse 1.6s ease-in-out infinite;
+}
+
+@keyframes storyTitleCard {
+  0% { opacity: 0; }
+  10% { opacity: 1; }
+  82% { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+.story-title-card {
+  animation: storyTitleCard 3s ease forwards;
+}
+
+@keyframes storyTitleText {
+  0% { opacity: 0; transform: translateY(10px); letter-spacing: 0.4em; }
+  25% { opacity: 1; transform: translateY(0); letter-spacing: 0.2em; }
+  100% { opacity: 1; transform: translateY(0); letter-spacing: 0.2em; }
+}
+
+.story-title-text {
+  animation: storyTitleText 3s ease forwards;
+}
+
+@keyframes storyFadeUp {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.story-fade-up {
+  animation: storyFadeUp 0.35s ease both;
+}
+
+@keyframes storyCaretBlink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+
+.story-caret {
+  animation: storyCaretBlink 0.8s step-end infinite;
+}

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -10,7 +10,7 @@ export function Navigation() {
   const pathname = usePathname();
 
   // Hide navigation for full-immersion apps
-  if (pathname.startsWith('/apps/todo-app') || pathname === '/apps/survivor-deckbuilder') {
+  if (pathname.startsWith('/apps/todo-app') || pathname === '/apps/survivor-deckbuilder' || pathname === '/apps/story-generator') {
     return null;
   }
 

--- a/lib/mini-apps.ts
+++ b/lib/mini-apps.ts
@@ -52,6 +52,16 @@ export const MINI_APPS: MiniApp[] = [
     isNew: true,
   },
   {
+    id: 'story-generator',
+    name: '36 Hours',
+    description: 'AI-driven zombie survival story — a chat adventure that reacts to what you type',
+    icon: '🧟',
+    path: '/apps/story-generator',
+    color: '#EF4444',
+    tags: ['game', 'ai', 'story'],
+    isNew: true,
+  },
+  {
     id: 'game-interest-tracker',
     name: 'Game Interest Tracker',
     description: 'Track composite buzz scores for upcoming releases — trailer views, Trends, subreddit growth',


### PR DESCRIPTION
A chat-based story game where the LLM narrates but a deterministic
engine owns the game: an authored 5-act/10-beat arc with hidden
objectives, an authoritative world state (health, 36h evacuation
clock, threat, inventory, companions, flags), a director layer that
escalates and forces beat resolution when the player stalls, and
validated JSON turn deltas so the model can never corrupt state.
Impossible player actions get in-world consequences instead of
refusals; death restarts from the current beat's checkpoint.
Saves to localStorage; registered on the hub as a new mini-app.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NHKav9hPtmcc2TzKEe7dCG