### PR TITLE
Streamline PS Plus buttons and add RAWG game name autocomplete

### DIFF
--- a/app/apps/game-analytics/components/GameForm.tsx
+++ b/app/apps/game-analytics/components/GameForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect, useMemo } from 'react';
 import { ChevronDown, X, Tag, DollarSign, Calendar, MessageSquare, Sparkles, Loader2, Wallet } from 'lucide-react';
+import { searchRAWGGames, RAWGGameData } from '../lib/rawg-api';
 import { Game, GameStatus, PurchaseSource, SubscriptionSource, BudgetSettings } from '../lib/types';
 import { calculateCostPerHour, getValueRating, formatRating, getTotalHours, getBudgetImpactPreview } from '../lib/calculations';
 import { lookupGameLength } from '../lib/ai-timeline-service';
@@ -129,6 +130,40 @@ export function GameForm({ onSubmit, onClose, initialGame, allGames = [], existi
     playLogs: initialGame?.playLogs || [],
     isSpecial: initialGame?.isSpecial || false,
   });
+
+  // RAWG name autocomplete
+  const [nameResults, setNameResults] = useState<RAWGGameData[]>([]);
+  const [nameSearching, setNameSearching] = useState(false);
+  const [showNameDropdown, setShowNameDropdown] = useState(false);
+  const nameDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const nameJustSelectedRef = useRef(false);
+
+  useEffect(() => {
+    if (nameJustSelectedRef.current) {
+      nameJustSelectedRef.current = false;
+      return;
+    }
+    if (nameDebounceRef.current) clearTimeout(nameDebounceRef.current);
+    const query = formData.name.trim();
+    if (query.length < 2) {
+      setNameResults([]);
+      setShowNameDropdown(false);
+      return;
+    }
+    nameDebounceRef.current = setTimeout(async () => {
+      setNameSearching(true);
+      try {
+        const results = await searchRAWGGames(query, 8);
+        setNameResults(results);
+        setShowNameDropdown(results.length > 0);
+      } catch {
+        setNameResults([]);
+      } finally {
+        setNameSearching(false);
+      }
+    }, 400);
+    return () => { if (nameDebounceRef.current) clearTimeout(nameDebounceRef.current); };
+  }, [formData.name]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Drag-to-dismiss
   const sheetRef = useRef<HTMLDivElement>(null);
@@ -303,14 +338,52 @@ export function GameForm({ onSubmit, onClose, initialGame, allGames = [], existi
             {/* Game Name */}
             <div>
               <label className="block text-xs font-medium text-white/50 mb-1.5">Game Name *</label>
-              <input
-                type="text"
-                required
-                value={formData.name}
-                onChange={e => setFormData({ ...formData, name: e.target.value })}
-                className="w-full px-3 py-3 bg-white/[0.03] border border-white/5 text-white rounded-xl text-sm focus:outline-none focus:bg-white/[0.05] focus:border-white/10 transition-all placeholder:text-white/30"
-                placeholder="Enter game name"
-              />
+              <div className="relative">
+                <input
+                  type="text"
+                  required
+                  value={formData.name}
+                  onChange={e => setFormData({ ...formData, name: e.target.value })}
+                  onBlur={() => setTimeout(() => setShowNameDropdown(false), 150)}
+                  onFocus={() => { if (nameResults.length > 0) setShowNameDropdown(true); }}
+                  className="w-full px-3 py-3 bg-white/[0.03] border border-white/5 text-white rounded-xl text-sm focus:outline-none focus:bg-white/[0.05] focus:border-white/10 transition-all placeholder:text-white/30 pr-8"
+                  placeholder="Enter game name"
+                />
+                {nameSearching && (
+                  <Loader2 size={14} className="absolute right-3 top-1/2 -translate-y-1/2 text-white/30 animate-spin pointer-events-none" />
+                )}
+                {showNameDropdown && nameResults.length > 0 && (
+                  <div className="absolute left-0 right-0 top-full mt-1 z-50 bg-[#1a1a26] border border-white/10 rounded-xl overflow-hidden shadow-2xl">
+                    {nameResults.map(result => (
+                      <button
+                        key={result.id}
+                        type="button"
+                        onMouseDown={(e) => {
+                          e.preventDefault();
+                          nameJustSelectedRef.current = true;
+                          setFormData(prev => ({ ...prev, name: result.name }));
+                          setShowNameDropdown(false);
+                          setNameResults([]);
+                        }}
+                        className="w-full flex items-center gap-3 px-3 py-2.5 hover:bg-white/[0.06] active:bg-white/[0.09] transition-colors text-left"
+                      >
+                        {result.backgroundImage ? (
+                          <img src={result.backgroundImage} alt="" className="w-9 h-9 rounded-lg object-cover shrink-0" />
+                        ) : (
+                          <div className="w-9 h-9 rounded-lg bg-white/5 flex items-center justify-center shrink-0 text-base">🎮</div>
+                        )}
+                        <div className="flex-1 min-w-0">
+                          <div className="text-sm text-white/90 truncate">{result.name}</div>
+                          <div className="text-[10px] text-white/30">
+                            {result.released ? result.released.slice(0, 4) : ''}
+                            {result.metacritic ? <span className="ml-1.5 text-emerald-400/70">MC {result.metacritic}</span> : null}
+                          </div>
+                        </div>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
             </div>
 
             {/* Status Picker — bigger pills with icons */}

--- a/app/apps/game-analytics/components/SubscriptionDropPanel.tsx
+++ b/app/apps/game-analytics/components/SubscriptionDropPanel.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from 'react';
 import {
-  Gift, Loader2, Sparkles, Flame, Check, Heart, X, ListPlus, Bookmark,
+  Gift, Loader2, Sparkles, Flame, Check, X, Bookmark, Play, ListPlus,
   ExternalLink, ChevronDown, ChevronUp, AlertTriangle, Undo2, PiggyBank,
   Crown, Clock, ShoppingCart, LogOut, RefreshCw, TrendingUp, Search,
 } from 'lucide-react';
@@ -473,7 +473,7 @@ export function SubscriptionDropPanel({ games, userId, onAddGame, onAddToQueue, 
               <span key={rec.id} className="text-[11px] text-white/45 bg-white/[0.04] rounded-lg px-2.5 py-1.5">
                 {rec.gameName}
                 <span className="text-white/20 ml-1">
-                  {rec.status === 'interested' ? '· Up Next' : rec.status === 'wishlisted' ? '· Wishlist' : '· Someday'}
+                  {rec.status === 'played' ? '· Played' : rec.status === 'interested' ? '· Queue' : '· Library'}
                 </span>
               </span>
             ))}
@@ -660,28 +660,23 @@ function SubscriptionGameCard({
           </div>
         ) : (
           <div className="flex items-center gap-1.5">
-            <button onClick={() => sub.addToUpNext(rec)}
-              className="flex-1 flex items-center justify-center gap-1 py-2 rounded-lg bg-indigo-500/10 text-indigo-300/80 text-xs font-medium hover:bg-indigo-500/20 transition-colors"
-              title="Add to library and Up Next queue">
-              <ListPlus size={12} /> Up Next
+            <button onClick={() => sub.addAsPlaying(rec)}
+              className="flex-1 flex items-center justify-center gap-1.5 py-2 rounded-lg bg-blue-500/15 text-blue-300 text-xs font-medium hover:bg-blue-500/25 transition-colors"
+              title="Add to library and start playing now">
+              <Play size={12} /> Playing Now
             </button>
-            <button onClick={() => sub.saveForLater(rec.id)}
-              className="flex items-center justify-center gap-1 py-2 px-2.5 rounded-lg bg-cyan-500/10 text-cyan-300/70 text-xs font-medium hover:bg-cyan-500/20 transition-colors"
-              title="Save for later — keep it here as a maybe, don't add to library">
+            <button onClick={() => sub.addToUpNext(rec)}
+              className="flex items-center justify-center py-2 px-2.5 rounded-lg bg-indigo-500/10 text-indigo-300/80 text-xs hover:bg-indigo-500/20 transition-colors"
+              title="Add to Up Next queue">
               <Bookmark size={12} />
             </button>
-            <button onClick={() => sub.addToWishlist(rec)}
-              className="flex items-center justify-center gap-1 py-2 px-2.5 rounded-lg bg-purple-500/10 text-purple-400/70 text-xs font-medium hover:bg-purple-500/20 transition-colors"
-              title="Add to your library Wishlist">
-              <Heart size={12} />
-            </button>
             <button onClick={() => setShowRating(true)}
-              className="flex items-center justify-center gap-1 py-2 px-2.5 rounded-lg bg-emerald-500/10 text-emerald-400/70 text-xs font-medium hover:bg-emerald-500/20 transition-colors"
+              className="flex items-center justify-center py-2 px-2.5 rounded-lg bg-emerald-500/10 text-emerald-400/70 text-xs hover:bg-emerald-500/20 transition-colors"
               title="Already played — add with a rating">
               <Check size={12} />
             </button>
             <button onClick={() => sub.markDismissed(rec.id)}
-              className="py-2 px-2.5 rounded-lg bg-white/5 text-white/25 text-xs hover:bg-red-500/10 hover:text-red-400/70 transition-colors"
+              className="flex items-center justify-center py-2 px-2.5 rounded-lg bg-white/5 text-white/25 text-xs hover:bg-red-500/10 hover:text-red-400/70 transition-colors"
               title="Not interested">
               <X size={12} />
             </button>

--- a/app/apps/game-analytics/hooks/useSubscriptionGames.ts
+++ b/app/apps/game-analytics/hooks/useSubscriptionGames.ts
@@ -302,6 +302,17 @@ export function useSubscriptionGames({ userId, games, onAddGame, onAddToQueue, o
     }
   }, [onAddGame, buildFreeGame, updateStatus]);
 
+  const addAsPlaying = useCallback(async (rec: GameRecommendation) => {
+    try {
+      await onAddGame(buildFreeGame(rec, 'In Progress', {
+        startDate: new Date().toISOString().split('T')[0],
+      }));
+      await updateStatus(rec.id, 'interested');
+    } catch (e) {
+      setError(e instanceof Error ? e : new Error(String(e)));
+    }
+  }, [onAddGame, buildFreeGame, updateStatus]);
+
   // Bulk: add every top pick still awaiting a decision to Up Next.
   const addAllTopPicksToUpNext = useCallback(async () => {
     const picks = recs.filter(r => r.status === 'suggested' && r.isTopPick);
@@ -452,9 +463,8 @@ export function useSubscriptionGames({ userId, games, onAddGame, onAddToQueue, o
     dismissNudge,
     markDismissed,
     undoDismiss,
-    saveForLater,
     addToUpNext,
-    addToWishlist,
+    addAsPlaying,
     addAsPlayed,
     addAllTopPicksToUpNext,
     claimAllMonthly,


### PR DESCRIPTION
PS Plus: replace 5-button triage row with 4 clear actions — Playing Now
(In Progress + today startDate), queue bookmark (Up Next), tick (already
played with rating), cross (dismiss). Removes the broken save-for-later
bookmark that never added to the library, and the Wishlist heart.

GameForm: debounced RAWG autocomplete on the name field. After 2+ chars
and 400ms of inactivity, fetches up to 8 RAWG suggestions and shows a
dropdown with thumbnail, year, and Metacritic score. Selecting a result
fills the canonical game name so thumbnail auto-fetch works better.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0176HLiJ6WgsKoaMcGyAfZys